### PR TITLE
chore: use core or alloc instead of std where possible

### DIFF
--- a/lib/unionlabs/src/bounded.rs
+++ b/lib/unionlabs/src/bounded.rs
@@ -14,8 +14,8 @@ macro_rules! bounded_int {
                 }
             }
 
-            impl<const MIN: $ty, const MAX: $ty> std::fmt::Debug for $Struct<MIN, MAX> {
-                fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            impl<const MIN: $ty, const MAX: $ty> core::fmt::Debug for $Struct<MIN, MAX> {
+                fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
                     f.write_fmt(format_args!("{}<{MIN}, {MAX}>({})", stringify!($Struct), self.0))
                 }
             }
@@ -87,7 +87,7 @@ macro_rules! bounded_int {
                 }
             }
 
-            impl<const MIN: $ty, const MAX: $ty> std::str::FromStr for $Struct<MIN, MAX> {
+            impl<const MIN: $ty, const MAX: $ty> core::str::FromStr for $Struct<MIN, MAX> {
                 type Err = BoundedIntParseError<$ty>;
 
                 fn from_str(s: &str) -> Result<Self, Self::Err> {
@@ -97,8 +97,8 @@ macro_rules! bounded_int {
                 }
             }
 
-            impl<const MIN: $ty, const MAX: $ty> std::fmt::Display for $Struct<MIN, MAX> {
-                fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            impl<const MIN: $ty, const MAX: $ty> core::fmt::Display for $Struct<MIN, MAX> {
+                fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
                     write!(f, "{}", self.0)
                 }
             }
@@ -148,7 +148,7 @@ pub struct BoundedIntError<T> {
 
 #[derive(Debug, Clone, PartialEq)]
 pub enum BoundedIntParseError<T> {
-    Parse(std::num::ParseIntError),
+    Parse(core::num::ParseIntError),
     Value(BoundedIntError<T>),
 }
 
@@ -159,19 +159,19 @@ bounded_int! {
     pub BoundedI64(i64);
     pub BoundedI128(i128);
 
-    #[non_zero(std::num::NonZeroU8)]
+    #[non_zero(core::num::NonZeroU8)]
     pub BoundedU8(u8);
-    #[non_zero(std::num::NonZeroU16)]
+    #[non_zero(core::num::NonZeroU16)]
     pub BoundedU16(u16);
-    #[non_zero(std::num::NonZeroU32)]
+    #[non_zero(core::num::NonZeroU32)]
     pub BoundedU32(u32);
-    #[non_zero(std::num::NonZeroU64)]
+    #[non_zero(core::num::NonZeroU64)]
     pub BoundedU64(u64);
-    #[non_zero(std::num::NonZeroU128)]
+    #[non_zero(core::num::NonZeroU128)]
     pub BoundedU128(u128);
 
     pub BoundedIsize(isize);
-    #[non_zero(std::num::NonZeroUsize)]
+    #[non_zero(core::num::NonZeroUsize)]
     pub BoundedUsize(usize);
 }
 

--- a/lib/unionlabs/src/cosmos/crypto.rs
+++ b/lib/unionlabs/src/cosmos/crypto.rs
@@ -1,4 +1,4 @@
-use std::fmt::Debug;
+use core::fmt::Debug;
 
 use serde::{Deserialize, Serialize};
 

--- a/lib/unionlabs/src/cosmos/ics23/inner_spec.rs
+++ b/lib/unionlabs/src/cosmos/ics23/inner_spec.rs
@@ -1,4 +1,4 @@
-use std::borrow::Cow;
+use alloc::borrow::Cow;
 
 use serde::{Deserialize, Serialize};
 

--- a/lib/unionlabs/src/cosmos/ics23/leaf_op.rs
+++ b/lib/unionlabs/src/cosmos/ics23/leaf_op.rs
@@ -1,4 +1,4 @@
-use std::borrow::Cow;
+use alloc::borrow::Cow;
 
 use serde::{Deserialize, Serialize};
 

--- a/lib/unionlabs/src/cosmos/staking/validator.rs
+++ b/lib/unionlabs/src/cosmos/staking/validator.rs
@@ -1,4 +1,4 @@
-use std::num::TryFromIntError;
+use core::num::TryFromIntError;
 
 use serde::{Deserialize, Serialize};
 

--- a/lib/unionlabs/src/cosmwasm/wasm/union/custom_query.rs
+++ b/lib/unionlabs/src/cosmwasm/wasm/union/custom_query.rs
@@ -1,4 +1,4 @@
-use std::fmt::Debug;
+use core::fmt::Debug;
 
 use cosmwasm_std::{to_json_vec, Binary, ContractResult, Deps, Env, QueryRequest, SystemResult};
 use prost::Message;

--- a/lib/unionlabs/src/encoding.rs
+++ b/lib/unionlabs/src/encoding.rs
@@ -1,4 +1,4 @@
-use std::fmt::Debug;
+use core::fmt::Debug;
 
 #[cfg(feature = "ethabi")]
 use crate::{IntoEthAbi, TryFromEthAbi, TryFromEthAbiBytesError, TryFromEthAbiErrorOf};

--- a/lib/unionlabs/src/ethereum.rs
+++ b/lib/unionlabs/src/ethereum.rs
@@ -1,4 +1,4 @@
-use std::fmt::Debug;
+use core::fmt::Debug;
 
 use hex_literal::hex;
 use serde::{Deserialize, Serialize};

--- a/lib/unionlabs/src/ethereum/beacon.rs
+++ b/lib/unionlabs/src/ethereum/beacon.rs
@@ -271,7 +271,7 @@ pub struct GenesisData {
 
 #[cfg(test)]
 mod tests {
-    use std::str::FromStr;
+    use core::str::FromStr;
 
     use super::*;
     use crate::{

--- a/lib/unionlabs/src/ethereum/config.rs
+++ b/lib/unionlabs/src/ethereum/config.rs
@@ -1,5 +1,4 @@
-use core::fmt::Debug;
-use std::str::FromStr;
+use core::{fmt::Debug, str::FromStr};
 
 use serde::{Deserialize, Serialize};
 use typenum::Unsigned;

--- a/lib/unionlabs/src/events.rs
+++ b/lib/unionlabs/src/events.rs
@@ -1,5 +1,4 @@
-use core::str::FromStr;
-use std::num::NonZeroU64;
+use core::{num::NonZeroU64, str::FromStr};
 
 use macros::apply;
 

--- a/lib/unionlabs/src/google/protobuf/any.rs
+++ b/lib/unionlabs/src/google/protobuf/any.rs
@@ -1,4 +1,4 @@
-use std::{fmt::Debug, marker::PhantomData};
+use core::{fmt::Debug, marker::PhantomData};
 
 use serde::{
     de::{self, Visitor},
@@ -54,7 +54,7 @@ where
         {
             type Value = Any<T>;
 
-            fn expecting(&self, formatter: &mut std::fmt::Formatter) -> std::fmt::Result {
+            fn expecting(&self, formatter: &mut core::fmt::Formatter) -> core::fmt::Result {
                 write!(
                     formatter,
                     "a google.protobuf.Any containing {}",

--- a/lib/unionlabs/src/google/protobuf/duration.rs
+++ b/lib/unionlabs/src/google/protobuf/duration.rs
@@ -1,4 +1,4 @@
-use std::{
+use core::{
     fmt::{self, Debug, Display},
     num::ParseIntError,
     ops::{Mul, Neg},
@@ -354,7 +354,7 @@ impl TryFrom<contracts::glue::GoogleProtobufDurationData> for Duration {
 
 #[cfg(test)]
 mod tests {
-    use std::cmp::Ordering;
+    use core::cmp::Ordering;
 
     use super::*;
     use crate::test_utils::{assert_json_roundtrip, assert_proto_roundtrip};

--- a/lib/unionlabs/src/google/protobuf/timestamp.rs
+++ b/lib/unionlabs/src/google/protobuf/timestamp.rs
@@ -1,5 +1,4 @@
-use core::num::TryFromIntError;
-use std::{cmp::Ordering, fmt::Display, ops::Neg, str::FromStr};
+use core::{cmp::Ordering, fmt::Display, num::TryFromIntError, ops::Neg, str::FromStr};
 
 use chrono::{DateTime, NaiveDateTime, SecondsFormat, TimeZone, Utc};
 use serde::{
@@ -120,7 +119,7 @@ impl Timestamp {
 }
 
 impl Display for Timestamp {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         f.write_str(&DateTime::<Utc>::from(*self).to_rfc3339_opts(
             SecondsFormat::Nanos,
             // use_z
@@ -301,7 +300,7 @@ impl From<Timestamp> for contracts::glue::GoogleProtobufTimestampData {
 pub enum TryFromEthAbiTimestampError {
     Seconds(BoundedIntError<i64>),
     Nanos(BoundedIntError<i32>),
-    NanosTryFromI64(std::num::TryFromIntError),
+    NanosTryFromI64(core::num::TryFromIntError),
 }
 
 #[cfg(feature = "ethabi")]

--- a/lib/unionlabs/src/ibc/applications/transfer/fungible_token_transfer_data.rs
+++ b/lib/unionlabs/src/ibc/applications/transfer/fungible_token_transfer_data.rs
@@ -1,4 +1,4 @@
-use std::num::ParseIntError;
+use core::num::ParseIntError;
 
 use crate::{Proto, TypeUrl};
 

--- a/lib/unionlabs/src/ibc/applications/transfer/msg_transfer.rs
+++ b/lib/unionlabs/src/ibc/applications/transfer/msg_transfer.rs
@@ -1,4 +1,4 @@
-use std::num::NonZeroU64;
+use core::num::NonZeroU64;
 
 use serde::{Deserialize, Serialize};
 

--- a/lib/unionlabs/src/ibc/core/channel/counterparty.rs
+++ b/lib/unionlabs/src/ibc/core/channel/counterparty.rs
@@ -1,4 +1,4 @@
-use std::str::FromStr;
+use core::str::FromStr;
 
 use serde::{Deserialize, Serialize};
 

--- a/lib/unionlabs/src/ibc/core/channel/packet.rs
+++ b/lib/unionlabs/src/ibc/core/channel/packet.rs
@@ -1,4 +1,4 @@
-use std::num::{NonZeroU64, TryFromIntError};
+use core::num::{NonZeroU64, TryFromIntError};
 
 use serde::{Deserialize, Serialize};
 

--- a/lib/unionlabs/src/ibc/core/client/height.rs
+++ b/lib/unionlabs/src/ibc/core/client/height.rs
@@ -1,4 +1,4 @@
-use std::{
+use core::{
     fmt::{Debug, Display},
     num::ParseIntError,
     str::FromStr,
@@ -26,7 +26,7 @@ pub struct Height {
 }
 
 impl Debug for Height {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         write!(f, "Height({self})")
     }
 }
@@ -63,7 +63,7 @@ pub enum HeightFromStrError {
 }
 
 impl Display for HeightFromStrError {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         match self {
             HeightFromStrError::ParseIntError(e) => write!(f, "invalid height string: {e}"),
             HeightFromStrError::Invalid => write!(f, "invalid height string"),
@@ -100,17 +100,17 @@ impl From<Height> for protos::ibc::core::client::v1::Height {
 
 // REVIEW(benluelo): Ordering for heights with different revision numbers?
 impl PartialOrd for Height {
-    fn partial_cmp(&self, other: &Self) -> Option<std::cmp::Ordering> {
+    fn partial_cmp(&self, other: &Self) -> Option<core::cmp::Ordering> {
         Some(match self.revision_number.cmp(&other.revision_number) {
-            std::cmp::Ordering::Less => std::cmp::Ordering::Less,
-            std::cmp::Ordering::Equal => self.revision_height.cmp(&other.revision_height),
-            std::cmp::Ordering::Greater => std::cmp::Ordering::Greater,
+            core::cmp::Ordering::Less => core::cmp::Ordering::Less,
+            core::cmp::Ordering::Equal => self.revision_height.cmp(&other.revision_height),
+            core::cmp::Ordering::Greater => core::cmp::Ordering::Greater,
         })
     }
 }
 
-impl std::fmt::Display for Height {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+impl core::fmt::Display for Height {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         write!(f, "{}-{}", self.revision_number, self.revision_height)
     }
 }

--- a/lib/unionlabs/src/ibc/core/connection/connection_end.rs
+++ b/lib/unionlabs/src/ibc/core/connection/connection_end.rs
@@ -1,4 +1,4 @@
-use std::str::FromStr;
+use core::str::FromStr;
 
 use serde::{Deserialize, Serialize};
 

--- a/lib/unionlabs/src/ibc/core/connection/counterparty.rs
+++ b/lib/unionlabs/src/ibc/core/connection/counterparty.rs
@@ -1,4 +1,4 @@
-use std::str::FromStr;
+use core::str::FromStr;
 
 use serde::{Deserialize, Serialize};
 

--- a/lib/unionlabs/src/ibc/core/connection/msg_connection_open_ack.rs
+++ b/lib/unionlabs/src/ibc/core/connection/msg_connection_open_ack.rs
@@ -1,4 +1,4 @@
-use std::fmt::Debug;
+use core::fmt::Debug;
 
 use serde::{Deserialize, Serialize};
 

--- a/lib/unionlabs/src/ibc/core/connection/msg_connection_open_try.rs
+++ b/lib/unionlabs/src/ibc/core/connection/msg_connection_open_try.rs
@@ -1,4 +1,4 @@
-use std::fmt::Debug;
+use core::fmt::Debug;
 
 use serde::{Deserialize, Serialize};
 

--- a/lib/unionlabs/src/ibc/lightclients/ethereum/client_state.rs
+++ b/lib/unionlabs/src/ibc/lightclients/ethereum/client_state.rs
@@ -1,4 +1,4 @@
-use std::str::FromStr;
+use core::str::FromStr;
 
 use serde::{Deserialize, Serialize};
 use uint::FromDecStrErr;

--- a/lib/unionlabs/src/ibc/lightclients/ethereum/light_client_update.rs
+++ b/lib/unionlabs/src/ibc/lightclients/ethereum/light_client_update.rs
@@ -1,4 +1,4 @@
-use std::fmt::Debug;
+use core::fmt::Debug;
 
 use serde::{Deserialize, Serialize};
 use ssz::{Decode, Encode};

--- a/lib/unionlabs/src/ibc/lightclients/ethereum/sync_aggregate.rs
+++ b/lib/unionlabs/src/ibc/lightclients/ethereum/sync_aggregate.rs
@@ -16,8 +16,8 @@ pub struct SyncAggregate<C: SYNC_COMMITTEE_SIZE> {
     pub sync_committee_signature: BlsSignature,
 }
 
-impl<C: SYNC_COMMITTEE_SIZE + std::fmt::Debug> std::fmt::Debug for SyncAggregate<C> {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+impl<C: SYNC_COMMITTEE_SIZE + core::fmt::Debug> core::fmt::Debug for SyncAggregate<C> {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         f.debug_struct("SyncAggregate")
             .field(
                 "sync_committee_bits",

--- a/lib/unionlabs/src/ibc/lightclients/scroll/client_state.rs
+++ b/lib/unionlabs/src/ibc/lightclients/scroll/client_state.rs
@@ -1,4 +1,4 @@
-use std::{fmt::Debug, str::FromStr};
+use core::{fmt::Debug, str::FromStr};
 
 use serde::{Deserialize, Serialize};
 use uint::FromDecStrErr;

--- a/lib/unionlabs/src/ibc/lightclients/tendermint/fraction.rs
+++ b/lib/unionlabs/src/ibc/lightclients/tendermint/fraction.rs
@@ -1,4 +1,4 @@
-use std::num::NonZeroU64;
+use core::num::NonZeroU64;
 
 use serde::{Deserialize, Serialize};
 

--- a/lib/unionlabs/src/ibc/lightclients/wasm/client_state.rs
+++ b/lib/unionlabs/src/ibc/lightclients/wasm/client_state.rs
@@ -1,4 +1,4 @@
-use std::fmt::Debug;
+use core::fmt::Debug;
 
 use serde::{Deserialize, Serialize};
 

--- a/lib/unionlabs/src/ibc/lightclients/wasm/consensus_state.rs
+++ b/lib/unionlabs/src/ibc/lightclients/wasm/consensus_state.rs
@@ -1,4 +1,4 @@
-use std::fmt::Debug;
+use core::fmt::Debug;
 
 use prost::Message;
 use serde::{Deserialize, Serialize};

--- a/lib/unionlabs/src/id.rs
+++ b/lib/unionlabs/src/id.rs
@@ -1,4 +1,4 @@
-use std::fmt::Debug;
+use core::fmt::Debug;
 
 use crate::{
     const_assert,
@@ -144,7 +144,7 @@ impl<T: Into<String> + From<String>, const MIN: usize, const MAX: usize>
 
 #[cfg(test)]
 mod tests {
-    use std::borrow::Cow;
+    use alloc::borrow::Cow;
 
     use super::*;
     use crate::validated::{ValidateT, Validated};

--- a/lib/unionlabs/src/lib.rs
+++ b/lib/unionlabs/src/lib.rs
@@ -1,9 +1,16 @@
 #![doc = include_str!("../README.md")]
-#![deny(clippy::pedantic)]
+#![deny(
+    clippy::pedantic,
+    clippy::std_instead_of_core,
+    clippy::std_instead_of_alloc,
+    clippy::alloc_instead_of_core
+)]
 #![allow(clippy::missing_errors_doc, clippy::module_name_repetitions)]
 #![feature(trait_alias)]
 
-use std::{
+extern crate alloc;
+
+use core::{
     fmt::{Debug, Display},
     ptr::addr_of,
     str::FromStr,
@@ -76,13 +83,13 @@ pub mod uint;
 pub(crate) mod macros;
 
 pub mod errors {
-    use std::fmt::{Debug, Display};
+    use core::fmt::{Debug, Display};
 
     #[derive(Debug, Clone)]
     pub struct UnknownEnumVariant<T>(pub T);
 
     impl<T: Display> Display for UnknownEnumVariant<T> {
-        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
             f.write_fmt(format_args!("unknown enum variant: {}", self.0))
         }
     }
@@ -204,7 +211,7 @@ where
 #[cfg(any(feature = "fuzzing", test))]
 #[allow(clippy::missing_panics_doc)]
 pub mod test_utils {
-    use std::{
+    use core::{
         fmt::{Debug, Display},
         str::FromStr,
     };
@@ -438,7 +445,7 @@ pub enum QueryHeight<H: IsHeight> {
 }
 
 impl<H: IsHeight> Display for QueryHeight<H> {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         match self {
             QueryHeight::Latest => f.write_str("latest"),
             QueryHeight::Specific(height) => f.write_fmt(format_args!("{height}")),
@@ -492,11 +499,11 @@ where
     T: ToOwned + ?Sized,
     T::Owned: for<'a> arbitrary::Arbitrary<'a>,
 {
-    u.arbitrary::<T::Owned>().map(std::borrow::Cow::Owned)
+    u.arbitrary::<T::Owned>().map(alloc::borrow::Cow::Owned)
 }
 
 pub mod never {
-    use std::{self, fmt::Display};
+    use core::{self, fmt::Display};
 
     use serde::{Deserialize, Serialize};
 
@@ -505,7 +512,7 @@ pub mod never {
     pub enum Never {}
 
     impl Display for Never {
-        fn fmt(&self, _: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        fn fmt(&self, _: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
             match *self {}
         }
     }

--- a/lib/unionlabs/src/macros.rs
+++ b/lib/unionlabs/src/macros.rs
@@ -33,7 +33,7 @@ macro_rules! hex_string_array_wrapper {
                 }
             }
 
-            impl std::str::FromStr for $Struct {
+            impl core::str::FromStr for $Struct {
                 type Err = serde_utils::FromHexStringError;
 
                 fn from_str(s: &str) -> Result<Self, Self::Err> {
@@ -93,13 +93,13 @@ macro_rules! hex_string_array_wrapper {
                 }
             }
 
-            impl ::std::fmt::Debug for $Struct {
+            impl ::core::fmt::Debug for $Struct {
                 fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
                     write!(f, "{}({self})", stringify!($Struct))
                 }
             }
 
-            impl ::std::fmt::Display for $Struct {
+            impl ::core::fmt::Display for $Struct {
                 fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
                     write!(f, "0x{}", hex::encode(self.0).as_str())
                 }
@@ -207,9 +207,9 @@ macro_rules! hex_string_array_wrapper {
                 fn decode(rlp: &rlp::Rlp) -> Result<Self, ::rlp::DecoderError> {
                     rlp.decoder()
                         .decode_value(|bytes| match bytes.len().cmp(&$N) {
-                            ::std::cmp::Ordering::Less => Err(::rlp::DecoderError::RlpIsTooShort),
-                            ::std::cmp::Ordering::Greater => Err(::rlp::DecoderError::RlpIsTooBig),
-                            ::std::cmp::Ordering::Equal => {
+                            ::core::cmp::Ordering::Less => Err(::rlp::DecoderError::RlpIsTooShort),
+                            ::core::cmp::Ordering::Greater => Err(::rlp::DecoderError::RlpIsTooBig),
+                            ::core::cmp::Ordering::Equal => {
                                 Ok($Struct(bytes.try_into().expect("size is checked; qed;")))
                             }
                         })
@@ -254,7 +254,7 @@ macro_rules! wrapper_enum {
             )+
         }
 
-        impl std::str::FromStr for $Enum {
+        impl core::str::FromStr for $Enum {
             type Err = crate::errors::UnknownEnumVariant<String>;
 
             fn from_str(s: &str) -> Result<Self, Self::Err> {
@@ -279,8 +279,8 @@ macro_rules! wrapper_enum {
             }
         }
 
-        impl std::fmt::Display for $Enum {
-            fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        impl core::fmt::Display for $Enum {
+            fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
                 f.write_str(<&'static str>::from(*self))
             }
         }

--- a/lib/unionlabs/src/proof.rs
+++ b/lib/unionlabs/src/proof.rs
@@ -1,4 +1,4 @@
-use std::{
+use core::{
     fmt::{Debug, Display},
     num::NonZeroU64,
     str::FromStr,

--- a/lib/unionlabs/src/signer.rs
+++ b/lib/unionlabs/src/signer.rs
@@ -1,4 +1,4 @@
-use std::{self, fmt::Display};
+use core::{self, fmt::Display};
 
 use bip32::{
     secp256k1::{ecdsa, ecdsa::Signature, schnorr::signature::Signer},
@@ -38,7 +38,7 @@ impl CosmosSigner {
 }
 
 impl Display for CosmosSigner {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         // TODO: benchmark this, and consider caching it in the struct
         // bech32(prefix, ripemd(sha256(pubkey)))
         let encoded = subtle_encoding::bech32::encode(

--- a/lib/unionlabs/src/traits.rs
+++ b/lib/unionlabs/src/traits.rs
@@ -1,11 +1,11 @@
-use std::{
-    error::Error,
+use core::{
     fmt::{Debug, Display},
     future::Future,
     hash::Hash,
     num::NonZeroU64,
     str::FromStr,
 };
+use std::error::Error;
 
 use serde::{Deserialize, Serialize};
 
@@ -42,7 +42,7 @@ pub trait Id:
 
 impl Id for String {
     // type FromStrErr = <String as FromStr>::Err;
-    type FromStrErr = std::string::ParseError;
+    type FromStrErr = alloc::string::ParseError;
 }
 
 impl<T: Id, V: Validate<T> + 'static> Id for Validated<T, V>

--- a/lib/unionlabs/src/uint.rs
+++ b/lib/unionlabs/src/uint.rs
@@ -1,4 +1,4 @@
-use std::{fmt::Display, str::FromStr};
+use core::{fmt::Display, str::FromStr};
 
 use custom_debug_derive::Debug;
 use serde::{Deserialize, Serialize};
@@ -210,14 +210,14 @@ impl FromStr for U256 {
 }
 
 impl Display for U256 {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         f.write_fmt(format_args!("{}", self.0))
     }
 }
 
 #[cfg(test)]
 mod u256_tests {
-    use std::str::FromStr;
+    use core::str::FromStr;
 
     use serde::{Deserialize, Serialize};
 

--- a/lib/unionlabs/src/validated.rs
+++ b/lib/unionlabs/src/validated.rs
@@ -1,4 +1,4 @@
-use std::{fmt::Display, marker::PhantomData, ops::Deref, str::FromStr};
+use core::{fmt::Display, marker::PhantomData, ops::Deref, str::FromStr};
 
 use custom_debug_derive::Debug;
 use either::Either;
@@ -39,7 +39,7 @@ pub trait ValidateT: Sized {
 impl<T> ValidateT for T {}
 
 impl<T: Display, V: Validate<T>> Display for Validated<T, V> {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         write!(f, "{}", self.0)
     }
 }
@@ -154,7 +154,7 @@ impl<T> ValidateExt<T> for () {
 
 #[cfg(test)]
 mod tests {
-    use std::marker::PhantomData;
+    use core::marker::PhantomData;
 
     use either::Either;
 


### PR DESCRIPTION
also add a lint to ensure we use the most primitive import (core -> alloc -> std).

this is in preparation to make `unionlabs` more no-std friendly down the line.