### PR TITLE
feat(ui): hide scrollbar

### DIFF
--- a/dictionary.txt
+++ b/dictionary.txt
@@ -562,6 +562,7 @@ rustls
 rustup
 schemars
 schnorr
+scrollbars
 sdkerrors
 secp
 sepolia

--- a/site/src/app.css
+++ b/site/src/app.css
@@ -26,3 +26,25 @@
   src: url("/fonts/Disket-Mono-Bold.ttf") format("truetype");
   font-weight: 700;
 }
+
+*::-webkit-scrollbar {
+  height: 0.3rem;
+  width: 0rem;
+}
+
+*::-webkit-scrollbar-track {
+  -ms-overflow-style: none;
+  overflow: -moz-scrollbars-none;
+}
+
+*::-webkit-scrollbar-thumb {
+  -ms-overflow-style: none;
+  overflow: -moz-scrollbars-none;
+}
+
+@supports (scrollbar-gutter: stable) {
+  html {
+    overflow-y: auto;
+    scrollbar-gutter: stable;
+  }
+}


### PR DESCRIPTION
this pr hides ugly browser default scrollbar while maintaining scrollbar functionality

b4
![CleanShot 2023-12-15 at 04 27 38@2x](https://github.com/unionlabs/union/assets/23618431/c3fca565-437d-42b4-b259-9e0a9d556f0c)

after
![CleanShot 2023-12-15 at 04 27 52@2x](https://github.com/unionlabs/union/assets/23618431/fe3933bb-a1cb-4ef8-a8e0-a4c130bc08ec)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Style**
	- Updated scrollbar styling and behavior in the web app.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->