### PR TITLE
feat(voyager): split the LightClient trait into two

### DIFF
--- a/voyager/src/main.rs
+++ b/voyager/src/main.rs
@@ -1,6 +1,6 @@
 #![recursion_limit = "256"]
 // *almost* stable, more than safe enough to use imo https://github.com/rust-lang/rfcs/pull/3425
-#![feature(return_position_impl_trait_in_trait)]
+#![feature(return_position_impl_trait_in_trait, trait_alias)]
 // #![warn(clippy::pedantic)]
 #![allow(
      // required due to return_position_impl_trait_in_trait false positives

--- a/voyager/src/msg.rs
+++ b/voyager/src/msg.rs
@@ -17,7 +17,7 @@ use crate::{
         evm::{CometblsMainnet, CometblsMinimal},
         proof::StateProof,
         union::{EthereumMainnet, EthereumMinimal},
-        LightClient,
+        LightClient, LightClientBase,
     },
     msg::{
         aggregate::AnyAggregate,
@@ -37,12 +37,12 @@ pub mod msg;
 pub mod wait;
 
 pub type ChainIdOf<L> =
-    <<<L as LightClient>::HostChain as Chain>::SelfClientState as ClientState>::ChainId;
+    <<<L as LightClientBase>::HostChain as Chain>::SelfClientState as ClientState>::ChainId;
 
 pub type StateProofOf<T, L> = StateProof<
     <T as IbcPath<
-        <L as LightClient>::HostChain,
-        <<L as LightClient>::Counterparty as LightClient>::HostChain,
+        <L as LightClientBase>::HostChain,
+        <<L as LightClientBase>::Counterparty as LightClientBase>::HostChain,
     >>::Output,
 >;
 
@@ -389,7 +389,7 @@ pub mod aggregate {
 
     use super::ChainIdOf;
     use crate::{
-        chain::{ChainOf, HeightOf, LightClient},
+        chain::{ChainOf, HeightOf, LightClient, LightClientBase},
         msg::fetch::FetchStateProof,
     };
 
@@ -504,21 +504,21 @@ pub mod aggregate {
     #[serde(bound(serialize = "", deserialize = ""))]
     pub struct AggregateConnectionOpenTry<L: LightClient> {
         pub event_height: HeightOf<L::HostChain>,
-        pub event: ConnectionOpenInit<L::ClientId, <L::Counterparty as LightClient>::ClientId>,
+        pub event: ConnectionOpenInit<L::ClientId, <L::Counterparty as LightClientBase>::ClientId>,
     }
 
     #[derive(DebugNoBound, CloneNoBound, PartialEqNoBound, Serialize, Deserialize)]
     #[serde(bound(serialize = "", deserialize = ""))]
     pub struct AggregateConnectionOpenAck<L: LightClient> {
         pub event_height: HeightOf<L::HostChain>,
-        pub event: ConnectionOpenTry<L::ClientId, <L::Counterparty as LightClient>::ClientId>,
+        pub event: ConnectionOpenTry<L::ClientId, <L::Counterparty as LightClientBase>::ClientId>,
     }
 
     #[derive(DebugNoBound, CloneNoBound, PartialEqNoBound, Serialize, Deserialize)]
     #[serde(bound(serialize = "", deserialize = ""))]
     pub struct AggregateConnectionOpenConfirm<L: LightClient> {
         pub event_height: HeightOf<L::HostChain>,
-        pub event: ConnectionOpenAck<L::ClientId, <L::Counterparty as LightClient>::ClientId>,
+        pub event: ConnectionOpenAck<L::ClientId, <L::Counterparty as LightClientBase>::ClientId>,
     }
 
     #[derive(DebugNoBound, CloneNoBound, PartialEqNoBound, Serialize, Deserialize)]
@@ -556,7 +556,7 @@ pub mod aggregate {
         pub event: RecvPacket,
         // HACK: Need to pass the block hash through, figure out a better/cleaner way to do this
         pub block_hash: H256,
-        pub counterparty_client_id: <L::Counterparty as LightClient>::ClientId,
+        pub counterparty_client_id: <L::Counterparty as LightClientBase>::ClientId,
     }
 
     #[derive(DebugNoBound, CloneNoBound, PartialEqNoBound, Serialize, Deserialize)]
@@ -602,7 +602,7 @@ pub mod aggregate {
     #[derive(DebugNoBound, CloneNoBound, PartialEqNoBound, Serialize, Deserialize)]
     #[serde(bound(serialize = "", deserialize = ""))]
     pub struct AggregateFetchCounterpartyStateProof<L: LightClient> {
-        pub counterparty_client_id: <L::Counterparty as LightClient>::ClientId,
+        pub counterparty_client_id: <L::Counterparty as LightClientBase>::ClientId,
         pub fetch: FetchStateProof<L::Counterparty>,
     }
 
@@ -610,7 +610,7 @@ pub mod aggregate {
     #[serde(bound(serialize = "", deserialize = ""))]
     pub struct AggregateUpdateClientFromClientId<L: LightClient> {
         pub client_id: L::ClientId,
-        pub counterparty_client_id: <L::Counterparty as LightClient>::ClientId,
+        pub counterparty_client_id: <L::Counterparty as LightClientBase>::ClientId,
     }
 
     #[derive(DebugNoBound, CloneNoBound, PartialEqNoBound, Serialize, Deserialize)]
@@ -618,7 +618,7 @@ pub mod aggregate {
     pub struct AggregateUpdateClient<L: LightClient> {
         pub update_to: HeightOf<L::HostChain>,
         pub client_id: L::ClientId,
-        pub counterparty_client_id: <L::Counterparty as LightClient>::ClientId,
+        pub counterparty_client_id: <L::Counterparty as LightClientBase>::ClientId,
     }
 
     #[derive(DebugNoBound, CloneNoBound, PartialEqNoBound, Serialize, Deserialize)]
@@ -626,7 +626,7 @@ pub mod aggregate {
     pub struct AggregateWaitForTrustedHeight<L: LightClient> {
         pub wait_for: HeightOf<L::HostChain>,
         pub client_id: L::ClientId,
-        pub counterparty_client_id: <L::Counterparty as LightClient>::ClientId,
+        pub counterparty_client_id: <L::Counterparty as LightClientBase>::ClientId,
     }
 
     #[derive(DebugNoBound, CloneNoBound, PartialEqNoBound, Serialize, Deserialize)]
@@ -634,7 +634,7 @@ pub mod aggregate {
     pub struct AggregateUpdateClientWithCounterpartyChainId<L: LightClient> {
         pub update_to: HeightOf<L::HostChain>,
         pub client_id: L::ClientId,
-        pub counterparty_client_id: <L::Counterparty as LightClient>::ClientId,
+        pub counterparty_client_id: <L::Counterparty as LightClientBase>::ClientId,
         pub counterparty_chain_id: ChainIdOf<L::Counterparty>,
     }
 
@@ -643,7 +643,7 @@ pub mod aggregate {
     pub struct AggregateMsgUpdateClient<L: LightClient> {
         pub update_to: HeightOf<L::HostChain>,
         pub client_id: L::ClientId,
-        pub counterparty_client_id: <L::Counterparty as LightClient>::ClientId,
+        pub counterparty_client_id: <L::Counterparty as LightClientBase>::ClientId,
         pub counterparty_chain_id: ChainIdOf<L::Counterparty>,
     }
 
@@ -681,23 +681,6 @@ pub mod aggregate {
     }
 }
 
-// impl<L: LightClient, T> TryFrom<AggregateData> for Identified<L, T>
-// where
-//     T: TryFrom<Data<L>, Error = Data<L>> + Into<Data<L>> + Debug + Clone + PartialEq,
-//     identified!(Data<L>): TryFrom<AggregateData, Error = AggregateData> + Into<AggregateData>,
-// {
-//     type Error = AggregateData;
-
-//     fn try_from(value: AggregateData) -> Result<Self, Self::Error> {
-//         let Identified { chain_id, data } = <identified!(Data<L>)>::try_from(value)?;
-
-//         match T::try_from(data) {
-//             Ok(t) => Ok(Identified { chain_id, data: t }),
-//             Err(data) => Err(Identified { chain_id, data }.into()),
-//         }
-//     }
-// }
-
 pub trait AnyLightClient {
     type Inner<L: LightClient>: Debug
         + Display
@@ -726,84 +709,6 @@ pub enum AnyLightClientIdentified<T: AnyLightClient> {
     #[display(fmt = "CometblsMinimal({}, {})", "_0.chain_id", "_0.data")]
     CometblsMinimal(Identified<CometblsMinimal, InnerOf<T, CometblsMinimal>>),
 }
-
-// pub trait Map<T> {
-//     type This<S>;
-
-//     fn map<U>(this: Self::This<T>, f: impl FnOnce(T) -> U) -> Self::This<U>;
-// }
-
-// impl<T> Map<T> for Option<T> {
-//     type This<S> = Option<S>;
-
-//     fn map<U>(this: Self::This<T>, f: impl FnOnce(T) -> U) -> Self::This<U> {
-//         this.map(f)
-//     }
-// }
-
-// impl<T, E> Map<T> for Result<T, E> {
-//     type This<S> = Result<S, E>;
-
-//     fn map<U>(this: Self::This<T>, f: impl FnOnce(T) -> U) -> Self::This<U> {
-//         this.map(f)
-//     }
-// }
-
-// impl<T: AnyLightClient> AnyLightClientIdentified<T> {
-//     pub fn map<U, A>(self, a: A) -> A::Output<AnyLightClientIdentified<U>>
-//     where
-//         U: AnyLightClient,
-//         A: AnyLightClientMapper<T, U>,
-//     // <AnyLightClientMapper<T, U>>::Output<>
-//         <A as AnyLightClientMapper<T, U>>::Output<
-//             Identified<EthereumMainnet, InnerOf<U, EthereumMainnet>>,
-//         >: Map<
-//             Identified<EthereumMainnet, InnerOf<U, EthereumMainnet>>,
-//             This<<A as AnyLightClientMapper<T, U>>::Output<
-//                 Identified<EthereumMainnet, InnerOf<U, EthereumMainnet>>,
-//             >> = <A as AnyLightClientMapper<T, U>>::Output<
-//                 Identified<EthereumMainnet, InnerOf<U, EthereumMainnet>>,
-//             >,
-//         >,
-//     {
-//         use AnyLightClientIdentified as AnyLc;
-
-//         let t = match self {
-//             AnyLc::EthereumMainnet(t) => {
-//                 let t: A::Output<AnyLc<U>> = <A::Output<Identified<_, _>> as Map<_>>::map::<AnyLc<U>>(a.map(t), |x| AnyLc::EthereumMainnet(x));
-//             }
-//             AnyLc::EthereumMinimal(t) => {
-//                 <A::Output<Identified<_, _>> as Map<_>>::map::<AnyLc<U>>(a.map(t), |x| AnyLc::EthereumMinimal(x))
-//             }
-//             AnyLc::CometblsMainnet(t) => {
-//                 <A::Output<Identified<_, _>> as Map<_>>::map::<AnyLc<U>>(a.map(t), |x| AnyLc::CometblsMainnet(x))
-//             }
-//             AnyLc::CometblsMinimal(t) => {
-//                 <A::Output<Identified<_, _>> as Map<_>>::map::<AnyLc<U>>(a.map(t), |x| AnyLc::CometblsMinimal(x))
-//             }
-//             // EthereumMainnet(t) => a.map(t),
-//             // EthereumMinimal(t) => a.map(t),
-//             // CometblsMainnet(t) => a.map(t),
-//             // CometblsMinimal(t) => a.map(t),
-//         };
-
-//         todo!()
-//     }
-// }
-
-// trait AnyLightClientMapper<T: AnyLightClient, U: AnyLightClient> {
-//     type Output<O>: Map<O, This<O> = Self::Output<O>>;
-
-//     fn map<L: LightClient>(
-//         self,
-//         t: Identified<L, InnerOf<T, L>>,
-//     ) -> Self::Output<Identified<L, InnerOf<U, L>>>;
-
-//     // fn map2(
-//     //     self,
-//     //     t: Identified<impl LightClient, InnerOf<T, impl LightClient>>,
-//     // ) -> Self::Output<Identified<impl LightClient, InnerOf<U, impl LightClient>>>;
-// }
 
 impl<T: AnyLightClient> From<Identified<EthereumMainnet, InnerOf<T, EthereumMainnet>>>
     for AnyLightClientIdentified<T>

--- a/voyager/src/msg/data.rs
+++ b/voyager/src/msg/data.rs
@@ -13,7 +13,9 @@ use unionlabs::{
 };
 
 use crate::{
-    chain::{ChainOf, ClientStateOf, ConsensusStateOf, HeaderOf, HeightOf, LightClient},
+    chain::{
+        ChainOf, ClientStateOf, ConsensusStateOf, HeaderOf, HeightOf, LightClient, LightClientBase,
+    },
     msg::{
         any_enum, fetch::FetchPacketAcknowledgement, identified, AnyLightClientIdentified,
         StateProofOf,
@@ -122,7 +124,7 @@ pub struct ChannelEnd<L: LightClient> {
 pub struct ConnectionEnd<L: LightClient>(
     pub  unionlabs::ibc::core::connection::connection_end::ConnectionEnd<
         L::ClientId,
-        <L::Counterparty as LightClient>::ClientId,
+        <L::Counterparty as LightClientBase>::ClientId,
         // NOTE: String used here since it may be empty; figure out a way to more strongly type this
         String,
     >,
@@ -140,7 +142,7 @@ pub struct PacketAcknowledgement<L: LightClient> {
 pub struct TrustedClientState<L: LightClient> {
     pub fetched_at: HeightOf<ChainOf<L>>,
     pub client_id: L::ClientId,
-    pub trusted_client_state: ClientStateOf<<L::Counterparty as LightClient>::HostChain>,
+    pub trusted_client_state: ClientStateOf<<L::Counterparty as LightClientBase>::HostChain>,
 }
 
 #[derive(DebugNoBound, CloneNoBound, PartialEqNoBound, Serialize, Deserialize)]

--- a/voyager/src/msg/event.rs
+++ b/voyager/src/msg/event.rs
@@ -5,7 +5,7 @@ use serde::{Deserialize, Serialize};
 use unionlabs::ethereum::H256;
 
 use crate::{
-    chain::{ChainOf, HeightOf, LightClient},
+    chain::{ChainOf, HeightOf, LightClient, LightClientBase},
     msg::any_enum,
 };
 
@@ -34,7 +34,7 @@ pub struct IbcEvent<L: LightClient> {
     pub event: unionlabs::events::IbcEvent<
         L::ClientId,
         L::ClientType,
-        <L::Counterparty as LightClient>::ClientId,
+        <L::Counterparty as LightClientBase>::ClientId,
     >,
 }
 
@@ -73,6 +73,6 @@ pub enum Command<L: LightClient> {
     #[display(fmt = "UpdateClient({client_id}, {counterparty_client_id})")]
     UpdateClient {
         client_id: L::ClientId,
-        counterparty_client_id: <L::Counterparty as LightClient>::ClientId,
+        counterparty_client_id: <L::Counterparty as LightClientBase>::ClientId,
     },
 }

--- a/voyager/src/msg/fetch.rs
+++ b/voyager/src/msg/fetch.rs
@@ -10,7 +10,7 @@ use unionlabs::{
 };
 
 use crate::{
-    chain::{ChainOf, HeightOf, LightClient, QueryHeight},
+    chain::{ChainOf, HeightOf, LightClient, LightClientBase, QueryHeight},
     msg::{any_enum, ChainIdOf},
 };
 
@@ -73,7 +73,7 @@ pub struct FetchTrustedClientState<L: LightClient> {
 #[serde(bound(serialize = "", deserialize = ""))]
 pub struct FetchCounterpartyTrustedClientState<L: LightClient> {
     pub at: QueryHeight<HeightOf<ChainOf<L::Counterparty>>>,
-    pub client_id: <L::Counterparty as LightClient>::ClientId,
+    pub client_id: <L::Counterparty as LightClientBase>::ClientId,
 }
 
 #[derive(DebugNoBound, CloneNoBound, PartialEqNoBound, Serialize, Deserialize)]
@@ -130,7 +130,7 @@ pub struct FetchUpdateHeaders<L: LightClient> {
     pub client_id: L::ClientId,
     pub counterparty_chain_id: ChainIdOf<L::Counterparty>,
     // id of the counterparty client that will be updated with the fetched headers
-    pub counterparty_client_id: <L::Counterparty as LightClient>::ClientId,
+    pub counterparty_client_id: <L::Counterparty as LightClientBase>::ClientId,
     pub update_from: HeightOf<L::HostChain>,
     pub update_to: HeightOf<L::HostChain>,
 }

--- a/voyager/src/msg/msg.rs
+++ b/voyager/src/msg/msg.rs
@@ -18,7 +18,9 @@ use unionlabs::ibc::core::{
 };
 
 use crate::{
-    chain::{ChainOf, ClientStateOf, ConsensusStateOf, HeaderOf, HeightOf, LightClient},
+    chain::{
+        ChainOf, ClientStateOf, ConsensusStateOf, HeaderOf, HeightOf, LightClient, LightClientBase,
+    },
     msg::any_enum,
 };
 
@@ -66,7 +68,7 @@ impl<L: LightClient> Display for Msg<L> {
 #[derive(DebugNoBound, CloneNoBound, PartialEqNoBound, Serialize, Deserialize)]
 #[serde(bound(serialize = "", deserialize = ""))]
 pub struct MsgConnectionOpenInitData<L: LightClient> {
-    pub msg: MsgConnectionOpenInit<L::ClientId, <L::Counterparty as LightClient>::ClientId>,
+    pub msg: MsgConnectionOpenInit<L::ClientId, <L::Counterparty as LightClientBase>::ClientId>,
 }
 
 #[derive(DebugNoBound, CloneNoBound, PartialEqNoBound, Serialize, Deserialize)]
@@ -75,7 +77,7 @@ pub struct MsgConnectionOpenTryData<L: LightClient> {
     pub msg: MsgConnectionOpenTry<
         ClientStateOf<L::HostChain>,
         L::ClientId,
-        <L::Counterparty as LightClient>::ClientId,
+        <L::Counterparty as LightClientBase>::ClientId,
         HeightOf<ChainOf<L::Counterparty>>,
         HeightOf<ChainOf<L>>,
     >,
@@ -154,6 +156,7 @@ pub struct MsgCreateClientData<L: LightClient> {
 #[derive(DebugNoBound, CloneNoBound, PartialEqNoBound, Serialize, Deserialize)]
 #[serde(bound(serialize = "", deserialize = ""))]
 pub struct MsgUpdateClientData<L: LightClient> {
-    pub msg: MsgUpdateClient<L::ClientId, HeaderOf<<L::Counterparty as LightClient>::HostChain>>,
+    pub msg:
+        MsgUpdateClient<L::ClientId, HeaderOf<<L::Counterparty as LightClientBase>::HostChain>>,
     pub update_from: HeightOf<ChainOf<L::Counterparty>>,
 }

--- a/voyager/src/msg/wait.rs
+++ b/voyager/src/msg/wait.rs
@@ -4,7 +4,7 @@ use frame_support_procedural::{CloneNoBound, DebugNoBound, PartialEqNoBound};
 use serde::{Deserialize, Serialize};
 
 use crate::{
-    chain::{ChainOf, HeightOf, LightClient},
+    chain::{ChainOf, HeightOf, LightClient, LightClientBase},
     msg::{any_enum, ChainIdOf},
 };
 
@@ -44,7 +44,7 @@ pub struct WaitForTimestamp<L: LightClient> {
 #[serde(bound(serialize = "", deserialize = ""))]
 pub struct WaitForTrustedHeight<L: LightClient> {
     pub client_id: L::ClientId,
-    pub counterparty_client_id: <L::Counterparty as LightClient>::ClientId,
+    pub counterparty_client_id: <L::Counterparty as LightClientBase>::ClientId,
     pub counterparty_chain_id: ChainIdOf<L::Counterparty>,
     pub height: HeightOf<ChainOf<L::Counterparty>>,
 }


### PR DESCRIPTION
splits out the types and methods related to the queue into a new trait