### PR TITLE
chore(voyager): remove unused duplicate field in message

### DIFF
--- a/lib/relay-message/src/aggregate.rs
+++ b/lib/relay-message/src/aggregate.rs
@@ -133,7 +133,6 @@ impl<Hc: ChainExt, Tr: ChainExt> identified!(Aggregate<Hc, Tr>) {
 
         // proof
         Identified<Hc, Tr, IbcProof<ClientStatePath<Hc::ClientId>, Hc, Tr>>: IsAggregateData,
-
         Identified<Hc, Tr, IbcProof<ClientConsensusStatePath<Hc::ClientId, Tr::Height>, Hc, Tr>>:
             IsAggregateData,
         Identified<Hc, Tr, IbcProof<ConnectionPath, Hc, Tr>>: IsAggregateData,
@@ -326,7 +325,6 @@ pub struct AggregateConnectionFetchFromChannelEnd<Hc: ChainExt, Tr: ChainExt> {
 #[cover(Tr)]
 pub struct AggregateChannelHandshakeMsgAfterUpdate<Hc: ChainExt, Tr: ChainExt> {
     // Will be threaded through to the update msg
-    pub update_to: HeightOf<Hc>,
     pub event_height: HeightOf<Hc>,
     pub channel_handshake_event: ChannelHandshakeEvent,
 }
@@ -446,7 +444,6 @@ where
             chain_id: this_chain_id,
             t:
                 AggregateChannelHandshakeMsgAfterUpdate {
-                    update_to,
                     channel_handshake_event,
                     event_height,
                     __marker: _,
@@ -494,7 +491,7 @@ where
                 this_chain_id.clone(),
                 connection.client_id,
                 connection.counterparty.client_id,
-                update_to,
+                event_height,
             )],
             [],
             id(this_chain_id, event_msg),

--- a/lib/relay-message/src/event.rs
+++ b/lib/relay-message/src/event.rs
@@ -168,8 +168,6 @@ impl<Hc: ChainExt, Tr: ChainExt> Event<Hc, Tr> {
                     id(
                         hc.chain_id(),
                         AggregateChannelHandshakeMsgAfterUpdate {
-                            // REVIEW: Remove this field and just use `event_height`?
-                            update_to: ibc_event.height,
                             event_height: ibc_event.height,
                             channel_handshake_event: ChannelHandshakeEvent::Init(init),
                             __marker: PhantomData,
@@ -202,7 +200,6 @@ impl<Hc: ChainExt, Tr: ChainExt> Event<Hc, Tr> {
                     id(
                         hc.chain_id(),
                         AggregateChannelHandshakeMsgAfterUpdate {
-                            update_to: ibc_event.height,
                             event_height: ibc_event.height,
                             channel_handshake_event: ChannelHandshakeEvent::Try(try_),
                             __marker: PhantomData,
@@ -235,7 +232,6 @@ impl<Hc: ChainExt, Tr: ChainExt> Event<Hc, Tr> {
                     id(
                         hc.chain_id(),
                         AggregateChannelHandshakeMsgAfterUpdate {
-                            update_to: ibc_event.height,
                             event_height: ibc_event.height,
                             channel_handshake_event: ChannelHandshakeEvent::Ack(ack),
                             __marker: PhantomData,

--- a/voyager-config.json
+++ b/voyager-config.json
@@ -24,7 +24,7 @@
       "scroll_api": "https://sepolia-api-re.scroll.io/"
     },
     "ethereum-devnet": {
-      "enabled": false,
+      "enabled": true,
       "chain_type": "ethereum",
       "preset_base": "minimal",
       "ibc_handler_address": "0xEDa338E4dC46038493b885327842fD3E301CaB39",


### PR DESCRIPTION
cleans up a TODO to remove a legacy field from an aggregation message