### PR TITLE
chore: remove duplicated code between union and cosmos

### DIFF
--- a/lib/block-message/src/aggregate.rs
+++ b/lib/block-message/src/aggregate.rs
@@ -6,7 +6,6 @@ use queue_msg::{
     aggregation::{do_aggregate, UseAggregate},
     fetch, msg_struct, HandleAggregate, QueueError, QueueMsg, QueueMsgTypes,
 };
-use serde::{Deserialize, Serialize};
 use unionlabs::ibc::core::client::height::IsHeight;
 
 use crate::{
@@ -18,6 +17,7 @@ use crate::{
 
 #[apply(any_enum)]
 #[any = AnyAggregate]
+#[specific = ChainSpecificAggregate]
 pub enum Aggregate<C: ChainExt> {
     FetchBlockRange(AggregateFetchBlockRange<C>),
     #[serde(untagged)]

--- a/lib/block-message/src/chain_impls.rs
+++ b/lib/block-message/src/chain_impls.rs
@@ -41,7 +41,7 @@ macro_rules! try_from_block_poll_msg {
 
                                             match t {
                                                 crate::data::Data::ChainSpecific(
-                                                    ChainSpecificData($d Enum::$d Variant(
+                                                    crate::data::ChainSpecificData($d Enum::$d Variant(
                                                     t,
                                                 ))) => Ok(Identified::new(chain_id, t)),
                                                 _ => Err(QueueMsg::Data(Into::<AnyChainIdentified<AnyData>>::into(Identified::<$d Chain, _>::new(chain_id, t))))
@@ -61,7 +61,7 @@ macro_rules! try_from_block_poll_msg {
                                 fn from(Identified { chain_id, t, }: Identified<$d Chain, $d Ty>) -> crate::AnyChainIdentified<crate::data::AnyData> {
                                     crate::AnyChainIdentified::<crate::data::AnyData>::from(Identified::<$d Chain, _>::new(
                                         chain_id,
-                                        Data::ChainSpecific(ChainSpecificData($d Enum::$d Variant(
+                                        Data::ChainSpecific(crate::data::ChainSpecificData($d Enum::$d Variant(
                                             t,
                                         ))),
                                     ))
@@ -82,7 +82,7 @@ macro_rules! try_from_block_poll_msg {
                                     } = value.try_into()?;
 
                                     match t {
-                                        Data::ChainSpecific(ChainSpecificData($d Enum::$d Variant(
+                                        Data::ChainSpecific(crate::data::ChainSpecificData($d Enum::$d Variant(
                                             t,
                                         ))) => Ok(Identified::new(chain_id, t)),
                                         _ => Err(Into::<AnyChainIdentified<AnyData>>::into(Identified::new(chain_id, t)))

--- a/lib/block-message/src/data.rs
+++ b/lib/block-message/src/data.rs
@@ -2,13 +2,13 @@ use std::fmt::Display;
 
 use macros::apply;
 use queue_msg::{data, msg_struct, HandleData, QueueError, QueueMsg, QueueMsgTypes};
-use serde::{Deserialize, Serialize};
 use unionlabs::{events::IbcEvent, hash::H256, ClientType};
 
 use crate::{any_enum, AnyChainIdentified, BlockPollingTypes, ChainExt};
 
 #[apply(any_enum)]
 #[any = AnyData]
+#[specific = ChainSpecificData]
 pub enum Data<C: ChainExt> {
     IbcEvent(ChainEvent<C>),
     LatestHeight(LatestHeight<C>),

--- a/lib/block-message/src/fetch.rs
+++ b/lib/block-message/src/fetch.rs
@@ -6,7 +6,6 @@ use macros::apply;
 use queue_msg::{
     aggregate, conc, fetch, msg_struct, wait, HandleFetch, QueueError, QueueMsg, QueueMsgTypes,
 };
-use serde::{Deserialize, Serialize};
 use unionlabs::ibc::core::client::height::IsHeight;
 
 use crate::{
@@ -18,6 +17,7 @@ use crate::{
 
 #[apply(any_enum)]
 #[any = AnyFetch]
+#[specific = ChainSpecificFetch]
 pub enum Fetch<C: ChainExt> {
     FetchBlock(FetchBlock<C>),
     FetchBlockRange(FetchBlockRange<C>),

--- a/lib/block-message/src/lib.rs
+++ b/lib/block-message/src/lib.rs
@@ -127,6 +127,7 @@ macro_rules! any_enum {
     (
         $(#[doc = $outer_doc:literal])*
         #[any = $Any:ident]
+        $(#[specific = $Specific:ident])?
         pub enum $Enum:ident<C: ChainExt> {
             $(
                 $(#[doc = $doc:literal])*
@@ -221,6 +222,14 @@ macro_rules! any_enum {
                 }
             )*
         };
+
+        $(
+            impl<C: ChainExt> $Enum<C> {
+                pub fn specific(t: impl Into<C::$Enum>) -> $Enum<C> {
+                    $Specific(t.into()).into()
+                }
+            }
+        )?
     };
 }
 pub(crate) use any_enum;

--- a/lib/block-message/src/wait.rs
+++ b/lib/block-message/src/wait.rs
@@ -3,7 +3,6 @@ use std::fmt::Display;
 use chain_utils::{Chains, GetChain};
 use macros::apply;
 use queue_msg::{data, defer, msg_struct, now, seq, wait, HandleWait, QueueError, QueueMsg};
-use serde::{Deserialize, Serialize};
 use unionlabs::{ibc::core::client::height::IsHeight, traits::HeightOf};
 
 use crate::{

--- a/lib/queue-msg/src/lib.rs
+++ b/lib/queue-msg/src/lib.rs
@@ -856,19 +856,21 @@ impl<T: QueueMsgTypes> Queue<T> for InMemoryQueue<T> {
 macro_rules! msg_struct {
     (
         $(#[cover($($CoverTy:ty),+)])?
+        $(#[doc = $doc:tt])*
         pub struct $Struct:ident$(<$($generics:ident: $bound:ident$(<$($boundT:ident),+>)?),+>)? {
             $(
                 pub $field:ident: $FieldTy:ty,
             )*
         }
     ) => {
-        #[derive(Serialize, Deserialize)]
+        #[derive(::serde::Serialize, ::serde::Deserialize)]
         #[serde(bound(serialize = "", deserialize = ""), deny_unknown_fields)]
         #[cfg_attr(
             feature = "arbitrary",
             derive(arbitrary::Arbitrary),
             arbitrary(bound = "")
         )]
+        $(#[doc = $doc])*
         pub struct $Struct$(<$($generics: $bound$(<$($boundT),+>)?),+>)? {
             $(
                 pub $field: $FieldTy,
@@ -876,7 +878,7 @@ macro_rules! msg_struct {
             $(
                 #[serde(skip)]
                 #[cfg_attr(feature = "arbitrary", arbitrary(default))]
-                pub __marker: PhantomData<fn() -> ($($CoverTy,)+)>,
+                pub __marker: ::core::marker::PhantomData<fn() -> ($($CoverTy,)+)>,
             )?
         }
         const _: () = {
@@ -895,7 +897,7 @@ macro_rules! msg_struct {
                     Self {
                         $($field: ::core::clone::Clone::clone(&self.$field),)*
                         $(
-                            __marker: PhantomData::<fn() -> ($($CoverTy,)+)>,
+                            __marker: ::core::marker::PhantomData::<fn() -> ($($CoverTy,)+)>,
                         )?
                     }
                 }
@@ -913,19 +915,21 @@ macro_rules! msg_struct {
 
     (
         $(#[cover($($CoverTy:ty),+)])?
-        pub struct $Struct:ident<$($generics:ident: $bound:ident$(<$($boundT:ident),+>)?),+>(pub $FieldTy:ty$(,)?);
+        $(#[doc = $doc:tt])*
+        pub struct $Struct:ident$(<$($generics:ident: $bound:ident$(<$($boundT:ident),+>)?),+>)?(pub $FieldTy:ty$(,)?);
     ) => {
-        #[derive(Serialize, Deserialize)]
+        #[derive(::serde::Serialize, ::serde::Deserialize)]
         #[serde(bound(serialize = "", deserialize = ""), deny_unknown_fields, transparent)]
         #[cfg_attr(
             feature = "arbitrary",
             derive(arbitrary::Arbitrary),
             arbitrary(bound = "")
         )]
-        pub struct $Struct<$($generics: $bound$(<$($boundT),+>)?),+> (pub $FieldTy);
+        $(#[doc = $doc])*
+        pub struct $Struct $(<$($generics: $bound$(<$($boundT),+>)?),+>)? (pub $FieldTy);
         const _: () = {
-            impl<$($generics: $bound$(<$($boundT),+>)?),+> ::core::fmt::Debug
-            for $Struct<$($generics),+> {
+            impl$(<$($generics: $bound$(<$($boundT),+>)?),+>)? ::core::fmt::Debug
+            for $Struct $(<$($generics),+>)? {
                 fn fmt(&self, fmt: &mut ::core::fmt::Formatter) -> ::core::fmt::Result {
                     fmt.debug_tuple(stringify!($Struct))
                         .field(&self.0)
@@ -933,15 +937,15 @@ macro_rules! msg_struct {
                 }
             }
 
-            impl<$($generics: $bound$(<$($boundT),+>)?),+> ::core::clone::Clone
-            for $Struct<$($generics),+> {
+            impl$(<$($generics: $bound$(<$($boundT),+>)?),+>)? ::core::clone::Clone
+            for $Struct $(<$($generics),+>)? {
                 fn clone(&self) -> Self {
                     Self(::core::clone::Clone::clone(&self.0))
                 }
             }
 
-            impl<$($generics: $bound$(<$($boundT),+>)?),+> ::core::cmp::PartialEq
-            for $Struct<$($generics),+> {
+            impl$(<$($generics: $bound$(<$($boundT),+>)?),+>)? ::core::cmp::PartialEq
+            for $Struct $(<$($generics),+>)? {
                 fn eq(&self, other: &Self) -> bool {
                     self.0 == other.0
                 }

--- a/lib/relay-message/src/aggregate.rs
+++ b/lib/relay-message/src/aggregate.rs
@@ -63,6 +63,7 @@ use crate::{
 #[apply(any_enum)]
 /// Aggregate data, using data from [`AggregateData`]
 #[any = AnyAggregate]
+#[specific = LightClientSpecificAggregate]
 pub enum Aggregate<Hc: ChainExt, Tr: ChainExt> {
     ConnectionOpenTry(AggregateConnectionOpenTry<Hc, Tr>),
     ConnectionOpenAck(AggregateConnectionOpenAck<Hc, Tr>),

--- a/lib/relay-message/src/chain_impls.rs
+++ b/lib/relay-message/src/chain_impls.rs
@@ -40,7 +40,7 @@ macro_rules! try_from_relayer_msg {
 
                                             match t {
                                                 crate::Data::LightClientSpecific(
-                                                    LightClientSpecificData($d Enum::$d Variant(
+                                                    crate::data::LightClientSpecificData($d Enum::$d Variant(
                                                     t,
                                                 ))) => Ok(crate::id(chain_id, t)),
                                                 _ => Err(queue_msg::QueueMsg::Data(Into::<AnyLightClientIdentified<AnyData>>::into(crate::id(chain_id, t))))
@@ -59,7 +59,7 @@ macro_rules! try_from_relayer_msg {
                                 fn from(Identified { chain_id, t, __marker: _ }: Identified<$d Chain, Tr, $d Ty>) -> crate::AnyLightClientIdentified<crate::data::AnyData> {
                                     crate::AnyLightClientIdentified::from(crate::id(
                                         chain_id,
-                                        Data::LightClientSpecific(LightClientSpecificData($d Enum::$d Variant(
+                                        Data::LightClientSpecific(crate::data::LightClientSpecificData($d Enum::$d Variant(
                                             t,
                                         ))),
                                     ))
@@ -80,7 +80,7 @@ macro_rules! try_from_relayer_msg {
                                     } = value.try_into()?;
 
                                     match t {
-                                        Data::LightClientSpecific(LightClientSpecificData($d Enum::$d Variant(
+                                        Data::LightClientSpecific(crate::data::LightClientSpecificData($d Enum::$d Variant(
                                             t,
                                         ))) => Ok(crate::id(chain_id, t)),
                                         _ => Err(Into::<AnyLightClientIdentified<AnyData>>::into(crate::id(chain_id, t)))

--- a/lib/relay-message/src/data.rs
+++ b/lib/relay-message/src/data.rs
@@ -1,8 +1,5 @@
-use std::marker::PhantomData;
-
 use macros::apply;
 use queue_msg::{data, msg_struct, HandleData, QueueError, QueueMsg, QueueMsgTypes};
-use serde::{Deserialize, Serialize};
 use unionlabs::{
     proof::{
         AcknowledgementPath, ChannelEndPath, ClientConsensusStatePath, ClientStatePath,
@@ -19,6 +16,7 @@ use crate::{
 #[apply(any_enum)]
 /// Data that will likely be used in a [`QueueMsg::Aggregate`].
 #[any = AnyData]
+#[specific = LightClientSpecificData]
 pub enum Data<Hc: ChainExt, Tr: ChainExt> {
     SelfClientState(SelfClientState<Hc, Tr>),
     SelfConsensusState(SelfConsensusState<Hc, Tr>),

--- a/lib/relay-message/src/fetch.rs
+++ b/lib/relay-message/src/fetch.rs
@@ -8,7 +8,6 @@ use chain_utils::GetChain;
 use futures::Future;
 use macros::apply;
 use queue_msg::{data, fetch, msg_struct, HandleFetch, QueueError, QueueMsg, QueueMsgTypes};
-use serde::{Deserialize, Serialize};
 use unionlabs::{
     hash::H256,
     id::{ChannelId, PortId},
@@ -29,6 +28,7 @@ use crate::{
 #[apply(any_enum)]
 /// Fetch some data that will likely be used in a [`QueueMsg::Aggregate`].
 #[any = AnyFetch]
+#[specific = LightClientSpecificFetch]
 pub enum Fetch<Hc: ChainExt, Tr: ChainExt> {
     State(FetchState<Hc, Tr>),
     Proof(FetchProof<Hc, Tr>),

--- a/lib/relay-message/src/lib.rs
+++ b/lib/relay-message/src/lib.rs
@@ -115,6 +115,7 @@ macro_rules! any_enum {
     (
         $(#[doc = $outer_doc:literal])*
         #[any = $Any:ident]
+        $(#[specific = $Specific:ident])?
         pub enum $Enum:ident<Hc: ChainExt, Tr: ChainExt> {
             $(
                 $(#[doc = $doc:literal])*
@@ -212,6 +213,14 @@ macro_rules! any_enum {
                 }
             )+
         };
+
+        $(
+            impl<Hc: ChainExt, Tr: ChainExt> $Enum<Hc, Tr> {
+                pub fn specific(t: impl Into<Hc::$Enum<Tr>>) -> $Enum<Hc, Tr> {
+                    $Specific(t.into()).into()
+                }
+            }
+        )?
     };
 }
 pub(crate) use any_enum;

--- a/lib/relay-message/src/msg.rs
+++ b/lib/relay-message/src/msg.rs
@@ -1,9 +1,8 @@
-use std::{fmt::Display, marker::PhantomData};
+use std::fmt::Display;
 
 use chain_utils::GetChain;
 use macros::apply;
 use queue_msg::{msg_struct, HandleMsg, QueueError, QueueMsg, QueueMsgTypes};
-use serde::{Deserialize, Serialize};
 use unionlabs::{
     ibc::core::{
         channel::{

--- a/lib/relay-message/src/wait.rs
+++ b/lib/relay-message/src/wait.rs
@@ -1,11 +1,10 @@
-use std::{fmt::Display, marker::PhantomData};
+use std::fmt::Display;
 
 use chain_utils::{ChainNotFoundError, GetChain};
 use macros::apply;
 use queue_msg::{
     defer, fetch, msg_struct, now, seq, wait, HandleWait, QueueError, QueueMsg, QueueMsgTypes,
 };
-use serde::{Deserialize, Serialize};
 use unionlabs::{
     ibc::core::client::height::IsHeight,
     proof::ClientStatePath,

--- a/voyager/src/main.rs
+++ b/voyager/src/main.rs
@@ -335,10 +335,9 @@ mod tests {
         chain_impls::{
             cosmos_sdk::fetch::{AbciQueryType, FetchAbciQuery},
             evm::EvmConfig,
-            union::UnionFetch,
         },
         event::IbcEvent,
-        fetch::{FetchSelfClientState, FetchSelfConsensusState, LightClientSpecificFetch},
+        fetch::{FetchSelfClientState, FetchSelfConsensusState},
         msg::{MsgChannelOpenInitData, MsgConnectionOpenInitData},
         RelayerMsgTypes, WasmConfig,
     };
@@ -399,13 +398,13 @@ mod tests {
         println!("---------------------------------------");
         print_json::<RelayerMsgTypes>(fetch(relay_message::id::<Wasm<Union>, Evm<Minimal>, _>(
             union_chain_id.clone(),
-            LightClientSpecificFetch(UnionFetch::AbciQuery(FetchAbciQuery {
+            relay_message::fetch::Fetch::specific(FetchAbciQuery {
                 path: proof::Path::ClientStatePath(proof::ClientStatePath {
                     client_id: parse!("client-id"),
                 }),
                 height: parse!("123-456"),
                 ty: AbciQueryType::State,
-            })),
+            }),
         )));
 
         println!("---------------------------------------");


### PR DESCRIPTION
- there was a lot of copy-pasted code between union and cosmos in voyager, this has been deduplicated now
- added helpers a la `Fetch::specific` to more tersely construct `{LightClient,Chain}Specific{Data,Fetch,Aggregate}`, removing lots of nested expressions and `.into()` calls
- union now uses `TrustedValidators` and `UntrustedValidators` instead of just `Validators`, mirroring cosmos, so that the aggregation is not dependant on the order of the data in the aggregation queue
- use `#[apply(msg_struct)]` in a few more places
- use more fully qualified paths in macros to reduce imports in files they're called in
- use `id()` instead of `Identified::new()`
  - should probably remove the `Identified::new` constructor at this point, will do in a future PR

i meant to break this up into two commits, but i accidentally amended instead of committed. oops
