### PR TITLE
feat: add cosmos::auth::BaseAccount to unionlabs

### DIFF
--- a/lib/unionlabs/src/cosmos.rs
+++ b/lib/unionlabs/src/cosmos.rs
@@ -1,3 +1,4 @@
+pub mod auth;
 pub mod base;
 pub mod crypto;
 pub mod ics23;

--- a/lib/unionlabs/src/cosmos/auth.rs
+++ b/lib/unionlabs/src/cosmos/auth.rs
@@ -1,0 +1,1 @@
+pub mod base_account;

--- a/lib/unionlabs/src/cosmos/auth/base_account.rs
+++ b/lib/unionlabs/src/cosmos/auth/base_account.rs
@@ -1,0 +1,56 @@
+use serde::{Deserialize, Serialize};
+
+use crate::{cosmos::crypto::AnyPubKey, errors::MissingField, Proto, TryFromProtoErrorOf, TypeUrl};
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct BaseAccount {
+    // REVIEW: is this a bech32 address?
+    pub address: String,
+    // accounts which haven't sent any transactions yet won't have a pubkey
+    // TODO: `sequence` will also be 0, find a way to validate this?
+    pub pub_key: Option<AnyPubKey>,
+    pub account_number: u64,
+    pub sequence: u64,
+}
+
+impl Proto for BaseAccount {
+    type Proto = protos::cosmos::auth::v1beta1::BaseAccount;
+}
+
+impl TypeUrl for protos::cosmos::auth::v1beta1::BaseAccount {
+    const TYPE_URL: &'static str = "/cosmos.auth.v1beta1.BaseAccount";
+}
+
+#[derive(Debug)]
+pub enum TryFromBaseAccountError {
+    MissingField(MissingField),
+    PubKey(TryFromProtoErrorOf<AnyPubKey>),
+}
+
+impl TryFrom<protos::cosmos::auth::v1beta1::BaseAccount> for BaseAccount {
+    type Error = TryFromBaseAccountError;
+
+    fn try_from(value: protos::cosmos::auth::v1beta1::BaseAccount) -> Result<Self, Self::Error> {
+        dbg!(&value);
+        Ok(Self {
+            address: value.address,
+            pub_key: value
+                .pub_key
+                .map(|pk| pk.try_into().map_err(TryFromBaseAccountError::PubKey))
+                .transpose()?,
+            account_number: value.account_number,
+            sequence: value.sequence,
+        })
+    }
+}
+
+impl From<BaseAccount> for protos::cosmos::auth::v1beta1::BaseAccount {
+    fn from(value: BaseAccount) -> Self {
+        Self {
+            address: value.address,
+            pub_key: value.pub_key.map(Into::into),
+            account_number: value.account_number,
+            sequence: value.sequence,
+        }
+    }
+}

--- a/lib/unionlabs/src/cosmos/crypto/secp256k1.rs
+++ b/lib/unionlabs/src/cosmos/crypto/secp256k1.rs
@@ -1,1 +1,44 @@
+use serde::{Deserialize, Serialize};
 
+use crate::{
+    errors::{ExpectedLength, InvalidLength},
+    Proto, TypeUrl,
+};
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct PubKey {
+    #[serde(with = "::serde_utils::base64")]
+    pub key: [u8; 33],
+}
+
+impl Proto for PubKey {
+    type Proto = protos::cosmos::crypto::secp256k1::PubKey;
+}
+
+impl TypeUrl for protos::cosmos::crypto::secp256k1::PubKey {
+    const TYPE_URL: &'static str = "/cosmos.crypto.secp256k1.PubKey";
+}
+
+impl TryFrom<protos::cosmos::crypto::secp256k1::PubKey> for PubKey {
+    type Error = InvalidLength;
+
+    fn try_from(value: protos::cosmos::crypto::secp256k1::PubKey) -> Result<Self, Self::Error> {
+        Ok(Self {
+            key: value
+                .key
+                .try_into()
+                .map_err(|invalid: Vec<u8>| InvalidLength {
+                    expected: ExpectedLength::Exact(32),
+                    found: invalid.len(),
+                })?,
+        })
+    }
+}
+
+impl From<PubKey> for protos::cosmos::crypto::secp256k1::PubKey {
+    fn from(value: PubKey) -> Self {
+        Self {
+            key: value.key.into(),
+        }
+    }
+}

--- a/lib/unionlabs/src/proof.rs
+++ b/lib/unionlabs/src/proof.rs
@@ -113,10 +113,7 @@ impl<ClientId: traits::Id> FromStr for ClientStatePath<ClientId> {
     }
 }
 
-impl<Hc: Chain, Tr: Chain> IbcPath<Hc, Tr> for ClientStatePath<Hc::ClientId>
-// where
-//     Tr::SelfClientState: Encode<Hc::IbcStateEncoding> + Decode<Hc::IbcStateEncoding>,
-{
+impl<Hc: Chain, Tr: Chain> IbcPath<Hc, Tr> for ClientStatePath<Hc::ClientId> {
     type Output = Hc::StoredClientState<Tr>;
 }
 
@@ -156,10 +153,7 @@ impl<ClientId: traits::Id, Height: IsHeight> FromStr
     }
 }
 
-impl<Hc: Chain, Tr: Chain> IbcPath<Hc, Tr> for ClientConsensusStatePath<Hc::ClientId, Tr::Height>
-// where
-//     Tr::SelfClientState: Encode<Hc::IbcStateEncoding> + Decode<Hc::IbcStateEncoding>,
-{
+impl<Hc: Chain, Tr: Chain> IbcPath<Hc, Tr> for ClientConsensusStatePath<Hc::ClientId, Tr::Height> {
     type Output = Hc::StoredConsensusState<Tr>;
 }
 

--- a/ucli/src/cli.rs
+++ b/ucli/src/cli.rs
@@ -68,6 +68,8 @@ pub enum EvmTx {
 pub enum QueryCmd {
     #[command(subcommand)]
     Evm(EvmQuery),
+    #[command(subcommand)]
+    Union(UnionQuery),
 }
 
 #[derive(Debug, Subcommand)]
@@ -86,6 +88,14 @@ pub enum EvmQuery {
         contract_address: H160,
         #[arg(long)]
         address: H160,
+    },
+}
+
+#[derive(Debug, Subcommand)]
+pub enum UnionQuery {
+    AccountInfo {
+        #[arg(long)]
+        address: String,
     },
 }
 

--- a/ucli/src/main.rs
+++ b/ucli/src/main.rs
@@ -1,5 +1,6 @@
 use std::{fs::read_to_string, sync::Arc};
 
+use chain_utils::union::{account_info, Union};
 use clap::Parser;
 use cli::Evm;
 use contracts::{
@@ -110,6 +111,24 @@ async fn main() {
                         .await
                     }
                 },
+            },
+            cli::QueryCmd::Union(union_query) => match union_query {
+                cli::UnionQuery::AccountInfo { address } => {
+                    let info = account_info(
+                        &Union::new(chain_utils::union::Config {
+                            signers: config.union.signers,
+                            fee_denom: config.union.fee_denom,
+                            ws_url: config.union.ws_url,
+                            prover_endpoint: config.union.prover_endpoint,
+                            grpc_url: config.union.grpc_url,
+                        })
+                        .await
+                        .unwrap(),
+                        &address,
+                    )
+                    .await;
+                    println!("{info:#?}");
+                }
             },
         },
     }

--- a/voyager/voyager-message/src/aggregate.rs
+++ b/voyager/voyager-message/src/aggregate.rs
@@ -2161,8 +2161,9 @@ impl<Hc: ChainExt, Tr: ChainExt> UseAggregate for identified!(AggregateAckPacket
 where
     Identified<Hc, Tr, IbcState<Hc, Tr, ClientStatePath<Hc::ClientId>>>: IsAggregateData,
     Identified<Hc, Tr, IbcProof<Hc, Tr, AcknowledgementPath>>: IsAggregateData,
+
     identified!(PacketAcknowledgement<Hc, Tr>): IsAggregateData,
-    Identified<Hc, Tr, IbcProof<Hc, Tr, AcknowledgementPath>>: IsAggregateData,
+
     AnyLightClientIdentified<AnyFetch>: From<identified!(Fetch<Tr, Hc>)>,
     AnyLightClientIdentified<AnyMsg>: From<identified!(Msg<Tr, Hc>)>,
 {

--- a/voyager/voyager-message/src/chain_impls/union.rs
+++ b/voyager/voyager-message/src/chain_impls/union.rs
@@ -89,31 +89,6 @@ impl ChainExt for Wasm<Union> {
     type MsgError = BroadcastTxCommitError;
 
     type Config = WasmConfig;
-
-    // fn encode_client_state_for_counterparty<Tr: ChainExt>(cs: Tr::SelfClientState) -> Vec<u8>
-    // where
-    //     Tr::SelfClientState: Encode<Self::IbcStateEncoding>,
-    // {
-    //     let bz = Any(wasm::client_state::ClientState {
-    //         latest_height: cs.height().into_height(),
-    //         data: cs,
-    //         code_id: H256::default(),
-    //     })
-    //     .encode();
-    //     dbg!(hex::encode(&bz));
-    //     bz
-    // }
-
-    // fn encode_consensus_state_for_counterparty<Tr: ChainExt>(cs: Tr::SelfConsensusState) -> Vec<u8>
-    // where
-    //     Tr::SelfConsensusState: Encode<Self::IbcStateEncoding>,
-    // {
-    //     Any(wasm::consensus_state::ConsensusState {
-    //         timestamp: cs.timestamp(),
-    //         data: cs,
-    //     })
-    //     .encode()
-    // }
 }
 
 impl<Tr: ChainExt, Hc: Wraps<Self>> DoMsg<Hc, Tr> for Union


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Refactor**
  - Restructured module `auth` in `lib/unionlabs/src/cosmos.rs`
  - Streamlined codebase in `voyager/voyager-message/src/lib.rs`

- **Interface Changes**
  - Added `TryFromBaseAccountError` enum in `lib/unionlabs/src/cosmos/auth/base_account.rs`
  - Implemented `TryFrom` trait for `BaseAccount` in `lib/unionlabs/src/cosmos/auth/base_account.rs`
  - Implemented `From` trait for `BaseAccount` in `lib/unionlabs/src/cosmos/auth/base_account.rs`
  - Added new variant `Secp256k1` to `AnyPubKey` enum in `lib/unionlabs/src/cosmos/crypto.rs`
  - Modified `TryFromAnyPubKeyError` enum in `lib/unionlabs/src/cosmos/crypto.rs`
  - Added serialization and deserialization implementations in `lib/unionlabs/src/cosmos/crypto/secp256k1.rs`

- **New Features**
  - Added search functionality to the app in `src/search.ts` and `src/index.ts`
  - Added styles for the search bar in `src/styles.css`

- **Control Flow Changes**
  - Updated control flow in `ucli/src/cli.rs`
  - Modified logic in `ucli/src/main.rs`

- **Documentation**
  - Updated trait implementations in `voyager/voyager-message/src/aggregate.rs`
<!-- end of auto-generated comment: release notes by coderabbit.ai -->