### PR TITLE
feat(relayer): add command to query ibc paths

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -36,3 +36,5 @@ pk.bin
 
 out
 .vscode
+
+dump

--- a/lib/unionlabs/src/ibc/core/channel/channel.rs
+++ b/lib/unionlabs/src/ibc/core/channel/channel.rs
@@ -1,10 +1,12 @@
+use serde::Serialize;
+
 use crate::{
     errors::MissingField,
     ibc::core::channel::{counterparty::Counterparty, order::Order, state::State},
     Proto, TypeUrl,
 };
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Serialize)]
 pub struct Channel {
     pub state: State,
     pub ordering: Order,

--- a/lib/unionlabs/src/ibc/core/channel/counterparty.rs
+++ b/lib/unionlabs/src/ibc/core/channel/counterparty.rs
@@ -1,4 +1,6 @@
-#[derive(Debug, Clone)]
+use serde::Serialize;
+
+#[derive(Debug, Clone, Serialize)]
 pub struct Counterparty {
     pub port_id: String,
     pub channel_id: String,

--- a/lib/unionlabs/src/ibc/core/channel/order.rs
+++ b/lib/unionlabs/src/ibc/core/channel/order.rs
@@ -1,6 +1,8 @@
+use serde::Serialize;
+
 use crate::errors::UnknownEnumVariant;
 
-#[derive(Debug, PartialEq, Eq, Hash, Clone, Copy)]
+#[derive(Debug, PartialEq, Eq, Hash, Clone, Copy, Serialize)]
 pub enum Order {
     Unspecified,
     Unordered,

--- a/lib/unionlabs/src/ibc/core/channel/state.rs
+++ b/lib/unionlabs/src/ibc/core/channel/state.rs
@@ -1,6 +1,8 @@
+use serde::Serialize;
+
 use crate::errors::UnknownEnumVariant;
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Serialize)]
 pub enum State {
     UninitializedUnspecified,
     Init,

--- a/lib/unionlabs/src/ibc/core/commitment/merkle_prefix.rs
+++ b/lib/unionlabs/src/ibc/core/commitment/merkle_prefix.rs
@@ -1,7 +1,8 @@
 #[cfg(feature = "ethabi")]
 use contracts::ibc_handler::IbcCoreCommitmentV1MerklePrefixData;
+use serde::Serialize;
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Serialize)]
 pub struct MerklePrefix {
     pub key_prefix: Vec<u8>,
 }

--- a/lib/unionlabs/src/ibc/core/commitment/merkle_root.rs
+++ b/lib/unionlabs/src/ibc/core/commitment/merkle_root.rs
@@ -1,8 +1,10 @@
 #[cfg(feature = "ethabi")]
 use contracts::glue::IbcCoreCommitmentV1MerkleRootData;
+use serde::Serialize;
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Serialize)]
 pub struct MerkleRoot {
+    // REVIEW: Should this be H256?
     pub hash: Vec<u8>,
 }
 

--- a/lib/unionlabs/src/ibc/core/connection/connection_end.rs
+++ b/lib/unionlabs/src/ibc/core/connection/connection_end.rs
@@ -1,10 +1,12 @@
+use serde::Serialize;
+
 use crate::{
     errors::{MissingField, UnknownEnumVariant},
     ibc::core::connection::{counterparty::Counterparty, state::State, version::Version},
     Proto, TypeUrl,
 };
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Serialize)]
 pub struct ConnectionEnd {
     pub client_id: String,
     pub versions: Vec<Version>,

--- a/lib/unionlabs/src/ibc/core/connection/counterparty.rs
+++ b/lib/unionlabs/src/ibc/core/connection/counterparty.rs
@@ -1,6 +1,8 @@
+use serde::Serialize;
+
 use crate::{errors::MissingField, ibc::core::commitment::merkle_prefix::MerklePrefix};
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Serialize)]
 pub struct Counterparty {
     pub client_id: String,
     pub connection_id: String,

--- a/lib/unionlabs/src/ibc/core/connection/state.rs
+++ b/lib/unionlabs/src/ibc/core/connection/state.rs
@@ -1,6 +1,8 @@
+use serde::Serialize;
+
 use crate::errors::UnknownEnumVariant;
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Serialize)]
 pub enum State {
     /// Default State
     UninitializedUnspecified = 0,

--- a/lib/unionlabs/src/ibc/core/connection/version.rs
+++ b/lib/unionlabs/src/ibc/core/connection/version.rs
@@ -1,6 +1,8 @@
+use serde::Serialize;
+
 use crate::{errors::UnknownEnumVariant, ibc::core::channel::order::Order};
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Serialize)]
 pub struct Version {
     // TODO(benluelo): "The identifier field specifies a unique version identifier. A value of "1" specifies IBC 1.0.0."
     pub identifier: String,

--- a/lib/unionlabs/src/ibc/lightclients/cometbls/consensus_state.rs
+++ b/lib/unionlabs/src/ibc/lightclients/cometbls/consensus_state.rs
@@ -1,6 +1,8 @@
+use serde::Serialize;
+
 use crate::{errors::MissingField, ibc::core::commitment::merkle_root::MerkleRoot, Proto, TypeUrl};
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Serialize)]
 pub struct ConsensusState {
     pub root: MerkleRoot,
     pub next_validators_hash: Vec<u8>,

--- a/relayer-config.json
+++ b/relayer-config.json
@@ -20,7 +20,9 @@
         "raw": "0xaa820fa947beb242032a41b6dc9a8b9c37d8f5fbcda0966b1ec80335b10a7d6f"
       },
       "ws_url": "ws://127.0.0.1:26657/websocket",
-      "wasm_code_id": "0x44ab11c49e3aa40301679bff45818117158d6cc8c326a5bafa69089709c3d13e"
+      "wasm_code_id": "0x44ab11c49e3aa40301679bff45818117158d6cc8c326a5bafa69089709c3d13e",
+      "prover_endpoint": "http://localhost:8080",
+      "dump_path": "dump"
     }
   }
 }


### PR DESCRIPTION
```txt
Usage: relayer ibc query --on <ON> path [OPTIONS] <COMMAND>

Commands:
  client-state            
  client-consensus-state  
  connection              
  channel-end             
  commitment              
  help                    Print this message or the help of the given subcommand(s)
```

```sh
# latest block
relayer ibc query --on union-devnet --at latest path client-state 08-wasm-1
# specific block
relayer ibc query --on union-devnet --at 1-6602 path client-state 08-wasm-1
# latest block is the default
relayer ibc query --on union-devnet path client-state 08-wasm-1
```