### PR TITLE
fix(ci): remove x.com from link checker

### DIFF
--- a/lychee.toml
+++ b/lychee.toml
@@ -4,7 +4,7 @@ exclude = [
   '^https://statesync.testnet.bonlulu.uno/',
   '^https://grpc.testnet.bonlulu.uno/',
   '^http://myserver.com:1111/',
-  '^https://x.com/'
+  '^https://x.com/',
 ]
 
 exclude_all_private = true


### PR DESCRIPTION
x.com doesn't like automated request, so it will often return "Bad Request" for content that exists. It's not worth evaluating these links manually.