### PR TITLE
feat(unionvisor): make log flags global

### DIFF
--- a/unionvisor/src/cli.rs
+++ b/unionvisor/src/cli.rs
@@ -30,11 +30,18 @@ pub struct Cli {
 
     /// The log level for unionvisor. uniond logs are piped to stdout and stderr regardless of level.
     /// and should be controlled with the commands args.
-    #[arg(short, long, env = "UNIONVISOR_LOG_LEVEL", default_value = "INFO")]
+    #[arg(
+        global = true,
+        short,
+        long,
+        env = "UNIONVISOR_LOG_LEVEL",
+        default_value = "INFO"
+    )]
     pub log_level: LevelFilter,
 
     /// The log format for both unionvisor and uniond.
     #[arg(
+        global = true,
         short = 'f',
         long,
         env = "UNIONVISOR_LOG_FORMAT",


### PR DESCRIPTION
Makes `unionvisor` flags relevant to logging global. 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Refactor**
  - Modified the `Cli` struct to handle log level and format with global attributes for configuration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->