### PR TITLE
docs: update galois architecture docs

### DIFF
--- a/dictionary.txt
+++ b/dictionary.txt
@@ -188,6 +188,7 @@ ctypes
 dasel
 dataconnector
 datadir
+datagram
 datetime
 delegators
 dels

--- a/docs/docs/02_architecture/galois.md
+++ b/docs/docs/02_architecture/galois.md
@@ -22,7 +22,7 @@ Transactions through Union to other layers are composed of three steps:
 sequenceDiagram
     Union->>+Voyager: Emits IBC datagram at block N
     Voyager->>+Galois: Proof Request for block M..N+1
-    Galois-->>-Voyager: Sends Generated Proofs for blocks 
+    Galois-->>-Voyager: Sends Generated Proofs for blocks
     Voyager->>-Counterparty: Updates counterparty with Union state
 ```
 


### PR DESCRIPTION
- Updates the architecture diagram explaining a message from Union to a Counterparty.
- Moves proof caching to future work

## Old Diagram
```mermaid
sequenceDiagram
    Union->>Galois: Generate a zkp of Union consensus
    Galois->>Voyager: Forward zkp for to HA relaying service
    Galois->>Union: Submit zkp for proof caching
    Voyager->>Counterparty: Submit zkp for packet processing
```

## New Diagram 
```mermaid
sequenceDiagram
    Union->>+Voyager: Emits IBC datagram at block N
    Voyager->>+Galois: Proof Request for block M..N+1
    Galois-->>-Voyager: Sends Generated Proofs for blocks
    Voyager->>-Counterparty: Updates counterparty with Union state
```

