### PR TITLE
feat!: add `Proto` trait as supertrait of `{From,TryFrom,Into}Proto`

### DIFF
--- a/cosmwasm/cw20-ics20/src/contract.rs
+++ b/cosmwasm/cw20-ics20/src/contract.rs
@@ -1,8 +1,8 @@
 #[cfg(not(feature = "library"))]
 use cosmwasm_std::entry_point;
 use cosmwasm_std::{
-    from_binary, to_binary, Addr, Binary, Deps, DepsMut, Env, IbcChannel, IbcMsg, IbcQuery,
-    MessageInfo, Order, PortIdResponse, Response, StdError, StdResult,
+    from_binary, to_binary, Addr, Binary, Deps, DepsMut, Env, IbcMsg, IbcQuery, MessageInfo, Order,
+    PortIdResponse, Response, StdError, StdResult,
 };
 use cw2::{get_contract_version, set_contract_version};
 use cw20::{Cw20Coin, Cw20ReceiveMsg};

--- a/lib/unionlabs/src/ethereum/beacon.rs
+++ b/lib/unionlabs/src/ethereum/beacon.rs
@@ -339,7 +339,7 @@ mod tests {
 
         assert_proto_roundtrip(&finality_update.attested_header);
 
-        dbg!(U256::from_dec_str("77"));
+        dbg!(U256::from_dec_str("77").unwrap());
 
         assert_eq!(
             finality_update

--- a/lib/unionlabs/src/ibc/core/channel/channel.rs
+++ b/lib/unionlabs/src/ibc/core/channel/channel.rs
@@ -1,7 +1,7 @@
 use crate::{
     errors::MissingField,
     ibc::core::channel::{counterparty::Counterparty, order::Order, state::State},
-    IntoProto, TryFromProto, TypeUrl,
+    Proto, TypeUrl,
 };
 
 #[derive(Debug, Clone)]
@@ -43,11 +43,7 @@ impl TryFrom<protos::ibc::core::channel::v1::Channel> for Channel {
     }
 }
 
-impl IntoProto for Channel {
-    type Proto = protos::ibc::core::channel::v1::Channel;
-}
-
-impl TryFromProto for Channel {
+impl Proto for Channel {
     type Proto = protos::ibc::core::channel::v1::Channel;
 }
 

--- a/lib/unionlabs/src/ibc/core/channel/packet.rs
+++ b/lib/unionlabs/src/ibc/core/channel/packet.rs
@@ -1,6 +1,4 @@
-use crate::{
-    errors::MissingField, ibc::core::client::height::Height, IntoProto, TryFromProto, TypeUrl,
-};
+use crate::{errors::MissingField, ibc::core::client::height::Height, Proto, TypeUrl};
 
 #[derive(Debug, Clone)]
 pub struct Packet {
@@ -14,11 +12,7 @@ pub struct Packet {
     pub timeout_timestamp: u64,
 }
 
-impl IntoProto for Packet {
-    type Proto = protos::ibc::core::channel::v1::Packet;
-}
-
-impl TryFromProto for Packet {
+impl Proto for Packet {
     type Proto = protos::ibc::core::channel::v1::Packet;
 }
 

--- a/lib/unionlabs/src/ibc/core/connection/connection_end.rs
+++ b/lib/unionlabs/src/ibc/core/connection/connection_end.rs
@@ -1,7 +1,7 @@
 use crate::{
     errors::{MissingField, UnknownEnumVariant},
     ibc::core::connection::{counterparty::Counterparty, state::State, version::Version},
-    IntoProto, TryFromProto, TypeUrl,
+    Proto, TypeUrl,
 };
 
 #[derive(Debug, Clone)]
@@ -52,11 +52,7 @@ impl TryFrom<protos::ibc::core::connection::v1::ConnectionEnd> for ConnectionEnd
     }
 }
 
-impl IntoProto for ConnectionEnd {
-    type Proto = protos::ibc::core::connection::v1::ConnectionEnd;
-}
-
-impl TryFromProto for ConnectionEnd {
+impl Proto for ConnectionEnd {
     type Proto = protos::ibc::core::connection::v1::ConnectionEnd;
 }
 

--- a/lib/unionlabs/src/ibc/lightclients/cometbls/client_state.rs
+++ b/lib/unionlabs/src/ibc/lightclients/cometbls/client_state.rs
@@ -6,7 +6,7 @@ use crate::{
         core::client::height::Height, google::protobuf::duration::Duration,
         lightclients::tendermint::fraction::Fraction,
     },
-    IntoProto, TryFromProto, TypeUrl,
+    Proto, TypeUrl,
 };
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -36,11 +36,7 @@ impl TypeUrl for protos::union::ibc::lightclients::cometbls::v1::ClientState {
     const TYPE_URL: &'static str = "/union.ibc.lightclients.cometbls.v1.ClientState";
 }
 
-impl IntoProto for ClientState {
-    type Proto = protos::union::ibc::lightclients::cometbls::v1::ClientState;
-}
-
-impl TryFromProto for ClientState {
+impl Proto for ClientState {
     type Proto = protos::union::ibc::lightclients::cometbls::v1::ClientState;
 }
 

--- a/lib/unionlabs/src/ibc/lightclients/cometbls/consensus_state.rs
+++ b/lib/unionlabs/src/ibc/lightclients/cometbls/consensus_state.rs
@@ -1,7 +1,4 @@
-use crate::{
-    errors::MissingField, ibc::core::commitment::merkle_root::MerkleRoot, IntoProto, TryFromProto,
-    TypeUrl,
-};
+use crate::{errors::MissingField, ibc::core::commitment::merkle_root::MerkleRoot, Proto, TypeUrl};
 
 #[derive(Debug, Clone)]
 pub struct ConsensusState {
@@ -26,11 +23,7 @@ impl TypeUrl for protos::union::ibc::lightclients::cometbls::v1::ConsensusState 
     const TYPE_URL: &'static str = "/union.ibc.lightclients.cometbls.v1.ConsensusState";
 }
 
-impl IntoProto for ConsensusState {
-    type Proto = protos::union::ibc::lightclients::cometbls::v1::ConsensusState;
-}
-
-impl TryFromProto for ConsensusState {
+impl Proto for ConsensusState {
     type Proto = protos::union::ibc::lightclients::cometbls::v1::ConsensusState;
 }
 

--- a/lib/unionlabs/src/ibc/lightclients/ethereum/account_update.rs
+++ b/lib/unionlabs/src/ibc/lightclients/ethereum/account_update.rs
@@ -1,6 +1,6 @@
 use serde::{Deserialize, Serialize};
 
-use crate::{ibc::lightclients::ethereum::proof::Proof, FromProto, IntoProto, TypeUrl};
+use crate::{ibc::lightclients::ethereum::proof::Proof, Proto, TypeUrl};
 
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
 pub struct AccountUpdate {
@@ -23,11 +23,7 @@ impl From<protos::union::ibc::lightclients::ethereum::v1::AccountUpdate> for Acc
     }
 }
 
-impl IntoProto for AccountUpdate {
-    type Proto = protos::union::ibc::lightclients::ethereum::v1::AccountUpdate;
-}
-
-impl FromProto for AccountUpdate {
+impl Proto for AccountUpdate {
     type Proto = protos::union::ibc::lightclients::ethereum::v1::AccountUpdate;
 }
 

--- a/lib/unionlabs/src/ibc/lightclients/ethereum/beacon_block_header.rs
+++ b/lib/unionlabs/src/ibc/lightclients/ethereum/beacon_block_header.rs
@@ -2,7 +2,7 @@ use serde::{Deserialize, Serialize};
 use ssz::{Decode, Encode};
 use tree_hash::TreeHash;
 
-use crate::{errors::InvalidLength, ethereum::H256, IntoProto, TryFromProto, TypeUrl};
+use crate::{errors::InvalidLength, ethereum::H256, Proto, TypeUrl};
 
 #[derive(Clone, Debug, PartialEq, Encode, Decode, TreeHash, Serialize, Deserialize)]
 pub struct BeaconBlockHeader {
@@ -65,10 +65,6 @@ impl TypeUrl for protos::union::ibc::lightclients::ethereum::v1::BeaconBlockHead
     const TYPE_URL: &'static str = "/union.ibc.lightclients.ethereum.v1.BeaconBlockHeader";
 }
 
-impl TryFromProto for BeaconBlockHeader {
-    type Proto = protos::union::ibc::lightclients::ethereum::v1::BeaconBlockHeader;
-}
-
-impl IntoProto for BeaconBlockHeader {
+impl Proto for BeaconBlockHeader {
     type Proto = protos::union::ibc::lightclients::ethereum::v1::BeaconBlockHeader;
 }

--- a/lib/unionlabs/src/ibc/lightclients/ethereum/client_state.rs
+++ b/lib/unionlabs/src/ibc/lightclients/ethereum/client_state.rs
@@ -7,7 +7,7 @@ use crate::{
         core::client::height::Height,
         lightclients::{ethereum::fork_parameters::ForkParameters, tendermint::fraction::Fraction},
     },
-    IntoProto, TryFromProto, TryFromProtoErrorOf, TypeUrl,
+    Proto, TryFromProtoErrorOf, TypeUrl,
 };
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -30,7 +30,7 @@ impl TypeUrl for protos::union::ibc::lightclients::ethereum::v1::ClientState {
     const TYPE_URL: &'static str = "/union.ibc.lightclients.ethereum.v1.ClientState";
 }
 
-impl IntoProto for ClientState {
+impl Proto for ClientState {
     type Proto = protos::union::ibc::lightclients::ethereum::v1::ClientState;
 }
 
@@ -95,8 +95,4 @@ impl TryFrom<protos::union::ibc::lightclients::ethereum::v1::ClientState> for Cl
             counterparty_commitment_slot: value.counterparty_commitment_slot,
         })
     }
-}
-
-impl TryFromProto for ClientState {
-    type Proto = protos::union::ibc::lightclients::ethereum::v1::ClientState;
 }

--- a/lib/unionlabs/src/ibc/lightclients/ethereum/consensus_state.rs
+++ b/lib/unionlabs/src/ibc/lightclients/ethereum/consensus_state.rs
@@ -1,8 +1,6 @@
 use serde::{Deserialize, Serialize};
 
-use crate::{
-    bls::BlsPublicKey, errors::InvalidLength, ethereum::H256, IntoProto, TryFromProto, TypeUrl,
-};
+use crate::{bls::BlsPublicKey, errors::InvalidLength, ethereum::H256, Proto, TypeUrl};
 
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct ConsensusState {
@@ -68,14 +66,10 @@ impl TryFrom<protos::union::ibc::lightclients::ethereum::v1::ConsensusState> for
     }
 }
 
-impl IntoProto for ConsensusState {
+impl Proto for ConsensusState {
     type Proto = protos::union::ibc::lightclients::ethereum::v1::ConsensusState;
 }
 
 impl TypeUrl for protos::union::ibc::lightclients::ethereum::v1::ConsensusState {
     const TYPE_URL: &'static str = "/union.ibc.lightclients.ethereum.v1.ConsensusState";
-}
-
-impl TryFromProto for ConsensusState {
-    type Proto = protos::union::ibc::lightclients::ethereum::v1::ConsensusState;
 }

--- a/lib/unionlabs/src/ibc/lightclients/ethereum/execution_payload_header.rs
+++ b/lib/unionlabs/src/ibc/lightclients/ethereum/execution_payload_header.rs
@@ -8,7 +8,7 @@ use crate::{
     errors::InvalidLength,
     ethereum::{Address, H256},
     ethereum_consts_traits::{BYTES_PER_LOGS_BLOOM, MAX_EXTRA_DATA_BYTES},
-    IntoProto, TryFromProto, TypeUrl,
+    Proto, TypeUrl,
 };
 
 #[derive(Clone, Debug, PartialEq, Encode, Decode, TreeHash, Serialize, Deserialize)]
@@ -153,10 +153,6 @@ impl TypeUrl for protos::union::ibc::lightclients::ethereum::v1::ExecutionPayloa
     const TYPE_URL: &'static str = "/union.ibc.lightclients.ethereum.v1.ExecutionPayloadHeader";
 }
 
-impl<C: BYTES_PER_LOGS_BLOOM + MAX_EXTRA_DATA_BYTES> TryFromProto for ExecutionPayloadHeader<C> {
-    type Proto = protos::union::ibc::lightclients::ethereum::v1::ExecutionPayloadHeader;
-}
-
-impl<C: BYTES_PER_LOGS_BLOOM + MAX_EXTRA_DATA_BYTES> IntoProto for ExecutionPayloadHeader<C> {
+impl<C: BYTES_PER_LOGS_BLOOM + MAX_EXTRA_DATA_BYTES> Proto for ExecutionPayloadHeader<C> {
     type Proto = protos::union::ibc::lightclients::ethereum::v1::ExecutionPayloadHeader;
 }

--- a/lib/unionlabs/src/ibc/lightclients/ethereum/fork.rs
+++ b/lib/unionlabs/src/ibc/lightclients/ethereum/fork.rs
@@ -1,7 +1,7 @@
 use serde::{Deserialize, Serialize};
 use ssz::{Decode, Encode};
 
-use crate::{errors::InvalidLength, ethereum::Version, IntoProto, TryFromProto, TypeUrl};
+use crate::{errors::InvalidLength, ethereum::Version, Proto, TypeUrl};
 
 #[derive(Debug, Clone, PartialEq, Encode, Decode, Serialize, Deserialize)]
 pub struct Fork {
@@ -35,10 +35,6 @@ impl TypeUrl for protos::union::ibc::lightclients::ethereum::v1::Fork {
     const TYPE_URL: &'static str = "/union.ibc.lightclients.ethereum.v1.Fork";
 }
 
-impl IntoProto for Fork {
-    type Proto = protos::union::ibc::lightclients::ethereum::v1::Fork;
-}
-
-impl TryFromProto for Fork {
+impl Proto for Fork {
     type Proto = protos::union::ibc::lightclients::ethereum::v1::Fork;
 }

--- a/lib/unionlabs/src/ibc/lightclients/ethereum/fork_parameters.rs
+++ b/lib/unionlabs/src/ibc/lightclients/ethereum/fork_parameters.rs
@@ -5,7 +5,7 @@ use crate::{
     errors::{InvalidLength, MissingField},
     ethereum::Version,
     ibc::lightclients::ethereum::fork::Fork,
-    IntoProto, TryFromProto, TryFromProtoErrorOf, TypeUrl,
+    Proto, TryFromProtoErrorOf, TypeUrl,
 };
 
 #[derive(Debug, Clone, PartialEq, Encode, Decode, Serialize, Deserialize)]
@@ -86,10 +86,6 @@ impl TypeUrl for protos::union::ibc::lightclients::ethereum::v1::ForkParameters 
     const TYPE_URL: &'static str = "/union.ibc.lightclients.ethereum.v1.ForkParameters";
 }
 
-impl IntoProto for ForkParameters {
-    type Proto = protos::union::ibc::lightclients::ethereum::v1::ForkParameters;
-}
-
-impl TryFromProto for ForkParameters {
+impl Proto for ForkParameters {
     type Proto = protos::union::ibc::lightclients::ethereum::v1::ForkParameters;
 }

--- a/lib/unionlabs/src/ibc/lightclients/ethereum/header.rs
+++ b/lib/unionlabs/src/ibc/lightclients/ethereum/header.rs
@@ -7,7 +7,7 @@ use crate::{
         account_update::AccountUpdate, light_client_update::LightClientUpdate,
         trusted_sync_committee::TrustedSyncCommittee,
     },
-    IntoProto, TryFromProto, TryFromProtoErrorOf, TypeUrl,
+    Proto, TryFromProtoErrorOf, TypeUrl,
 };
 
 // trait alias would be nice
@@ -74,13 +74,7 @@ impl<C: SYNC_COMMITTEE_SIZE + BYTES_PER_LOGS_BLOOM + MAX_EXTRA_DATA_BYTES>
     }
 }
 
-impl<C: SYNC_COMMITTEE_SIZE + BYTES_PER_LOGS_BLOOM + MAX_EXTRA_DATA_BYTES> IntoProto for Header<C> {
-    type Proto = protos::union::ibc::lightclients::ethereum::v1::Header;
-}
-
-impl<C: SYNC_COMMITTEE_SIZE + BYTES_PER_LOGS_BLOOM + MAX_EXTRA_DATA_BYTES> TryFromProto
-    for Header<C>
-{
+impl<C: SYNC_COMMITTEE_SIZE + BYTES_PER_LOGS_BLOOM + MAX_EXTRA_DATA_BYTES> Proto for Header<C> {
     type Proto = protos::union::ibc::lightclients::ethereum::v1::Header;
 }
 

--- a/lib/unionlabs/src/ibc/lightclients/ethereum/light_client_header.rs
+++ b/lib/unionlabs/src/ibc/lightclients/ethereum/light_client_header.rs
@@ -14,7 +14,7 @@ use crate::{
     ibc::lightclients::ethereum::{
         beacon_block_header::BeaconBlockHeader, execution_payload_header::ExecutionPayloadHeader,
     },
-    IntoProto, TryFromProto, TryFromProtoErrorOf, TypeUrl,
+    Proto, TryFromProtoErrorOf, TypeUrl,
 };
 
 #[derive(Clone, Debug, PartialEq, Encode, Decode, TreeHash, Serialize, Deserialize)]
@@ -89,10 +89,6 @@ impl TypeUrl for protos::union::ibc::lightclients::ethereum::v1::LightClientHead
     const TYPE_URL: &'static str = "/union.ibc.lightclients.ethereum.v1.LightClientHeader";
 }
 
-impl<C: BYTES_PER_LOGS_BLOOM + MAX_EXTRA_DATA_BYTES> TryFromProto for LightClientHeader<C> {
-    type Proto = protos::union::ibc::lightclients::ethereum::v1::LightClientHeader;
-}
-
-impl<C: BYTES_PER_LOGS_BLOOM + MAX_EXTRA_DATA_BYTES> IntoProto for LightClientHeader<C> {
+impl<C: BYTES_PER_LOGS_BLOOM + MAX_EXTRA_DATA_BYTES> Proto for LightClientHeader<C> {
     type Proto = protos::union::ibc::lightclients::ethereum::v1::LightClientHeader;
 }

--- a/lib/unionlabs/src/ibc/lightclients/ethereum/light_client_update.rs
+++ b/lib/unionlabs/src/ibc/lightclients/ethereum/light_client_update.rs
@@ -12,7 +12,7 @@ use crate::{
         light_client_header::LightClientHeader, sync_aggregate::SyncAggregate,
         sync_committee::SyncCommittee,
     },
-    try_from_proto_branch, IntoProto, TryFromProto, TryFromProtoErrorOf, TypeUrl,
+    try_from_proto_branch, Proto, TryFromProtoErrorOf, TypeUrl,
 };
 
 /// TODO: Move these to a more central location
@@ -136,13 +136,7 @@ impl TypeUrl for protos::union::ibc::lightclients::ethereum::v1::LightClientUpda
     const TYPE_URL: &'static str = "/union.ibc.lightclients.ethereum.v1.LightClientUpdate";
 }
 
-impl<C: SYNC_COMMITTEE_SIZE + BYTES_PER_LOGS_BLOOM + MAX_EXTRA_DATA_BYTES> TryFromProto
-    for LightClientUpdate<C>
-{
-    type Proto = protos::union::ibc::lightclients::ethereum::v1::LightClientUpdate;
-}
-
-impl<C: SYNC_COMMITTEE_SIZE + BYTES_PER_LOGS_BLOOM + MAX_EXTRA_DATA_BYTES> IntoProto
+impl<C: SYNC_COMMITTEE_SIZE + BYTES_PER_LOGS_BLOOM + MAX_EXTRA_DATA_BYTES> Proto
     for LightClientUpdate<C>
 {
     type Proto = protos::union::ibc::lightclients::ethereum::v1::LightClientUpdate;

--- a/lib/unionlabs/src/ibc/lightclients/ethereum/storage_proof.rs
+++ b/lib/unionlabs/src/ibc/lightclients/ethereum/storage_proof.rs
@@ -1,6 +1,6 @@
 use serde::{Deserialize, Serialize};
 
-use crate::{ibc::lightclients::ethereum::proof::Proof, FromProto, IntoProto, TypeUrl};
+use crate::{ibc::lightclients::ethereum::proof::Proof, Proto, TypeUrl};
 
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
 pub struct StorageProof {
@@ -23,11 +23,7 @@ impl From<protos::union::ibc::lightclients::ethereum::v1::StorageProof> for Stor
     }
 }
 
-impl IntoProto for StorageProof {
-    type Proto = protos::union::ibc::lightclients::ethereum::v1::StorageProof;
-}
-
-impl FromProto for StorageProof {
+impl Proto for StorageProof {
     type Proto = protos::union::ibc::lightclients::ethereum::v1::StorageProof;
 }
 

--- a/lib/unionlabs/src/ibc/lightclients/ethereum/sync_aggregate.rs
+++ b/lib/unionlabs/src/ibc/lightclients/ethereum/sync_aggregate.rs
@@ -4,8 +4,8 @@ use ssz_types::BitVector;
 use tree_hash::TreeHash;
 
 use crate::{
-    bls::BlsSignature, errors::InvalidLength, ethereum_consts_traits::SYNC_COMMITTEE_SIZE,
-    IntoProto, TryFromProto, TypeUrl,
+    bls::BlsSignature, errors::InvalidLength, ethereum_consts_traits::SYNC_COMMITTEE_SIZE, Proto,
+    TypeUrl,
 };
 
 #[derive(Debug, Clone, PartialEq, Deserialize, Serialize, Encode, Decode, TreeHash)]
@@ -55,10 +55,6 @@ impl TypeUrl for protos::union::ibc::lightclients::ethereum::v1::SyncAggregate {
     const TYPE_URL: &'static str = "/union.ibc.lightclients.ethereum.v1.SyncAggregate";
 }
 
-impl<C: SYNC_COMMITTEE_SIZE> TryFromProto for SyncAggregate<C> {
-    type Proto = protos::union::ibc::lightclients::ethereum::v1::SyncAggregate;
-}
-
-impl<C: SYNC_COMMITTEE_SIZE> IntoProto for SyncAggregate<C> {
+impl<C: SYNC_COMMITTEE_SIZE> Proto for SyncAggregate<C> {
     type Proto = protos::union::ibc::lightclients::ethereum::v1::SyncAggregate;
 }

--- a/lib/unionlabs/src/ibc/lightclients/ethereum/sync_committee.rs
+++ b/lib/unionlabs/src/ibc/lightclients/ethereum/sync_committee.rs
@@ -4,8 +4,8 @@ use ssz_types::{fixed_vector, FixedVector};
 use tree_hash::TreeHash;
 
 use crate::{
-    bls::BlsPublicKey, errors::InvalidLength, ethereum_consts_traits::SYNC_COMMITTEE_SIZE,
-    IntoProto, TryFromProto, TypeUrl,
+    bls::BlsPublicKey, errors::InvalidLength, ethereum_consts_traits::SYNC_COMMITTEE_SIZE, Proto,
+    TypeUrl,
 };
 
 #[derive(Clone, Debug, PartialEq, Encode, Decode, TreeHash, Serialize, Deserialize)]
@@ -68,10 +68,6 @@ impl TypeUrl for protos::union::ibc::lightclients::ethereum::v1::SyncCommittee {
     const TYPE_URL: &'static str = "/union.ibc.lightclients.ethereum.v1.SyncCommittee";
 }
 
-impl<C: SYNC_COMMITTEE_SIZE> TryFromProto for SyncCommittee<C> {
-    type Proto = protos::union::ibc::lightclients::ethereum::v1::SyncCommittee;
-}
-
-impl<C: SYNC_COMMITTEE_SIZE> IntoProto for SyncCommittee<C> {
+impl<C: SYNC_COMMITTEE_SIZE> Proto for SyncCommittee<C> {
     type Proto = protos::union::ibc::lightclients::ethereum::v1::SyncCommittee;
 }

--- a/lib/unionlabs/src/ibc/lightclients/ethereum/trusted_sync_committee.rs
+++ b/lib/unionlabs/src/ibc/lightclients/ethereum/trusted_sync_committee.rs
@@ -6,7 +6,7 @@ use crate::{
     errors::MissingField,
     ethereum_consts_traits::SYNC_COMMITTEE_SIZE,
     ibc::{core::client::height::Height, lightclients::ethereum::sync_committee::SyncCommittee},
-    IntoProto, TryFromProto, TryFromProtoErrorOf, TypeUrl,
+    Proto, TryFromProtoErrorOf, TypeUrl,
 };
 
 #[derive(Clone, Debug, PartialEq, Encode, Decode, TreeHash, Serialize, Deserialize)]
@@ -67,10 +67,6 @@ impl TypeUrl for protos::union::ibc::lightclients::ethereum::v1::TrustedSyncComm
     const TYPE_URL: &'static str = "/union.ibc.lightclients.ethereum.v1.TrustedSyncCommittee";
 }
 
-impl<C: SYNC_COMMITTEE_SIZE> TryFromProto for TrustedSyncCommittee<C> {
-    type Proto = protos::union::ibc::lightclients::ethereum::v1::TrustedSyncCommittee;
-}
-
-impl<C: SYNC_COMMITTEE_SIZE> IntoProto for TrustedSyncCommittee<C> {
+impl<C: SYNC_COMMITTEE_SIZE> Proto for TrustedSyncCommittee<C> {
     type Proto = protos::union::ibc::lightclients::ethereum::v1::TrustedSyncCommittee;
 }

--- a/lib/unionlabs/src/ibc/lightclients/wasm/client_state.rs
+++ b/lib/unionlabs/src/ibc/lightclients/wasm/client_state.rs
@@ -1,11 +1,10 @@
 use std::fmt::Debug;
 
-use prost::Message;
 use serde::{Deserialize, Serialize};
 
 use crate::{
-    errors::InvalidLength, ethereum::H256, ibc::core::client::height::Height, IntoProto,
-    TryFromProto, TryFromProtoErrorOf, TypeUrl,
+    errors::InvalidLength, ethereum::H256, ibc::core::client::height::Height, IntoProto, Proto,
+    TryFromProto, TryFromProtoBytesError, TryFromProtoErrorOf, TypeUrl,
 };
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -14,12 +13,6 @@ pub struct ClientState<Data> {
     pub code_id: H256,
     pub latest_height: Height,
 }
-
-// impl<Data> crate::chain::ClientState for ClientState<Data> {
-//     fn height(&self) -> Height {
-//         self.latest_height
-//     }
-// }
 
 impl TypeUrl for protos::ibc::lightclients::wasm::v1::ClientState {
     const TYPE_URL: &'static str = "/ibc.lightclients.wasm.v1.ClientState";
@@ -31,14 +24,14 @@ where
 {
     fn from(val: ClientState<Data>) -> Self {
         Self {
-            data: val.data.into_proto().encode_to_vec(),
+            data: val.data.into_proto_bytes(),
             code_id: val.code_id.into_bytes(),
             latest_height: Some(val.latest_height.into()),
         }
     }
 }
 
-impl<Data: IntoProto> IntoProto for ClientState<Data> {
+impl<Data: Proto> Proto for ClientState<Data> {
     type Proto = protos::ibc::lightclients::wasm::v1::ClientState;
 }
 
@@ -52,21 +45,17 @@ pub enum TryFromWasmClientStateError<Err> {
 impl<Data> TryFrom<protos::ibc::lightclients::wasm::v1::ClientState> for ClientState<Data>
 where
     Data: TryFromProto,
-    <Data as TryFromProto>::Proto: prost::Message + Default,
+    <Data as Proto>::Proto: prost::Message + Default,
     TryFromProtoErrorOf<Data>: Debug,
 {
-    type Error =
-        TryFromWasmClientStateError<<Data as TryFrom<<Data as TryFromProto>::Proto>>::Error>;
+    type Error = TryFromWasmClientStateError<TryFromProtoBytesError<TryFromProtoErrorOf<Data>>>;
 
     fn try_from(
         value: protos::ibc::lightclients::wasm::v1::ClientState,
     ) -> Result<Self, Self::Error> {
         Ok(Self {
-            data: Data::try_from_proto(
-                <Data as TryFromProto>::Proto::decode(&*value.data)
-                    .map_err(TryFromWasmClientStateError::Prost)?,
-            )
-            .map_err(TryFromWasmClientStateError::TryFromProto)?,
+            data: Data::try_from_proto_bytes(&value.data)
+                .map_err(TryFromWasmClientStateError::TryFromProto)?,
             code_id: value
                 .code_id
                 .try_into()
@@ -74,15 +63,4 @@ where
             latest_height: value.latest_height.unwrap().into(),
         })
     }
-}
-
-// , ibc::lightclients::wasm::client_state::ClientState<Data>: std::convert::TryFrom<protos::ibc::lightclients::wasm::v1::ClientState>
-
-impl<Data> TryFromProto for ClientState<Data>
-where
-    Data: TryFromProto,
-    <Data as TryFromProto>::Proto: prost::Message + Default,
-    TryFromProtoErrorOf<Data>: Debug,
-{
-    type Proto = protos::ibc::lightclients::wasm::v1::ClientState;
 }

--- a/lib/unionlabs/src/ibc/lightclients/wasm/header.rs
+++ b/lib/unionlabs/src/ibc/lightclients/wasm/header.rs
@@ -1,10 +1,9 @@
-use prost::Message;
 use serde::{Deserialize, Serialize};
 
 use crate::{
     errors::{required, MissingField},
     ibc::core::client::height::Height,
-    IntoProto, TryFromProto, TryFromProtoBytesError, TryFromProtoErrorOf, TypeUrl,
+    IntoProto, Proto, TryFromProto, TryFromProtoBytesError, TryFromProtoErrorOf, TypeUrl,
 };
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -13,14 +12,14 @@ pub struct Header<Data> {
     pub height: Height,
 }
 
-impl<Data: IntoProto> IntoProto for Header<Data> {
+impl<Data: Proto> Proto for Header<Data> {
     type Proto = protos::ibc::lightclients::wasm::v1::Header;
 }
 
 impl<Data: IntoProto> From<Header<Data>> for protos::ibc::lightclients::wasm::v1::Header {
     fn from(value: Header<Data>) -> Self {
         Self {
-            data: value.data.into_proto().encode_to_vec(),
+            data: value.data.into_proto_bytes(),
             height: Some(value.height.into()),
         }
     }
@@ -45,8 +44,4 @@ impl<Data: TryFromProto> TryFrom<protos::ibc::lightclients::wasm::v1::Header> fo
             height: required!(value.height, TryFromHeaderError)?.into(),
         })
     }
-}
-
-impl<Data: TryFromProto> TryFromProto for Header<Data> {
-    type Proto = protos::ibc::lightclients::wasm::v1::Header;
 }

--- a/lib/unionlabs/src/tendermint/types/block_id.rs
+++ b/lib/unionlabs/src/tendermint/types/block_id.rs
@@ -2,7 +2,7 @@ use crate::{
     errors::{InvalidLength, MissingField},
     ethereum::H256,
     tendermint::types::part_set_header::PartSetHeader,
-    IntoProto, TryFromProto, TryFromProtoErrorOf, TypeUrl,
+    Proto, TryFromProtoErrorOf, TypeUrl,
 };
 
 #[derive(Debug, Clone, PartialEq)]
@@ -35,10 +35,6 @@ impl TryFrom<protos::tendermint::types::BlockId> for BlockId {
     }
 }
 
-impl TryFromProto for BlockId {
-    type Proto = protos::tendermint::types::BlockId;
-}
-
 impl From<BlockId> for protos::tendermint::types::BlockId {
     fn from(value: BlockId) -> Self {
         Self {
@@ -48,7 +44,7 @@ impl From<BlockId> for protos::tendermint::types::BlockId {
     }
 }
 
-impl IntoProto for BlockId {
+impl Proto for BlockId {
     type Proto = protos::tendermint::types::BlockId;
 }
 

--- a/lib/unionlabs/src/tendermint/types/header.rs
+++ b/lib/unionlabs/src/tendermint/types/header.rs
@@ -5,7 +5,7 @@ use crate::{
     ethereum::{Address, H256},
     ibc::google::protobuf::timestamp::Timestamp,
     tendermint::{types::block_id::BlockId, version::consensus::Consensus},
-    IntoProto, TryFromProto, TryFromProtoErrorOf, TypeUrl,
+    Proto, TryFromProtoErrorOf, TypeUrl,
 };
 
 #[derive(Clone, PartialEq)]
@@ -135,11 +135,7 @@ impl TryFrom<protos::tendermint::types::Header> for Header {
     }
 }
 
-impl IntoProto for Header {
-    type Proto = protos::tendermint::types::Header;
-}
-
-impl TryFromProto for Header {
+impl Proto for Header {
     type Proto = protos::tendermint::types::Header;
 }
 

--- a/lib/unionlabs/src/tendermint/types/part_set_header.rs
+++ b/lib/unionlabs/src/tendermint/types/part_set_header.rs
@@ -1,4 +1,4 @@
-use crate::{errors::InvalidLength, ethereum::H256, IntoProto, TryFromProto, TypeUrl};
+use crate::{errors::InvalidLength, ethereum::H256, Proto, TypeUrl};
 
 #[derive(Debug, Clone, PartialEq)]
 pub struct PartSetHeader {
@@ -25,10 +25,6 @@ impl TryFrom<protos::tendermint::types::PartSetHeader> for PartSetHeader {
     }
 }
 
-impl TryFromProto for PartSetHeader {
-    type Proto = protos::tendermint::types::PartSetHeader;
-}
-
 impl From<PartSetHeader> for protos::tendermint::types::PartSetHeader {
     fn from(value: PartSetHeader) -> Self {
         Self {
@@ -38,7 +34,7 @@ impl From<PartSetHeader> for protos::tendermint::types::PartSetHeader {
     }
 }
 
-impl IntoProto for PartSetHeader {
+impl Proto for PartSetHeader {
     type Proto = protos::tendermint::types::PartSetHeader;
 }
 

--- a/lib/unionlabs/src/tendermint/version/consensus.rs
+++ b/lib/unionlabs/src/tendermint/version/consensus.rs
@@ -1,4 +1,4 @@
-use crate::{FromProto, IntoProto, TypeUrl};
+use crate::{Proto, TypeUrl};
 
 #[derive(Clone, PartialEq)]
 pub struct Consensus {
@@ -24,11 +24,7 @@ impl From<Consensus> for protos::tendermint::version::Consensus {
     }
 }
 
-impl FromProto for Consensus {
-    type Proto = protos::tendermint::version::Consensus;
-}
-
-impl IntoProto for Consensus {
+impl Proto for Consensus {
     type Proto = protos::tendermint::version::Consensus;
 }
 


### PR DESCRIPTION
`{From,TryFrom,Into}Proto` no longer each define an associated type `Proto`, instead there is a supertrait `Proto` and the aformentioned traits are now a bounds alias/ convenience over `T: Proto + {From,TryFrom,Into}<T::Proto>`.

closes #420 (nice :sunglasses:)