### PR TITLE
fix: ensure no invalid opcodes in wasm light client binary

### DIFF
--- a/dictionary.txt
+++ b/dictionary.txt
@@ -494,3 +494,6 @@ Shacham
 zkps
 Verkle
 Polkadot
+passthru
+wasi
+rustlib

--- a/light-clients/ethereum-light-client.nix
+++ b/light-clients/ethereum-light-client.nix
@@ -1,22 +1,43 @@
 { ... }: {
   perSystem = { self', pkgs, system, config, inputs', crane, ... }:
     let
-      attrs = crane.commonAttrs
-        // (crane.lib.crateNameFromCargoToml { cargoToml = ./ethereum-light-client/Cargo.toml; })
+      rustToolchain = crane.withBuildTarget CARGO_BUILD_TARGET;
+
+      attrs = (crane.lib.crateNameFromCargoToml { cargoToml = ./ethereum-light-client/Cargo.toml; })
         // {
         cargoExtraArgs = "-p union-ethereum-lc --features eth-minimal";
+        src = crane.rustSrc;
+        cargoVendorDir = crane.lib.vendorMultipleCargoDeps {
+          inherit (crane.lib.findCargoFiles crane.rustSrc) cargoConfigs;
+          cargoLockList = [
+            ../Cargo.lock
+            "${rustToolchain.toolchain.passthru.availableComponents.rust-src}/lib/rustlib/src/rust/Cargo.lock"
+          ];
+        };
       };
-
-      # cargoArtifacts = crane.lib.buildDepsOnly attrs;
 
       CARGO_BUILD_TARGET = "wasm32-unknown-unknown";
     in
     {
       packages = {
-        wasm-ethereum-lc = (crane.withBuildTarget CARGO_BUILD_TARGET).buildPackage (attrs // {
+        wasm-ethereum-lc = rustToolchain.buildPackage (attrs // {
           inherit CARGO_BUILD_TARGET;
 
-          # RUSTFLAGS are used to optimize the binary size
+          cargoBuildCommand = "RUSTFLAGS='-C target-feature=-sign-ext -C link-arg=-s -C target-cpu=mvp' cargo -Z build-std=std,panic_abort -Z build-std-features=panic_immediate_abort build --release --lib --target ${CARGO_BUILD_TARGET}";
+
+          checkPhase = ''
+            cargo test ${attrs.cargoExtraArgs} --target ${crane.hostTarget}
+
+            # grep exits 0 if a match is found
+            if ${pkgs.binaryen}/bin/wasm-dis target/wasm32-unknown-unknown/release/union_ethereum_lc.wasm | grep -P '\.extend\d{1,2}_s'
+            then
+              echo "wasm binary contains invalid opcodes!"
+              exit 1
+            else
+              echo "wasm binary doesn't contain any sign-extension opcodes!"
+            fi
+          '';
+
           installPhase = ''
             mkdir -p $out/lib
             # Optimize the binary size a little bit more
@@ -28,9 +49,10 @@
         });
       };
 
-      checks = crane.mkChecks "wasm-ethereum-lc" {
-        clippy = crane.lib.cargoClippy (attrs // { inherit (crane) cargoArtifacts; });
-        test = crane.lib.cargoTest (attrs // { inherit (crane) cargoArtifacts; });
-      };
+      checks = crane.mkChecks "wasm-ethereum-lc"
+        {
+          clippy = crane.lib.cargoClippy (attrs // { inherit (crane) cargoArtifacts; });
+          test = crane.lib.cargoTest (attrs // { inherit (crane) cargoArtifacts; });
+        };
     };
 }

--- a/light-clients/ethereum-light-client/.cargo/config.toml
+++ b/light-clients/ethereum-light-client/.cargo/config.toml
@@ -5,4 +5,5 @@ unit-test = "test --lib"
 integration-test = "test --test integration"
 schema = "run --bin schema"
 
-rustflags = ["-C link-arg=-s"]
+rustflags = ["-C target-feature=-sign-ext", "-C link-arg=-s", "-C target-cpu=mvp"]
+


### PR DESCRIPTION
also added a check to ensure that sign-ext opcodes don't find their way back into the binary.

this also provides a significant improvement to the size of the binary, from 2.8M to 1.1M (758K to 322K gzipped).

closes #91