### PR TITLE
feat(CI): use regctl to annotate descriptions for uniond/unionpd

### DIFF
--- a/.github/container-descriptions/uniond.txt
+++ b/.github/container-descriptions/uniond.txt
@@ -1,0 +1,1 @@
+uniond is the canonical implementation of a full node for the union network. Validators, RPC, and archive operators can run it to participate in the network.

--- a/.github/container-descriptions/unionpd.txt
+++ b/.github/container-descriptions/unionpd.txt
@@ -1,0 +1,1 @@
+Galois daemon (galoisd) is a gRPC service providing consensus verification for CometBLS block headers. It requires another service, such as an IBC relayer, to send block data for zpk generation.

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -147,6 +147,20 @@ jobs:
           --amend localhost:5000/unionfi/${{ matrix.package }}:${{ github.ref_name }}-x86_64-linux \
       - name: Push Manifest to Local Registry
         run: docker manifest push localhost:5000/unionfi/${{ matrix.package }}:${{ github.ref_name }}
+      - uses: actions/checkout@v3
+        with:
+          lfs: true
+          fetch-depth: 0
+      - name: Annotate Manifest
+        run: |
+          curl -L https://github.com/regclient/regclient/releases/latest/download/regctl-linux-amd64 >regctl
+          chmod 755 regctl && sudo cp ./regctl /usr/bin
+
+          echo "downloaded & installed regctl"
+
+          regctl registry set --tls disabled localhost:5000
+          regctl image mod localhost:5000/unionfi/${{ matrix.package }}:${{ github.ref_name }} --to-oci --create ${{ github.ref_name }} --annotation org.opencontainers.image.description="$(cat $GITHUB_WORKSPACE/.github/container-descriptions/${{ matrix.package }}.txt)"
+         
       - name: Copy Manifest to GHCR
         run: |
           wget https://github.com/rapidsai/skopeo/releases/download/v1.12/skopeo-linux-amd64 -O ./skopeo


### PR DESCRIPTION
Modified release workflow to use `regctl` to annotate uniond/unionpd containers with descriptions.

Example uniond mutli-arch container with description [here](https://github.com/unionfi/union/pkgs/container/uniond/99651073?tag=86-add-description-to-uniond-container)

Example unionpd mutli-arch container with description [here](https://github.com/unionfi/union/pkgs/container/unionpd/99650928?tag=86-add-description-to-uniond-container)

closes #86 
closes #87 