### PR TITLE
ci(docs): publish preview url

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -8,6 +8,11 @@ on:
     branches:
     - main
 
+env:
+  ARTIFACT_NAME: BUILD_LOG
+  NIX_VERSION: nix-2.13.2
+  NIXPKGS_CHANNEL: nixos-22.11
+
 jobs:
   build:
     uses: unionfi/workflows/.github/workflows/build.yml@main
@@ -16,3 +21,38 @@ jobs:
       access-tokens: github.com=${{ secrets.GITHUB_TOKEN }}
     with:
       filter_builds: '((.top_attr == "checks" or .top_attr == "packages") and (.system == "x86_64-linux" or .system == "aarch64-linux") and (.attr != "bundle-mainnet" and .attr != "bundle-testnet" and .attr != "generate-evm-proto" and .attr != "generate-prover-proto" and .attr != "pre-commit-check" and .attr != "pre-commit" and .attr != "devnet" and .attr != "devnet-cosmos" and .attr != "devnet-evm" and .attr != "rust-proto" and .attr != "generate-rust-proto")) or (.attr == "devnet" and .system == "x86_64-linux") or (.attr == "devnet-cosmos" and .system == "x86_64-linux") or (.attr == "devnet-evm" and .system == "x86_64-linux")'
+  preview:
+    runs-on: ubuntu-latest
+    outputs:
+      preview-url: ${{ steps.publish-preview.outputs.preview-url }}
+    permissions: write-all
+    steps:
+      - uses: actions/checkout@v3  
+        with:
+          lfs: true
+      - uses: cachix/install-nix-action@v20
+        with:
+          nix_path: nixpkgs=channel:${{ env.NIXPKGS_CHANNEL }}
+          github_access_token: ${{ github.token }}
+      - run: |
+          nix-channel --add https://nixos.org/channels/${{ env.NIXPKGS_CHANNEL }} nixpkgs
+          nix-channel --update
+          nix-env -iA nixpkgs.nodePackages.vercel
+      - name: "Publish Preview to Vercel"
+        id: publish-preview
+        working-directory: docs
+        run: |
+          vercel pull --yes --environment=preview --token=${{secrets.VERCEL_TOKEN}}
+          vercel build --token=${{secrets.VERCEL_TOKEN}}
+          PREVIEW_URL=$(vercel deploy --prebuilt --token=${{secrets.VERCEL_TOKEN}})
+          echo "preview-url=${PREVIEW_URL}" >> "$GITHUB_OUTPUT"
+      - name: Create Preview Comment
+        if: github.event_name == 'pull_request' 
+        uses: thollander/actions-comment-pull-request@v2
+        with:
+          mode: upsert
+          message: |
+           # Docs Preview URL
+           ${{ steps.publish-preview.outputs.preview-url }}
+          comment_tag: Docs Preview URL
+          GITHUB_TOKEN: ${{ github.token }}

--- a/docs/docs.nix
+++ b/docs/docs.nix
@@ -24,6 +24,7 @@
         installPhase = ''
           mkdir -p $out
           cp -dR ./build/* $out
+          echo "built docs"
         '';
       };
     };


### PR DESCRIPTION
This still shows a preview on every build. In a different PR, I'll make sure that it only does that iff the docs are changed.
