### PR TITLE
fix(docs): correct hyperlane

### DIFF
--- a/site/src/content/docs/docs/concepts/permissionless-vs-trustless.mdx
+++ b/site/src/content/docs/docs/concepts/permissionless-vs-trustless.mdx
@@ -30,6 +30,7 @@ An odd one out in the bunch is [Hyperlane](https://www.hyperlane.xyz/), which is
 :::info
 
 As of 18-01-2024, only multisig and Wormhole security modules are supported by Hyperlane.
+
 :::
 
 ## IBC and Union


### PR DESCRIPTION
In a display of the smallest dick energy I've observed since Brainjar, hyperlane's CEO requested we'd remove their info from the docs, as it was:

- incorrect.
- we are only funding them.

As he did not provide what was incorrect and did not read the previous section, which mentions other protocols, we will not be removing his stuff. Our initial take was correct, but a bit brief. I've instead lessened it a bit.