### PR TITLE
docs: make images and diagrams darkmode friendly

### DIFF
--- a/docs/docs/architecture/cometbls.md
+++ b/docs/docs/architecture/cometbls.md
@@ -28,7 +28,14 @@ Under CometBLS, the Union network can scale to over a hundred validators without
 
 We can scale the validator set using [distributed validator tech](https://figment.io/distributed-validator-technology-and-infrastructure-resilience/) (DVT) even more, allowing the Union network to effectively support thousands of validators. The foundation for this scaling is once again BLS signatures, which allows us to aggregate signed votes in smaller steps:
 
-![Distributed signing](/img/architecture/cometbls/signing-tree.drawio.svg)
+```mermaid
+erDiagram
+    Galois }|--|| Union : proves
+    Validator }|--|| Union : "transitions state"
+    DVT-1 }|..|| Validator : shards
+    DVT-2 }|..|| Validator : shards
+    DVT-3 }|..|| Validator : shards
+```
 
 The network can handle a hybrid set of regular and distributed validators, and recursively expand the DVT set without incurring any extra cost on the consensus or prover.
 

--- a/docs/docs/concepts/consensus-verification.mdx
+++ b/docs/docs/concepts/consensus-verification.mdx
@@ -24,7 +24,20 @@ Consensus verification is the next iteration. Instead of trusting a set of keepe
 
 The golden standard of bridging is state verification, which is the foundation for rollups as well. The current iteration of zero-knowledge technology is not performant enough for state verification in bridging applications, however, we are actively doing R&D on implementations.
 
-![Decentralization Gradient](/img/research/consensus-verification/gradient.drawio.svg)
+import ThemedImage from "@theme/ThemedImage";
+import useBaseUrl from "@docusaurus/useBaseUrl";
+
+<ThemedImage
+  alt="Docusaurus themed image"
+  sources={{
+    light: useBaseUrl(
+      "/img/research/consensus-verification/gradient-light.drawio.svg"
+    ),
+    dark: useBaseUrl(
+      "/img/research/consensus-verification/gradient-dark.drawio.svg"
+    ),
+  }}
+/>
 
 ## Categorically Different
 

--- a/docs/static/img/research/consensus-verification/gradient-dark.drawio.svg
+++ b/docs/static/img/research/consensus-verification/gradient-dark.drawio.svg
@@ -1,49 +1,55 @@
-<svg host="65bd71144e" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" version="1.1" width="601px" height="179px" viewBox="-0.5 -0.5 601 179" content="&lt;mxfile&gt;&lt;diagram id=&quot;E2demw0WxWMLNoXnIluc&quot; name=&quot;Page-1&quot;&gt;5VhNb6MwEP01OTbCOEBybGl391KpUqT9OFowBWsdHBnTJPvrdygmYEzUapWUasMhws+esf3mPRyY0Xiz/6rYNn+UKYiZ76X7Gb2f+X5IQvytgUMDLLyoATLF0wYiHbDmf8CAnkErnkJpDdRSCs23NpjIooBEWxhTSu7sYc9S2LNuWQYOsE6YcNEfPNV5gy79qMO/Ac/ydmYSrpqeDWsHm52UOUvlrgfRhxmNlZS6udvsYxA1dy0vTdyXE73HhSko9HsC/CbghYnK7M2sSx/azSpZFSnU48mM3u1yrmG9ZUndu8PqIpbrjTDdJh0oDfuTSyLHjaJAQG5AqwMOMQFLQ43RBglNe9cxHXoGy3sst3HMFDc7Zu72jzeGgnE6qENHjKtWTKAEU4cZ3KO2t19qJX9DLIVUiBSywJF3z1yIAYQJswKbCWYHxO9qxjgK7NZ0bHia1tOM8t1VxDsP5cQbcL4MRjh3KadnoHzhUH4PyTWQHk5IeuCQ/ljh4/NmjUQwXSmY/ClABo+B0J+vQoef5Qg/4Rn4Cd9+LEKR3tZHSS0owcqSJzYHsOf6Z62WeWBav3o993sjpNfGoW2g7A9NEPGDFqjjbry5R6MW6aJfW1b4EyiO+60F3lMqpM6JNqgEbk5WKoGeQNzi9KgPRqhvMQWCaf5izzhWDzPDk+S4lmPtKbVr7wdd8dsszWJNYP+AG+Q6nrSty4LVfNW/IjuvZioD7eR9FcyRiHdpKHI0tOZFhvLxvc9jszGXed1FPsxxy2t3XDSl4/xRx/WEsPg395Gh+4ZSOZ/dVu6R9hRP7q/PY7D23el6Hbaa0mGLCzmMfpzDCHEUFMuihKKsSoS/Y5Ge8e+05rKY3HdBy+f0vnvHK/b/7TtyolQfY7wwsJVwLuMFCzvvJY3nfpZYa6bhs5lu+EY7oencrwrXZjo6pemi4DKnXbi41GmHze6razO8+3RNH/4C&lt;/diagram&gt;&lt;/mxfile&gt;">
+<svg host="65bd71144e" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" version="1.1" width="601px" height="179px" viewBox="-0.5 -0.5 601 179" content="&lt;mxfile&gt;&lt;diagram id=&quot;fWuebobhIb-qaJMcGt1C&quot; name=&quot;Page-1&quot;&gt;7VlNc5swEP01HJNByIB9TEjSXjKTGc/046gBGTTFyBUitvvruwLJfLpxE2ynqTkk1tPuot23esjYwsFy80mQVfLII5pajh1tLHxnOY47c+GvArYVMLH9CogFiyoI1cCc/aIatDVasIjmLUPJeSrZqg2GPMtoKFsYEYKv22YLnrbvuiIx7QHzkKR99CuLZFKhU8ev8c+UxYm5M/Jm1cySGGOdSZ6QiK8bEL63cCA4l9Wn5SagqaqdqUvl97BndrcwQTN5iINTOTyTtNC56XXJrUlW8CKLqLJHFr5dJ0zS+YqEanYN7AKWyGWqpxcsTQOecgHjjGdgdJtLwX/s6oR2iDGzHPxQXjCjV0OFpJu9GaFdnaC/KF9SKbZgoh2murK6tZCnx+uaKM/WWNIgyfgR3RvxLnJdPvigKzhcTTxQTS+Vqi4cVq8a0uTs/SwUx5AxXpRXE/Ji9T+AjAVJofsjEwYWUEWqLHpcQdnki4RAyDiDYQjxKeC3qt4MuvtGTyxZFKmIg2TX7WCfnlxkd9iduj12/QFyHfft5E5GJfeOhhd6u/S63c07QO/0SPS6o9L7WMDT6GoOBSeyEPRQgv8xrUUdvjzneuYdxJg3gtp6Lz+7aBbdqOe92g4pyXMWtktIN0x+U71+7erR98bM3UZvg3KwNQPYttvKCTmuAZTflX1tY98gtXc5ark/UcEgX7U9S3AUKmnUO7V0iITa8EKEtNHxfW4bzLkDzBlM0JRI9ty+4xCd+g5PnJXbSLcOxu3Wcdy6d0yUarHasXmI6cTanaa6z3wTSBIRU9kLVDbYLvODes4fVSXmLIuhVR37owvFkE7Y9YVOphnTi2a8STP8c2qGM6gZjT6avE4/0On0YzbuKeMp+KCC8X4Uw7xzuEjGKyVjdk7JmBxJMvDpJAOhUTUj4FlOs7zIwfEL9McCvhpKxrMPKiSuYfj8QnLAu7aLkPxBSNAepk+jJJ7bbqSxlMSdtOMeU0nGfT85l0TS/0NFPPvdHEeGXkNeVOQvVASfU0V89zjnEW9yrPMIDOufoyrz+jc9fP8b&lt;/diagram&gt;&lt;/mxfile&gt;">
     <defs/>
     <g>
-        <rect x="0" y="97" width="600" height="80" rx="12" ry="12" fill="rgb(255, 255, 255)" stroke="rgb(0, 0, 0)" pointer-events="all"/>
-        <rect x="20" y="122" width="60" height="30" fill="none" stroke="none" pointer-events="all"/>
+        <rect x="0" y="97" width="600" height="80" rx="12" ry="12" fill="none" stroke="#ffffff" pointer-events="all"/>
+        <rect x="20" y="122" width="70" height="25" fill="none" stroke="#ffffff" pointer-events="all"/>
         <g transform="translate(-0.5 -0.5)">
             <switch>
                 <foreignObject pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow: visible; text-align: left;">
-                    <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe center; width: 58px; height: 1px; padding-top: 137px; margin-left: 21px;">
+                    <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe center; width: 68px; height: 1px; padding-top: 135px; margin-left: 21px;">
                         <div data-drawio-colors="color: rgb(0, 0, 0); " style="box-sizing: border-box; font-size: 0px; text-align: center;">
                             <div style="display: inline-block; font-size: 12px; font-family: Helvetica; color: rgb(0, 0, 0); line-height: 1.2; pointer-events: all; white-space: normal; overflow-wrap: normal;">
-                                Centralized
+                                <font color="#ffffff">
+                                    Centralized
+                                </font>
                             </div>
                         </div>
                     </div>
                 </foreignObject>
-                <text x="50" y="141" fill="rgb(0, 0, 0)" font-family="Helvetica" font-size="12px" text-anchor="middle">
+                <text x="55" y="138" fill="rgb(0, 0, 0)" font-family="Helvetica" font-size="12px" text-anchor="middle">
                     Centralized
                 </text>
             </switch>
         </g>
-        <rect x="520" y="122" width="60" height="30" fill="none" stroke="none" pointer-events="all"/>
+        <rect x="500" y="122" width="80" height="25" fill="none" stroke="#ffffff" pointer-events="all"/>
         <g transform="translate(-0.5 -0.5)">
             <switch>
                 <foreignObject pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow: visible; text-align: left;">
-                    <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe center; width: 58px; height: 1px; padding-top: 137px; margin-left: 521px;">
+                    <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe center; width: 78px; height: 1px; padding-top: 135px; margin-left: 501px;">
                         <div data-drawio-colors="color: rgb(0, 0, 0); " style="box-sizing: border-box; font-size: 0px; text-align: center;">
                             <div style="display: inline-block; font-size: 12px; font-family: Helvetica; color: rgb(0, 0, 0); line-height: 1.2; pointer-events: all; white-space: normal; overflow-wrap: normal;">
-                                Decentralized
+                                <font color="#ffffff">
+                                    Decentralized
+                                </font>
                             </div>
                         </div>
                     </div>
                 </foreignObject>
-                <text x="550" y="141" fill="rgb(0, 0, 0)" font-family="Helvetica" font-size="12px" text-anchor="middle">
-                    Decentrali...
+                <text x="540" y="138" fill="rgb(0, 0, 0)" font-family="Helvetica" font-size="12px" text-anchor="middle">
+                    Decentralized
                 </text>
             </switch>
         </g>
-        <rect x="100" y="-0.04" width="80" height="60" rx="9" ry="9" fill="rgb(255, 255, 255)" stroke="rgb(0, 0, 0)" pointer-events="all"/>
+        <rect x="100" y="-0.04" width="80" height="60" rx="9" ry="9" fill="none" stroke="#ffffff" pointer-events="all"/>
         <g transform="translate(-0.5 -0.5)">
             <switch>
                 <foreignObject pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow: visible; text-align: left;">
                     <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe center; width: 78px; height: 1px; padding-top: 30px; margin-left: 101px;">
                         <div data-drawio-colors="color: rgb(0, 0, 0); " style="box-sizing: border-box; font-size: 0px; text-align: center;">
                             <div style="display: inline-block; font-size: 12px; font-family: Helvetica; color: rgb(0, 0, 0); line-height: 1.2; pointer-events: all; white-space: normal; overflow-wrap: normal;">
-                                Multi-Signature
+                                <font color="#ffffff">
+                                    Multi-Signature
+                                </font>
                             </div>
                         </div>
                     </div>
@@ -53,16 +59,18 @@
                 </text>
             </switch>
         </g>
-        <path d="M 140 59.96 L 140 90.63" fill="none" stroke="rgb(0, 0, 0)" stroke-miterlimit="10" pointer-events="stroke"/>
-        <path d="M 140 95.88 L 136.5 88.88 L 140 90.63 L 143.5 88.88 Z" fill="rgb(0, 0, 0)" stroke="rgb(0, 0, 0)" stroke-miterlimit="10" pointer-events="all"/>
-        <rect x="0" y="-0.04" width="80" height="60" rx="9" ry="9" fill="rgb(255, 255, 255)" stroke="rgb(0, 0, 0)" pointer-events="all"/>
+        <path d="M 140 59.96 L 140 90.63" fill="none" stroke="#ffffff" stroke-miterlimit="10" pointer-events="stroke"/>
+        <path d="M 140 95.88 L 136.5 88.88 L 140 90.63 L 143.5 88.88 Z" fill="#ffffff" stroke="#ffffff" stroke-miterlimit="10" pointer-events="all"/>
+        <rect x="0" y="-0.04" width="80" height="60" rx="9" ry="9" fill="none" stroke="#ffffff" pointer-events="all"/>
         <g transform="translate(-0.5 -0.5)">
             <switch>
                 <foreignObject pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow: visible; text-align: left;">
                     <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe center; width: 78px; height: 1px; padding-top: 30px; margin-left: 1px;">
                         <div data-drawio-colors="color: rgb(0, 0, 0); " style="box-sizing: border-box; font-size: 0px; text-align: center;">
                             <div style="display: inline-block; font-size: 12px; font-family: Helvetica; color: rgb(0, 0, 0); line-height: 1.2; pointer-events: all; white-space: normal; overflow-wrap: normal;">
-                                Single Signature
+                                <font color="#ffffff">
+                                    Single Signature
+                                </font>
                             </div>
                         </div>
                     </div>
@@ -72,16 +80,18 @@
                 </text>
             </switch>
         </g>
-        <path d="M 40 59.96 L 40 90.63" fill="none" stroke="rgb(0, 0, 0)" stroke-miterlimit="10" pointer-events="stroke"/>
-        <path d="M 40 95.88 L 36.5 88.88 L 40 90.63 L 43.5 88.88 Z" fill="rgb(0, 0, 0)" stroke="rgb(0, 0, 0)" stroke-miterlimit="10" pointer-events="all"/>
-        <rect x="200" y="-0.04" width="80" height="60" rx="9" ry="9" fill="rgb(255, 255, 255)" stroke="rgb(0, 0, 0)" pointer-events="all"/>
+        <path d="M 40 59.96 L 40 90.63" fill="none" stroke="#ffffff" stroke-miterlimit="10" pointer-events="stroke"/>
+        <path d="M 40 95.88 L 36.5 88.88 L 40 90.63 L 43.5 88.88 Z" fill="#ffffff" stroke="#ffffff" stroke-miterlimit="10" pointer-events="all"/>
+        <rect x="200" y="-0.04" width="80" height="60" rx="9" ry="9" fill="none" stroke="#ffffff" pointer-events="all"/>
         <g transform="translate(-0.5 -0.5)">
             <switch>
                 <foreignObject pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow: visible; text-align: left;">
                     <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe center; width: 78px; height: 1px; padding-top: 30px; margin-left: 201px;">
                         <div data-drawio-colors="color: rgb(0, 0, 0); " style="box-sizing: border-box; font-size: 0px; text-align: center;">
                             <div style="display: inline-block; font-size: 12px; font-family: Helvetica; color: rgb(0, 0, 0); line-height: 1.2; pointer-events: all; white-space: normal; overflow-wrap: normal;">
-                                MPC
+                                <font color="#ffffff">
+                                    MPC
+                                </font>
                             </div>
                         </div>
                     </div>
@@ -91,16 +101,18 @@
                 </text>
             </switch>
         </g>
-        <path d="M 240 59.96 L 240 90.63" fill="none" stroke="rgb(0, 0, 0)" stroke-miterlimit="10" pointer-events="stroke"/>
-        <path d="M 240 95.88 L 236.5 88.88 L 240 90.63 L 243.5 88.88 Z" fill="rgb(0, 0, 0)" stroke="rgb(0, 0, 0)" stroke-miterlimit="10" pointer-events="all"/>
-        <rect x="424" y="-0.04" width="80" height="60" rx="9" ry="9" fill="rgb(255, 255, 255)" stroke="rgb(0, 0, 0)" pointer-events="all"/>
+        <path d="M 240 59.96 L 240 90.63" fill="none" stroke="#ffffff" stroke-miterlimit="10" pointer-events="stroke"/>
+        <path d="M 240 95.88 L 236.5 88.88 L 240 90.63 L 243.5 88.88 Z" fill="#ffffff" stroke="#ffffff" stroke-miterlimit="10" pointer-events="all"/>
+        <rect x="424" y="-0.04" width="80" height="60" rx="9" ry="9" fill="none" stroke="#ffffff" pointer-events="all"/>
         <g transform="translate(-0.5 -0.5)">
             <switch>
                 <foreignObject pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow: visible; text-align: left;">
                     <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe center; width: 78px; height: 1px; padding-top: 30px; margin-left: 425px;">
                         <div data-drawio-colors="color: rgb(0, 0, 0); " style="box-sizing: border-box; font-size: 0px; text-align: center;">
                             <div style="display: inline-block; font-size: 12px; font-family: Helvetica; color: rgb(0, 0, 0); line-height: 1.2; pointer-events: all; white-space: normal; overflow-wrap: normal;">
-                                Consensus Verification
+                                <font color="#ffffff">
+                                    Consensus Verification
+                                </font>
                             </div>
                         </div>
                     </div>
@@ -110,16 +122,18 @@
                 </text>
             </switch>
         </g>
-        <path d="M 464 59.96 L 464 90.63" fill="none" stroke="rgb(0, 0, 0)" stroke-miterlimit="10" pointer-events="stroke"/>
-        <path d="M 464 95.88 L 460.5 88.88 L 464 90.63 L 467.5 88.88 Z" fill="rgb(0, 0, 0)" stroke="rgb(0, 0, 0)" stroke-miterlimit="10" pointer-events="all"/>
-        <rect x="520" y="-0.04" width="80" height="60" rx="9" ry="9" fill="rgb(255, 255, 255)" stroke="rgb(0, 0, 0)" pointer-events="all"/>
+        <path d="M 464 59.96 L 464 90.63" fill="none" stroke="#ffffff" stroke-miterlimit="10" pointer-events="stroke"/>
+        <path d="M 464 95.88 L 460.5 88.88 L 464 90.63 L 467.5 88.88 Z" fill="#ffffff" stroke="#ffffff" stroke-miterlimit="10" pointer-events="all"/>
+        <rect x="520" y="-0.04" width="80" height="60" rx="9" ry="9" fill="none" stroke="#ffffff" pointer-events="all"/>
         <g transform="translate(-0.5 -0.5)">
             <switch>
                 <foreignObject pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow: visible; text-align: left;">
                     <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe center; width: 78px; height: 1px; padding-top: 30px; margin-left: 521px;">
                         <div data-drawio-colors="color: rgb(0, 0, 0); " style="box-sizing: border-box; font-size: 0px; text-align: center;">
                             <div style="display: inline-block; font-size: 12px; font-family: Helvetica; color: rgb(0, 0, 0); line-height: 1.2; pointer-events: all; white-space: normal; overflow-wrap: normal;">
-                                State Verification
+                                <font color="#ffffff">
+                                    State Verification
+                                </font>
                             </div>
                         </div>
                     </div>
@@ -129,8 +143,8 @@
                 </text>
             </switch>
         </g>
-        <path d="M 560 59.96 L 560 90.63" fill="none" stroke="rgb(0, 0, 0)" stroke-miterlimit="10" pointer-events="stroke"/>
-        <path d="M 560 95.88 L 556.5 88.88 L 560 90.63 L 563.5 88.88 Z" fill="rgb(0, 0, 0)" stroke="rgb(0, 0, 0)" stroke-miterlimit="10" pointer-events="all"/>
+        <path d="M 560 59.96 L 560 90.63" fill="none" stroke="#ffffff" stroke-miterlimit="10" pointer-events="stroke"/>
+        <path d="M 560 95.88 L 556.5 88.88 L 560 90.63 L 563.5 88.88 Z" fill="#ffffff" stroke="#ffffff" stroke-miterlimit="10" pointer-events="all"/>
     </g>
     <switch>
         <g requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility"/>

--- a/docs/static/img/research/consensus-verification/gradient-light.drawio.svg
+++ b/docs/static/img/research/consensus-verification/gradient-light.drawio.svg
@@ -1,0 +1,143 @@
+<svg host="65bd71144e" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" version="1.1" width="601px" height="179px" viewBox="-0.5 -0.5 601 179" content="&lt;mxfile&gt;&lt;diagram id=&quot;E2demw0WxWMLNoXnIluc&quot; name=&quot;Page-1&quot;&gt;7VhNb6MwFPw1OTYCHEM4NrTbvVSKFGk/jha8gCUHR8Y0yf76NcEOOKZqd5W0bLscIt7Yz9jzZnDwBCWb/YMg2+KRZ8AmgZftJ+huEgQ4xuq3AQ4tMPOiFsgFzVrI74AV/QUa9DRa0wwqq6PknEm6tcGUlyWk0sKIEHxnd1tzZj91S3JwgFVKmIt+p5ksWnQeRB3+FWhemCf7Ydy2bIjprFdSFSTjux6E7icoEZzL9m6zT4A13Ble2rwvz7SeJiaglK9JCNqEJ8JqvTY9L3kwixW8LjNo+vsTtNgVVMJqS9Kmdaeqq7BCbphuXlPGEs64UHHJS9Vp4U5Jz/IJhIR9D9JTfAC+ASkOqotunWu2tFz8UMe7jvzQ01jRI97kEV3v/DRyR4m60awMM4QchhK1EEGYUmXmkKUWJF9kROXmpQpTNRAofNEwQZW8bnXDhmZZM+Ig2109vMuw63tn9M7xAL0uu+gC7M4cdu8g/WD8hu/IL3b4fazVe/JmpYggshYwRrv7Z34Pg2kcOpTNBygLL0BZ+PIrEcrsttlGGo0xUlU0tWmBPZU/GgFNsY5+9lru9lpbx+BgAiX6Q5vkB9gATd6NN/VQZJAu+xhZ6UsQVK230fwR/JPyVLwWKViqgczaBt169aqBB6phMAGMSPpkb55DJdJPWHKqJneSA0K2HALc6cGM0s5eJ/b3u7OxThuv8SKOp3H/iuxxJRE5SGfco4ZORLxKVpEjqxUtc6WowBu1GYe86HWX/2a+nP/3ZTQqXwaDvuxpY/Z3HvXPPXqunsuZMna3x2UyRheOx4bmG+wz+zAelQ9nV/Ihejsf+r4jqoSXFZRVXSn4m6rbWv2Bl5SXY3QnNhS/vztf8UH/0d1pxDQSe4bYFsel7Iln9rjXtKd7CLKSRMI/YM3zj+93tKZ71vH5rIlGZc0IX2fnDGfX2jlV2B0Ot927E3Z0/xs=&lt;/diagram&gt;&lt;/mxfile&gt;">
+    <defs/>
+    <g>
+        <rect x="0" y="97" width="600" height="80" rx="12" ry="12" fill="none" stroke="rgb(0, 0, 0)" pointer-events="all"/>
+        <rect x="20" y="122" width="60" height="30" fill="none" stroke="none" pointer-events="all"/>
+        <g transform="translate(-0.5 -0.5)">
+            <switch>
+                <foreignObject pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow: visible; text-align: left;">
+                    <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe center; width: 58px; height: 1px; padding-top: 137px; margin-left: 21px;">
+                        <div data-drawio-colors="color: rgb(0, 0, 0); " style="box-sizing: border-box; font-size: 0px; text-align: center;">
+                            <div style="display: inline-block; font-size: 12px; font-family: Helvetica; color: rgb(0, 0, 0); line-height: 1.2; pointer-events: all; white-space: normal; overflow-wrap: normal;">
+                                Centralized
+                            </div>
+                        </div>
+                    </div>
+                </foreignObject>
+                <text x="50" y="141" fill="rgb(0, 0, 0)" font-family="Helvetica" font-size="12px" text-anchor="middle">
+                    Centralized
+                </text>
+            </switch>
+        </g>
+        <rect x="520" y="122" width="60" height="30" fill="none" stroke="none" pointer-events="all"/>
+        <g transform="translate(-0.5 -0.5)">
+            <switch>
+                <foreignObject pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow: visible; text-align: left;">
+                    <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe center; width: 58px; height: 1px; padding-top: 137px; margin-left: 521px;">
+                        <div data-drawio-colors="color: rgb(0, 0, 0); " style="box-sizing: border-box; font-size: 0px; text-align: center;">
+                            <div style="display: inline-block; font-size: 12px; font-family: Helvetica; color: rgb(0, 0, 0); line-height: 1.2; pointer-events: all; white-space: normal; overflow-wrap: normal;">
+                                Decentralized
+                            </div>
+                        </div>
+                    </div>
+                </foreignObject>
+                <text x="550" y="141" fill="rgb(0, 0, 0)" font-family="Helvetica" font-size="12px" text-anchor="middle">
+                    Decentrali...
+                </text>
+            </switch>
+        </g>
+        <rect x="100" y="-0.04" width="80" height="60" rx="9" ry="9" fill="none" stroke="rgb(0, 0, 0)" pointer-events="all"/>
+        <g transform="translate(-0.5 -0.5)">
+            <switch>
+                <foreignObject pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow: visible; text-align: left;">
+                    <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe center; width: 78px; height: 1px; padding-top: 30px; margin-left: 101px;">
+                        <div data-drawio-colors="color: rgb(0, 0, 0); " style="box-sizing: border-box; font-size: 0px; text-align: center;">
+                            <div style="display: inline-block; font-size: 12px; font-family: Helvetica; color: rgb(0, 0, 0); line-height: 1.2; pointer-events: all; white-space: normal; overflow-wrap: normal;">
+                                Multi-Signature
+                            </div>
+                        </div>
+                    </div>
+                </foreignObject>
+                <text x="140" y="34" fill="rgb(0, 0, 0)" font-family="Helvetica" font-size="12px" text-anchor="middle">
+                    Multi-Signatu...
+                </text>
+            </switch>
+        </g>
+        <path d="M 140 59.96 L 140 90.63" fill="none" stroke="rgb(0, 0, 0)" stroke-miterlimit="10" pointer-events="stroke"/>
+        <path d="M 140 95.88 L 136.5 88.88 L 140 90.63 L 143.5 88.88 Z" fill="rgb(0, 0, 0)" stroke="rgb(0, 0, 0)" stroke-miterlimit="10" pointer-events="all"/>
+        <rect x="0" y="-0.04" width="80" height="60" rx="9" ry="9" fill="none" stroke="rgb(0, 0, 0)" pointer-events="all"/>
+        <g transform="translate(-0.5 -0.5)">
+            <switch>
+                <foreignObject pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow: visible; text-align: left;">
+                    <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe center; width: 78px; height: 1px; padding-top: 30px; margin-left: 1px;">
+                        <div data-drawio-colors="color: rgb(0, 0, 0); " style="box-sizing: border-box; font-size: 0px; text-align: center;">
+                            <div style="display: inline-block; font-size: 12px; font-family: Helvetica; color: rgb(0, 0, 0); line-height: 1.2; pointer-events: all; white-space: normal; overflow-wrap: normal;">
+                                Single Signature
+                            </div>
+                        </div>
+                    </div>
+                </foreignObject>
+                <text x="40" y="34" fill="rgb(0, 0, 0)" font-family="Helvetica" font-size="12px" text-anchor="middle">
+                    Single Signat...
+                </text>
+            </switch>
+        </g>
+        <path d="M 40 59.96 L 40 90.63" fill="none" stroke="rgb(0, 0, 0)" stroke-miterlimit="10" pointer-events="stroke"/>
+        <path d="M 40 95.88 L 36.5 88.88 L 40 90.63 L 43.5 88.88 Z" fill="rgb(0, 0, 0)" stroke="rgb(0, 0, 0)" stroke-miterlimit="10" pointer-events="all"/>
+        <rect x="200" y="-0.04" width="80" height="60" rx="9" ry="9" fill="none" stroke="rgb(0, 0, 0)" pointer-events="all"/>
+        <g transform="translate(-0.5 -0.5)">
+            <switch>
+                <foreignObject pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow: visible; text-align: left;">
+                    <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe center; width: 78px; height: 1px; padding-top: 30px; margin-left: 201px;">
+                        <div data-drawio-colors="color: rgb(0, 0, 0); " style="box-sizing: border-box; font-size: 0px; text-align: center;">
+                            <div style="display: inline-block; font-size: 12px; font-family: Helvetica; color: rgb(0, 0, 0); line-height: 1.2; pointer-events: all; white-space: normal; overflow-wrap: normal;">
+                                MPC
+                            </div>
+                        </div>
+                    </div>
+                </foreignObject>
+                <text x="240" y="34" fill="rgb(0, 0, 0)" font-family="Helvetica" font-size="12px" text-anchor="middle">
+                    MPC
+                </text>
+            </switch>
+        </g>
+        <path d="M 240 59.96 L 240 90.63" fill="none" stroke="rgb(0, 0, 0)" stroke-miterlimit="10" pointer-events="stroke"/>
+        <path d="M 240 95.88 L 236.5 88.88 L 240 90.63 L 243.5 88.88 Z" fill="rgb(0, 0, 0)" stroke="rgb(0, 0, 0)" stroke-miterlimit="10" pointer-events="all"/>
+        <rect x="424" y="-0.04" width="80" height="60" rx="9" ry="9" fill="none" stroke="rgb(0, 0, 0)" pointer-events="all"/>
+        <g transform="translate(-0.5 -0.5)">
+            <switch>
+                <foreignObject pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow: visible; text-align: left;">
+                    <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe center; width: 78px; height: 1px; padding-top: 30px; margin-left: 425px;">
+                        <div data-drawio-colors="color: rgb(0, 0, 0); " style="box-sizing: border-box; font-size: 0px; text-align: center;">
+                            <div style="display: inline-block; font-size: 12px; font-family: Helvetica; color: rgb(0, 0, 0); line-height: 1.2; pointer-events: all; white-space: normal; overflow-wrap: normal;">
+                                Consensus Verification
+                            </div>
+                        </div>
+                    </div>
+                </foreignObject>
+                <text x="464" y="34" fill="rgb(0, 0, 0)" font-family="Helvetica" font-size="12px" text-anchor="middle">
+                    Consensus Ver...
+                </text>
+            </switch>
+        </g>
+        <path d="M 464 59.96 L 464 90.63" fill="none" stroke="rgb(0, 0, 0)" stroke-miterlimit="10" pointer-events="stroke"/>
+        <path d="M 464 95.88 L 460.5 88.88 L 464 90.63 L 467.5 88.88 Z" fill="rgb(0, 0, 0)" stroke="rgb(0, 0, 0)" stroke-miterlimit="10" pointer-events="all"/>
+        <rect x="520" y="-0.04" width="80" height="60" rx="9" ry="9" fill="none" stroke="rgb(0, 0, 0)" pointer-events="all"/>
+        <g transform="translate(-0.5 -0.5)">
+            <switch>
+                <foreignObject pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow: visible; text-align: left;">
+                    <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe center; width: 78px; height: 1px; padding-top: 30px; margin-left: 521px;">
+                        <div data-drawio-colors="color: rgb(0, 0, 0); " style="box-sizing: border-box; font-size: 0px; text-align: center;">
+                            <div style="display: inline-block; font-size: 12px; font-family: Helvetica; color: rgb(0, 0, 0); line-height: 1.2; pointer-events: all; white-space: normal; overflow-wrap: normal;">
+                                State Verification
+                            </div>
+                        </div>
+                    </div>
+                </foreignObject>
+                <text x="560" y="34" fill="rgb(0, 0, 0)" font-family="Helvetica" font-size="12px" text-anchor="middle">
+                    State Verific...
+                </text>
+            </switch>
+        </g>
+        <path d="M 560 59.96 L 560 90.63" fill="none" stroke="rgb(0, 0, 0)" stroke-miterlimit="10" pointer-events="stroke"/>
+        <path d="M 560 95.88 L 556.5 88.88 L 560 90.63 L 563.5 88.88 Z" fill="rgb(0, 0, 0)" stroke="rgb(0, 0, 0)" stroke-miterlimit="10" pointer-events="all"/>
+    </g>
+    <switch>
+        <g requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility"/>
+        <a transform="translate(0,-5)" xlink:href="https://www.diagrams.net/doc/faq/svg-export-text-problems" target="_blank">
+            <text text-anchor="middle" font-size="10px" x="50%" y="100%">
+                Text is not SVG - cannot display
+            </text>
+        </a>
+    </switch>
+</svg>


### PR DESCRIPTION
This switches images to mermaidjs where possible, and otherwise introduces a dark + light version for an svg.