### PR TITLE
fix(e2e): add required ethers flags

### DIFF
--- a/e2e/ensure-blocks/Cargo.toml
+++ b/e2e/ensure-blocks/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2021"
 
 [dependencies]
 clap = { version = "4.3.12", features = ["derive"] }
-ethers = { workspace = true, features = ["ws"] }
+ethers = { workspace = true, features = ["ws", "providers"] }
 reqwest = "0.11.18"
 tendermint-rpc = {  workspace = true, features = ["http-client", "websocket-client"] }
 tokio = { version = "1.29.1", features = ["full"] }


### PR DESCRIPTION
After changes to our ethers fork, the `ethers::providers` module was feature gated. This adds the feature to ensure blocks s.t. it compiles.