### PR TITLE
chore: add crane.nix and rust.nix in tools

### DIFF
--- a/tools/rust/crane.nix
+++ b/tools/rust/crane.nix
@@ -1,0 +1,58 @@
+{ inputs, ... }: {
+  perSystem = { pkgs, rust, system, lib, ... }:
+    let
+      crane = inputs.crane;
+      withBuildTarget = target:
+        let
+          toolchain = pkgs.rust-bin.fromRustupToolchain {
+            inherit (rust.config) channel profile;
+            components = rust.config.components ++ [ "cargo" "rustc" "rust-src" ];
+            # hopefully if we ever use wasi this issue will be resolved: pkgs.rust.toRustTarget pkgs.hostPlatform
+            targets = [ target (pkgs.rust.toRustTarget pkgs.hostPlatform) ];
+          };
+        in
+        crane.lib.${system}.overrideToolchain (toolchain) // { inherit toolchain; };
+      craneLib = crane.lib.${system}.overrideToolchain rust.nightly;
+
+      mkChecks = pkgName: checks: pkgs.lib.mapAttrs' (name: value: { name = "${pkgName}-${name}"; value = value; }) checks;
+
+      rustSrc =
+        let
+          unionvisor-testdata = path: _type: (builtins.match ".*unionvisor/src/testdata/.*" path) != null;
+          jsonFilter = path: _type: (builtins.match ".*json$" path) != null;
+          jsonOrCargo = path: type:
+            (unionvisor-testdata path type) || (jsonFilter path type) || (craneLib.filterCargoSources path type);
+        in
+        lib.cleanSourceWith {
+          src = craneLib.path ../../.;
+          filter = jsonOrCargo;
+        };
+
+      commonAttrs = {
+        # fake values to suppress warnings; see https://github.com/ipetkov/crane/issues/281
+        pname = "union-workspace";
+        version = "v0.0.0";
+
+        src = rustSrc;
+        buildInputs = [ pkgs.pkg-config pkgs.openssl ]
+          ++ (
+          pkgs.lib.optionals pkgs.stdenv.isDarwin (with pkgs.darwin.apple_sdk.frameworks; [
+            Security
+          ])
+        );
+        doCheck = false;
+        cargoExtraArgs = "--workspace --exclude ethereum-consensus --exclude ethereum-verifier";
+        PKG_CONFIG_PATH = "${pkgs.openssl.dev}/lib/pkgconfig";
+      };
+
+      cargoArtifacts = craneLib.buildDepsOnly commonAttrs;
+    in
+    {
+      _module.args.crane = {
+        lib = craneLib;
+        hostTarget = pkgs.rust.toRustTarget pkgs.hostPlatform;
+        inherit withBuildTarget cargoArtifacts commonAttrs mkChecks rustSrc;
+      };
+
+    };
+}

--- a/tools/rust/rust.nix
+++ b/tools/rust/rust.nix
@@ -1,0 +1,19 @@
+{ ... }: {
+  perSystem = { pkgs, ... }:
+    let
+      nightlyConfig = {
+        channel = "nightly-2023-05-16";
+        components = [ "rust-src" "rust-analyzer" ];
+        profile = "default";
+        targets = [ "wasm32-unknown-unknown" ];
+      };
+
+      rust-nightly = pkgs.rust-bin.fromRustupToolchain nightlyConfig;
+    in
+    {
+      _module.args.rust = {
+        nightly = rust-nightly;
+        config = nightlyConfig;
+      };
+    };
+}


### PR DESCRIPTION
Moves crane and rust related stuff from flake.nix to dedicated modules.