### PR TITLE
feat: use thin lto and don't set debug to true in --release

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,21 +37,11 @@ edition      = "2021"
 license-file = "LICENSE"
 repository   = "https://github.com/unionlabs/union"
 
-# TODO: Review if crane uses this and if so, how we should set these values
 [profile.release]
-debug     = true
+lto       = "thin"
 opt-level = 3
-# rpath = false
-lto = "fat"
-# debug-assertions = false
-# codegen-units = 1
-# panic = "abort"
-# incremental = false
-# overflow-checks = true
-# strip = true
 
 [workspace.dependencies]
-
 beacon-api                = { path = "lib/beacon-api", default-features = false }
 chain-utils               = { path = "lib/chain-utils", default-features = false }
 cometbls-groth16-verifier = { path = "lib/cometbls-groth16-verifier", default-features = false }


### PR DESCRIPTION
fat lto was causing pathological compile times in voyager (and in other places across our workspace, just not as bad as voyager). a voyager clean release build goes from 8+ mins to under 3 mins with this change, with negligible changes in binary size (~5% increase).