### PR TITLE
ci: only display a preview url if docs changed

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -8,11 +8,6 @@ on:
     branches:
     - main
 
-env:
-  ARTIFACT_NAME: BUILD_LOG
-  NIX_VERSION: nix-2.13.2
-  NIXPKGS_CHANNEL: nixos-22.11
-
 jobs:
   build:
     uses: unionfi/workflows/.github/workflows/build.yml@main
@@ -21,38 +16,4 @@ jobs:
       access-tokens: github.com=${{ secrets.GITHUB_TOKEN }}
     with:
       filter_builds: '((.top_attr == "checks" or .top_attr == "packages") and (.system == "x86_64-linux" or .system == "aarch64-linux") and (.attr != "bundle-mainnet" and .attr != "bundle-testnet" and .attr != "generate-evm-proto" and .attr != "generate-prover-proto" and .attr != "gen-proto" and .attr != "pre-commit-check" and .attr != "pre-commit" and .attr != "devnet" and .attr != "devnet-cosmos" and .attr != "devnet-evm" and .attr != "rust-proto" and .attr != "generate-rust-proto" and .attr != "evm-contracts")) or (.attr == "evm-contracts" and .system == "x86_64-linux") or (.attr == "devnet" and .system == "x86_64-linux") or (.attr == "devnet-cosmos" and .system == "x86_64-linux") or (.attr == "devnet-evm" and .system == "x86_64-linux")'
-  preview:
-    runs-on: ubuntu-latest
-    outputs:
-      preview-url: ${{ steps.publish-preview.outputs.preview-url }}
-    permissions: write-all
-    steps:
-      - uses: actions/checkout@v3
-        with:
-          lfs: true
-      - uses: cachix/install-nix-action@v20
-        with:
-          nix_path: nixpkgs=channel:${{ env.NIXPKGS_CHANNEL }}
-          github_access_token: ${{ github.token }}
-      - run: |
-          nix-channel --add https://nixos.org/channels/${{ env.NIXPKGS_CHANNEL }} nixpkgs
-          nix-channel --update
-          nix-env -iA nixpkgs.nodePackages.vercel
-      - name: "Publish Preview to Vercel"
-        id: publish-preview
-        working-directory: docs
-        run: |
-          vercel pull --yes --environment=preview --token=${{secrets.VERCEL_TOKEN}}
-          vercel build --token=${{secrets.VERCEL_TOKEN}}
-          PREVIEW_URL=$(vercel deploy --prebuilt --token=${{secrets.VERCEL_TOKEN}})
-          echo "preview-url=${PREVIEW_URL}" >> "$GITHUB_OUTPUT"
-      - name: Create Preview Comment
-        if: github.event_name == 'pull_request'
-        uses: thollander/actions-comment-pull-request@v2
-        with:
-          mode: upsert
-          message: |
-           # Docs Preview URL
-           ${{ steps.publish-preview.outputs.preview-url }}
-          comment_tag: Docs Preview URL
-          GITHUB_TOKEN: ${{ github.token }}
+ 

--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -1,0 +1,48 @@
+name: Preview
+
+on:
+  pull_request:
+    paths:
+    - 'docs/**'
+
+env:
+    ARTIFACT_NAME: BUILD_LOG
+    NIX_VERSION: nix-2.13.2
+    NIXPKGS_CHANNEL: nixos-22.11
+
+jobs:
+  preview:
+    runs-on: ubuntu-latest
+    outputs:
+      preview-url: ${{ steps.publish-preview.outputs.preview-url }}
+    permissions: write-all
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          lfs: true
+      - uses: cachix/install-nix-action@v20
+        with:
+          nix_path: nixpkgs=channel:${{ env.NIXPKGS_CHANNEL }}
+          github_access_token: ${{ github.token }}
+      - run: |
+          nix-channel --add https://nixos.org/channels/${{ env.NIXPKGS_CHANNEL }} nixpkgs
+          nix-channel --update
+          nix-env -iA nixpkgs.nodePackages.vercel
+      - name: "Publish Preview to Vercel"
+        id: publish-preview
+        working-directory: docs
+        run: |
+            vercel pull --yes --environment=preview --token=${{secrets.VERCEL_TOKEN}}
+            vercel build --token=${{secrets.VERCEL_TOKEN}}
+            PREVIEW_URL=$(vercel deploy --prebuilt --token=${{secrets.VERCEL_TOKEN}})
+            echo "preview-url=${PREVIEW_URL}" >> "$GITHUB_OUTPUT"
+      - name: Create Preview Comment
+        if: github.event_name == 'pull_request'
+        uses: thollander/actions-comment-pull-request@v2
+        with:
+          mode: upsert
+          message: |
+            # Docs Preview URL
+            ${{ steps.publish-preview.outputs.preview-url }}
+            comment_tag: Docs Preview URL
+            GITHUB_TOKEN: ${{ github.token }}


### PR DESCRIPTION
Let's see if this works. If no comment is set now, I'll edit the docs and see if it works.

The implementation is a little error prone as it relies on changed files, but shouldn't affect us too much. One we go OS we can use the store; but so far I had trouble getting it to work properly. 