### PR TITLE
[Tracking PR] disallow IFD

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -55,10 +55,6 @@ jobs:
               # Do not run on both systems
               [.attr] | inside(
                 [
-                  "uniond-release",
-                  "devnet",
-                  "devnet-union",
-                  "devnet-eth",
                   "docgen",
                   "download-circuit",
                   "evm",
@@ -95,9 +91,6 @@ jobs:
             (
               [.attr] | inside(
                 [
-                  "devnet",
-                  "devnet-union",
-                  "devnet-eth",
                   "evm",
                   "evm-contracts"
                 ]


### PR DESCRIPTION
For the unfamiliar, [this is how import from derivation works](https://nixos.org/manual/nix/unstable/language/import-from-derivation).

The checks for this PR is an experiment to see how many of our packages can be built without IFD. IFD is the source of most of the issues we've been experiencing with nixbuild.net, and also yield suboptimal cashing. 

Getting rid of it altogether would be nice, but we're not sure yet how feasible that is

This PR will continuously be rebased to get an overview of the current status of our IFD usage

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated CI/CD pipeline configuration for dependency commits and conditional checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->