### PR TITLE
fix: build on main and nightly

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -15,7 +15,7 @@ concurrency:
 
 jobs:
   spell-fmt-check:
-    uses: unionlabs/workflows/.github/workflows/build.yml@084e5981524aeb304346852dfafbef5d1ba9633d
+    uses: unionlabs/workflows/.github/workflows/build.yml@e79a9aee784f725e9f2622ae86ad77ca2b14138c
     secrets:
       nixbuild_token: ${{ secrets.nixbuild_token }}
       access-tokens: github.com=${{ secrets.GITHUB_TOKEN }}
@@ -27,7 +27,7 @@ jobs:
     if: |
       !cancelled()
       && (contains(needs.*.result, 'success') || github.event.pull_request.draft == true)
-    uses: unionlabs/workflows/.github/workflows/build.yml@084e5981524aeb304346852dfafbef5d1ba9633d
+    uses: unionlabs/workflows/.github/workflows/build.yml@e79a9aee784f725e9f2622ae86ad77ca2b14138c
     secrets:
       nixbuild_token: ${{ secrets.nixbuild_token }}
       access-tokens: github.com=${{ secrets.GITHUB_TOKEN }}
@@ -39,7 +39,7 @@ jobs:
     if: |
       !cancelled()
       && (contains(needs.*.result, 'success') || github.event.pull_request.draft == true)
-    uses: unionlabs/workflows/.github/workflows/build.yml@084e5981524aeb304346852dfafbef5d1ba9633d
+    uses: unionlabs/workflows/.github/workflows/build.yml@e79a9aee784f725e9f2622ae86ad77ca2b14138c
     secrets:
       nixbuild_token: ${{ secrets.nixbuild_token }}
       access-tokens: github.com=${{ secrets.GITHUB_TOKEN }}
@@ -51,7 +51,7 @@ jobs:
     if: |
       !cancelled()
       && (contains(needs.*.result, 'success') || github.event.pull_request.draft == true)
-    uses: unionlabs/workflows/.github/workflows/build.yml@084e5981524aeb304346852dfafbef5d1ba9633d
+    uses: unionlabs/workflows/.github/workflows/build.yml@e79a9aee784f725e9f2622ae86ad77ca2b14138c
     secrets:
       nixbuild_token: ${{ secrets.nixbuild_token }}
       access-tokens: github.com=${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -11,7 +11,7 @@ on:
 
 jobs:
   build:
-    uses: unionlabs/workflows/.github/workflows/build.yml@084e5981524aeb304346852dfafbef5d1ba9633d
+    uses: unionlabs/workflows/.github/workflows/build.yml@e79a9aee784f725e9f2622ae86ad77ca2b14138c
     secrets:
       nixbuild_token: ${{ secrets.nixbuild_token }}
       access-tokens: github.com=${{ secrets.github-token }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,7 +6,7 @@ on:
 
 jobs:
   build:
-    uses: unionlabs/workflows/.github/workflows/build.yml@084e5981524aeb304346852dfafbef5d1ba9633d
+    uses: unionlabs/workflows/.github/workflows/build.yml@e79a9aee784f725e9f2622ae86ad77ca2b14138c
     secrets:
       nixbuild_token: ${{ secrets.nixbuild_token }}
       access-tokens: github.com=${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
- Fixes issue with nightly builds where `filter_builds` wasn't being applied without `eval_target` being supplied. Closes #1265 
  - Fix demonstrated [here](https://github.com/unionlabs/union/actions/runs/7786460547/job/21231418919)
- Fixes issue where build summaries triggered an error if there were no jobs queued (closes #1261 )
  - Fix demonstrated [here](https://github.com/unionlabs/union/actions/runs/7788142685)
  
Needs unionlabs/workflows#29