### PR TITLE
fix(ci): add checkout before running e2e

### DIFF
--- a/.github/workflows/e2e-command.yml
+++ b/.github/workflows/e2e-command.yml
@@ -14,6 +14,10 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
+      - uses: actions/checkout@v3
+        with:   
+          fetch-depth: 0
+          
       - name: Run nightly workflow
         uses: ./.github/workflows/nightly.yml
 


### PR DESCRIPTION
 The e2e flow attempts to reference a local yaml file, which is only possible after checkout