### PR TITLE
ci: cleaned up jq filter

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -57,9 +57,9 @@ jobs:
             (
               [.attr] | inside(
                 [
-                  "evm-contracts"
-                  "devnet"
-                  "devnet-cosmos"
+                  "evm-contracts",
+                  "devnet",
+                  "devnet-cosmos",
                   "devnet-evm"
                 ]
               )


### PR DESCRIPTION
Should not modify the result of our current build filter. That will come when doing #546. This only makes it easier to read/edit the build filter. 