### PR TITLE
fix(e2e): remove upgrade from upgrade from genesis as there are none

### DIFF
--- a/e2e/upgrades.nix
+++ b/e2e/upgrades.nix
@@ -1,27 +1,27 @@
-{ e2e, pkgs, unionvisor, bundle, ... }:
+{ e2e, pkgs, bundle, ... }:
 let
-  unionvisorBin = pkgs.lib.meta.getExe unionvisor;
+  # unionvisorBin = pkgs.lib.meta.getExe unionvisor;
 
-  mkUpgradeProposal = version: height: pkgs.runCommand "upgrade-proposal" { } ''
-    mkdir -p $out
-    echo '{
-     "messages": [
-      {
-       "@type": "/cosmos.upgrade.v1beta1.MsgSoftwareUpgrade",
-       "authority": "union10d07y265gmmuvt4z0w9aw880jnsr700js4jdcz",
-       "plan": {
-        "name": "${version}",
-        "height": "${toString height}",
-        "info": "${version}"
-       }
-      }
-     ],
-     "deposit": "15000000stake",
-     "title": "${version}",
-     "summary": "Upgrade to ${version}"
-    }' > proposal-${version}.json
-    mv proposal-${version}.json $out
-  '';
+  # mkUpgradeProposal = version: height: pkgs.runCommand "upgrade-proposal" { } ''
+  #   mkdir -p $out
+  #   echo '{
+  #    "messages": [
+  #     {
+  #      "@type": "/cosmos.upgrade.v1beta1.MsgSoftwareUpgrade",
+  #      "authority": "union10d07y265gmmuvt4z0w9aw880jnsr700js4jdcz",
+  #      "plan": {
+  #       "name": "${version}",
+  #       "height": "${toString height}",
+  #       "info": "${version}"
+  #      }
+  #     }
+  #    ],
+  #    "deposit": "15000000stake",
+  #    "title": "${version}",
+  #    "summary": "Upgrade to ${version}"
+  #   }' > proposal-${version}.json
+  #   mv proposal-${version}.json $out
+  # '';
 
   forEachNode = f: ''
     ${f "0"}
@@ -30,16 +30,16 @@ let
     ${f "3"}
   '';
 
-  upgradeTo = version: height: ''
-    union.succeed('docker cp ${mkUpgradeProposal version height}/proposal-${version}.json devnet-minimal-uniond-0-1:/proposal-${version}.json')
-    union.succeed('docker exec devnet-minimal-uniond-0-1 ${unionvisorBin} --root . call --bundle /bundle -- tx gov submit-proposal proposal-${version}.json --from val-0 --keyring-backend test --home ./home -y')
+  # upgradeTo = version: height: ''
+  #   union.succeed('docker cp ${mkUpgradeProposal version height}/proposal-${version}.json devnet-minimal-uniond-0-1:/proposal-${version}.json')
+  #   union.succeed('docker exec devnet-minimal-uniond-0-1 ${unionvisorBin} --root . call --bundle /bundle -- tx gov submit-proposal proposal-${version}.json --from val-0 --keyring-backend test --home ./home -y')
 
-    union.shell_interact()
+  #   union.shell_interact()
 
-    ${forEachNode (id: "union.succeed('docker exec devnet-minimal-uniond-${id}-1 ${unionvisorBin} --root . call --bundle /bundle -- tx gov vote 1 yes --keyring-backend test --from val-${id} --home ./home -y')")}
+  #   ${forEachNode (id: "union.succeed('docker exec devnet-minimal-uniond-${id}-1 ${unionvisorBin} --root . call --bundle /bundle -- tx gov vote 1 yes --keyring-backend test --from val-${id} --home ./home -y')")}
 
-    union.wait_until_succeeds('[[ $(curl "http://localhost:26660/block" --fail --silent | ${pkgs.lib.meta.getExe pkgs.jq} ".result.block.header.height | tonumber > ${toString height}") == "true" ]]')
-  '';
+  #   union.wait_until_succeeds('[[ $(curl "http://localhost:26660/block" --fail --silent | ${pkgs.lib.meta.getExe pkgs.jq} ".result.block.header.height | tonumber > ${toString height}") == "true" ]]')
+  # '';
 in
 {
   upgrade-from-genesis = e2e.mkTest {

--- a/flake.nix
+++ b/flake.nix
@@ -263,7 +263,7 @@
               doCheck = true;
               checkPhase = ''
                 cd $src/.
-                for i in `find . -name "*.nix" -type f ! -name "*upgrades.nix"`; do
+                for i in `find . -name "*.nix" -type f`; do
                     nil diagnostics "$i"
                 done
                 touch $out


### PR DESCRIPTION
Since removing the versions and bundles from `union-testnet-3`, we have no upgrades to apply to `union-testnet-4`.

Once we have upgrades for `union-testnet-4` to test, they can be appended to this test.