### PR TITLE
feat(ci): avoid evaluating default in ci

### DIFF
--- a/uniond/cmd/uniond/main.go
+++ b/uniond/cmd/uniond/main.go
@@ -14,7 +14,7 @@ func main() {
 	rootCmd, _ := cmd.NewRootCmd()
 	rootCmd.AddCommand(cmd.GenBn254())
 	rootCmd.AddCommand(cmd.GenStateProof())
-	if err := svrcmd.Execute(rootCmd, "dog", app.DefaultNodeHome); err != nil {
+	if err := svrcmd.Execute(rootCmd, "", app.DefaultNodeHome); err != nil {
 		log.NewLogger(rootCmd.OutOrStderr()).Error("failure when running app", "err", err)
 		os.Exit(1)
 	}


### PR DESCRIPTION
- Confirmed that `uniond`/`default` was not built when cached in this run:
https://github.com/unionlabs/union/actions/runs/7892862705

- Confirmed that `uniond` rebuilds when not cached:
https://github.com/unionlabs/union/actions/runs/7892958671