### PR TITLE
docs(nix): add GitHub PAT warning to main README

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,7 @@ The official docs are hosted [here][docs]. Each individual component also has ac
 ## Contributing
 
 The [contributing](./CONTRIBUTING.md) guide explains how to get started working on Union and its components.
+Please make sure to [set up your GitHub PAT](<https://github.com/unionlabs/union/wiki/Personal-Access-Token-(PAT)-Setup>), otherwise Nix builds will fail.
 
 [docs]: https://docs.union.build "Official Union Docs"
 [IBC]: https://github.com/cosmos/ibc "cosmos/ibc"


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
	- Added note about setting up a GitHub Personal Access Token (PAT) in README.md.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->