### PR TITLE
feat: indexed event parameters

### DIFF
--- a/evm/contracts/apps/ucs/01-relay/Relay.sol
+++ b/evm/contracts/apps/ucs/01-relay/Relay.sol
@@ -74,7 +74,7 @@ library RelayLib {
     bytes1 public constant ACK_FAILURE = 0x00;
     uint256 public constant ACK_LENGTH = 1;
 
-    event DenomCreated(string denom, address token);
+    event DenomCreated(string indexed denom, address indexed token);
     event Received(
         string indexed sender,
         address indexed receiver,


### PR DESCRIPTION
This will make searching logs for specific data much easier.

> You can add the attribute indexed to up to three parameters which adds them to a special data structure known as [“topics”](https://docs.soliditylang.org/en/latest/abi-spec.html#abi-events) instead of the data part of the log. A topic can only hold a single word (32 bytes) so if you use a [reference type](https://docs.soliditylang.org/en/latest/types.html#reference-types) for an indexed argument, the Keccak-256 hash of the value is stored as a topic instead.

https://docs.soliditylang.org/en/latest/contracts.html#events