### PR TITLE
docs: added NodeStake endpoints to docs

### DIFF
--- a/docs/docs/06_joining_the_testnet/05_public_endpoints.md
+++ b/docs/docs/06_joining_the_testnet/05_public_endpoints.md
@@ -8,13 +8,16 @@ These endpoints may be helpful while joining the network and ensuring the correc
 
 - union-testnet-grpc.polkachu.com:24690
 - grpc-union-testnet-01.stakeflow.io:17002
+- https://grpc-t.union.nodestake.top:443
 
 ### RPC
 
 - https://union-testnet-rpc.polkachu.com
 - https://rpc-union-testnet-01.stakeflow.io
+- https://rpc-t.union.nodestake.top
 
 ### REST API
 
 - https://union-testnet-api.polkachu.com
 - https://api-union-testnet-01.stakeflow.io
+- https://api-t.union.nodestake.top


### PR DESCRIPTION
https://nodestake.top/union
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Added new URLs for gRPC and REST API endpoints in the documentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->