### PR TITLE
refactor(voyager): deduplicate more code between union/ cosmos/ wasm

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4645,6 +4645,7 @@ dependencies = [
  "serde",
  "serde-utils",
  "serde_json",
+ "static_assertions",
  "tendermint",
  "tendermint-proto",
  "tendermint-rpc",

--- a/lib/relay-message/Cargo.toml
+++ b/lib/relay-message/Cargo.toml
@@ -29,6 +29,7 @@ queue-msg                = { workspace = true }
 serde                    = { workspace = true, features = ["derive"] }
 serde-utils              = { workspace = true }
 serde_json               = { workspace = true }
+static_assertions        = "1.1.0"
 tendermint               = { workspace = true }
 tendermint-proto         = { workspace = true }
 tendermint-rpc           = { workspace = true, features = ["http-client", "websocket-client"] }

--- a/lib/relay-message/src/chain_impls.rs
+++ b/lib/relay-message/src/chain_impls.rs
@@ -24,26 +24,26 @@ macro_rules! try_from_relayer_msg {
                         ),
                     ) => {
                         $d (
-                            impl <$($generics)+> TryFrom<queue_msg::QueueMsg<crate::RelayerMsgTypes>> for Identified<$d Chain, Tr, $d Ty>
+                            impl <$($generics)+> TryFrom<queue_msg::QueueMsg<crate::RelayerMsgTypes>> for crate::Identified<$d Chain, Tr, $d Ty>
                             where
-                                identified!(Data<$d Chain, Tr>): TryFrom<AnyLightClientIdentified<AnyData>, Error = AnyLightClientIdentified<AnyData>> + Into<AnyLightClientIdentified<AnyData>>
+                                crate::Identified<$d Chain, Tr, crate::data::Data<$d Chain, Tr>>: TryFrom<crate::AnyLightClientIdentified<crate::data::AnyData>, Error = crate::AnyLightClientIdentified<crate::data::AnyData>> + Into<crate::AnyLightClientIdentified<crate::data::AnyData>>
                             {
                                 type Error = queue_msg::QueueMsg<crate::RelayerMsgTypes>;
-                                fn try_from(value: queue_msg::QueueMsg<crate::RelayerMsgTypes>) -> Result<Identified<$d Chain, Tr, $d Ty>, queue_msg::QueueMsg<crate::RelayerMsgTypes>> {
+                                fn try_from(value: queue_msg::QueueMsg<crate::RelayerMsgTypes>) -> Result<crate::Identified<$d Chain, Tr, $d Ty>, queue_msg::QueueMsg<crate::RelayerMsgTypes>> {
                                     match value {
                                         queue_msg::QueueMsg::Data(data) => {
-                                            let Identified {
+                                            let crate::Identified::<$d Chain, Tr, crate::data::Data<$d Chain, Tr>> {
                                                 chain_id,
                                                 t,
                                                 __marker: _,
                                             } = data.try_into().map_err(queue_msg::QueueMsg::Data)?;
 
                                             match t {
-                                                crate::Data::LightClientSpecific(
+                                                crate::data::Data::LightClientSpecific(
                                                     crate::data::LightClientSpecificData($d Enum::$d Variant(
                                                     t,
-                                                ))) => Ok(crate::id(chain_id, t)),
-                                                _ => Err(queue_msg::QueueMsg::Data(Into::<AnyLightClientIdentified<AnyData>>::into(crate::id(chain_id, t))))
+                                                ))) => Ok(crate::id::<$d Chain, Tr, $d Ty>(chain_id, t)),
+                                                _ => Err(queue_msg::QueueMsg::Data(Into::<crate::AnyLightClientIdentified<crate::data::AnyData>>::into(crate::id(chain_id, t))))
                                             }
 
                                         },
@@ -52,48 +52,42 @@ macro_rules! try_from_relayer_msg {
                                 }
                             }
 
-                            impl <$($generics)+> From<Identified<$d Chain, Tr, $d Ty>> for crate::AnyLightClientIdentified<crate::data::AnyData>
+                            impl <$($generics)+> From<crate::Identified<$d Chain, Tr, $d Ty>> for crate::AnyLightClientIdentified<crate::data::AnyData>
                             where
-                                AnyLightClientIdentified<AnyData>: From<identified!(Data<$d Chain, Tr>)>
+                                crate::AnyLightClientIdentified<crate::data::AnyData>: From<crate::Identified<$d Chain, Tr, crate::data::Data<$d Chain, Tr>>>
                             {
-                                fn from(Identified { chain_id, t, __marker: _ }: Identified<$d Chain, Tr, $d Ty>) -> crate::AnyLightClientIdentified<crate::data::AnyData> {
+                                fn from(crate::Identified { chain_id, t, __marker: _ }: crate::Identified<$d Chain, Tr, $d Ty>) -> crate::AnyLightClientIdentified<crate::data::AnyData> {
                                     crate::AnyLightClientIdentified::from(crate::id(
                                         chain_id,
-                                        Data::LightClientSpecific(crate::data::LightClientSpecificData($d Enum::$d Variant(
+                                        crate::data::Data::LightClientSpecific(crate::data::LightClientSpecificData($d Enum::$d Variant(
                                             t,
                                         ))),
                                     ))
                                 }
                             }
 
-                            impl <$($generics)+> TryFrom<crate::AnyLightClientIdentified<crate::data::AnyData>> for Identified<$d Chain, Tr, $d Ty>
+                            impl <$($generics)+> TryFrom<crate::AnyLightClientIdentified<crate::data::AnyData>> for crate::Identified<$d Chain, Tr, $d Ty>
                             where
-                                identified!(Data<$d Chain, Tr>): TryFrom<AnyLightClientIdentified<AnyData>, Error = AnyLightClientIdentified<AnyData>> + Into<AnyLightClientIdentified<AnyData>>
+                                crate::Identified<$d Chain, Tr, crate::data::Data<$d Chain, Tr>>: TryFrom<crate::AnyLightClientIdentified<crate::data::AnyData>, Error = crate::AnyLightClientIdentified<crate::data::AnyData>> + Into<crate::AnyLightClientIdentified<crate::data::AnyData>>
                             {
                                 type Error = crate::AnyLightClientIdentified<crate::data::AnyData>;
 
-                                fn try_from(value: crate::AnyLightClientIdentified<crate::data::AnyData>) -> Result<Identified<$d Chain, Tr, $d Ty>, crate::AnyLightClientIdentified<crate::data::AnyData>> {
-                                    let Identified {
+                                fn try_from(value: crate::AnyLightClientIdentified<crate::data::AnyData>) -> Result<crate::Identified<$d Chain, Tr, $d Ty>, crate::AnyLightClientIdentified<crate::data::AnyData>> {
+                                    let crate::Identified {
                                         chain_id,
                                         t,
                                         __marker: _,
                                     } = value.try_into()?;
 
                                     match t {
-                                        Data::LightClientSpecific(crate::data::LightClientSpecificData($d Enum::$d Variant(
+                                        crate::data::Data::LightClientSpecific(crate::data::LightClientSpecificData($d Enum::$d Variant(
                                             t,
                                         ))) => Ok(crate::id(chain_id, t)),
-                                        _ => Err(Into::<AnyLightClientIdentified<AnyData>>::into(crate::id(chain_id, t)))
+                                        _ => Err(Into::<crate::AnyLightClientIdentified<crate::data::AnyData>>::into(crate::id(chain_id, t)))
                                     }
                                 }
                             }
                         )+
-
-                        // impl From<<$d Chain as LightClient>::$d LcMsg> for $d Specific<$d Chain> {
-                        //     fn from(msg: <$d Chain as LightClient>::$d LcMsg) -> Self {
-                        //         Self(msg)
-                        //     }
-                        // }
                     };
                 }
             }

--- a/lib/relay-message/src/chain_impls/cosmos.rs
+++ b/lib/relay-message/src/chain_impls/cosmos.rs
@@ -2,13 +2,12 @@ use std::{collections::VecDeque, marker::PhantomData};
 
 use chain_utils::{
     cosmos::Cosmos,
-    cosmos_sdk::{BroadcastTxCommitError, CosmosSdkChain, CosmosSdkChainExt},
+    cosmos_sdk::{BroadcastTxCommitError, CosmosSdkChain},
     wasm::Wraps,
 };
 use frame_support_procedural::{CloneNoBound, DebugNoBound, PartialEqNoBound};
 use frunk::{hlist_pat, HList};
 use macros::apply;
-use protos::ibc::core::connection::v1::MsgConnectionOpenInit;
 use queue_msg::{
     aggregate,
     aggregation::{do_aggregate, UseAggregate},
@@ -17,7 +16,7 @@ use queue_msg::{
 use serde::{Deserialize, Serialize};
 use unionlabs::{
     encoding::{Decode, Encode, Proto},
-    google::protobuf::any::{mk_any, Any},
+    google::protobuf::any::IntoAny,
     hash::H160,
     ibc::{
         core::{
@@ -28,7 +27,7 @@ use unionlabs::{
     },
     proof::ClientStatePath,
     tendermint::types::validator::Validator,
-    traits::{Chain, ClientStateOf, ConsensusStateOf, HeaderOf, HeightOf},
+    traits::{Chain, ClientStateOf, ConsensusStateOf, HeaderOf},
     TypeUrl,
 };
 
@@ -36,25 +35,23 @@ use crate::{
     aggregate::{Aggregate, AnyAggregate},
     chain_impls::cosmos_sdk::{
         data::{TrustedCommit, TrustedValidators, UntrustedCommit, UntrustedValidators},
+        do_msg,
         fetch::{
             fetch_trusted_commit, fetch_trusted_validators, fetch_untrusted_commit,
-            fetch_untrusted_validators, AbciQueryType, FetchAbciQuery, FetchTrustedCommit,
-            FetchTrustedValidators, FetchUntrustedCommit, FetchUntrustedValidators,
+            fetch_untrusted_validators, FetchAbciQuery, FetchTrustedCommit, FetchTrustedValidators,
+            FetchUntrustedCommit, FetchUntrustedValidators,
         },
-        fetch_abci_query,
+        fetch_abci_query, CosmosSdkChainSealed,
     },
     data::{AnyData, Data, IbcState},
     fetch::{AnyFetch, DoFetch, Fetch, FetchUpdateHeaders},
     id, identified,
-    msg::{
-        AnyMsg, Msg, MsgConnectionOpenAckData, MsgConnectionOpenInitData, MsgConnectionOpenTryData,
-        MsgUpdateClientData,
-    },
+    msg::{AnyMsg, Msg, MsgUpdateClientData},
     seq,
     use_aggregate::IsAggregateData,
     wait::{AnyWait, Wait, WaitForBlock},
-    AnyLightClientIdentified, ChainExt, DoAggregate, DoFetchProof, DoFetchState,
-    DoFetchUpdateHeaders, DoMsg, Identified, PathOf, RelayerMsgTypes, Wasm, WasmConfig,
+    AnyLightClientIdentified, ChainExt, DoAggregate, DoFetchUpdateHeaders, DoMsg, Identified,
+    RelayerMsgTypes,
 };
 
 impl ChainExt for Cosmos {
@@ -67,256 +64,35 @@ impl ChainExt for Cosmos {
     type Config = ();
 }
 
-impl ChainExt for Wasm<Cosmos> {
-    type Data<Tr: ChainExt> = CosmosDataMsg<Self, Tr>;
-    type Fetch<Tr: ChainExt> = CosmosFetch<Wasm<Cosmos>, Tr>;
-    type Aggregate<Tr: ChainExt> = CosmosAggregateMsg<Wasm<Cosmos>, Tr>;
+impl CosmosSdkChainSealed for Cosmos {}
 
-    type MsgError = BroadcastTxCommitError;
-
-    type Config = WasmConfig;
-}
-
-impl<Tr: ChainExt, Hc: ChainExt + Wraps<Self>> DoMsg<Hc, Tr> for Cosmos
+impl<Tr> DoMsg<Cosmos, Tr> for Cosmos
 where
+    Tr: ChainExt,
+
     ConsensusStateOf<Tr>: Encode<Proto> + TypeUrl,
     ClientStateOf<Tr>: Encode<Proto> + TypeUrl,
     HeaderOf<Tr>: Encode<Proto> + TypeUrl,
 
-    ConsensusStateOf<Hc>: Encode<Proto> + TypeUrl,
+    ConsensusStateOf<Cosmos>: Encode<Proto> + TypeUrl,
+    ClientStateOf<Cosmos>: Encode<Proto> + TypeUrl,
 
-    ClientStateOf<Hc>: Encode<Proto> + TypeUrl,
-    // HeaderOf<Hc>: IntoProto,
-    // <HeaderOf<Hc> as Proto>::Proto: TypeUrl,
-    Tr::StoredClientState<Hc>: Into<protos::google::protobuf::Any>,
+    Tr::StoredClientState<Cosmos>: IntoAny,
     Tr::StateProof: Encode<Proto>,
 {
-    async fn msg(&self, msg: Msg<Hc, Tr>) -> Result<(), BroadcastTxCommitError> {
-        self.signers
-            .with(|signer| async {
-                let msg_any = match msg.clone() {
-                    Msg::ConnectionOpenInit(MsgConnectionOpenInitData(data)) => {
-                        mk_any(&MsgConnectionOpenInit {
-                            client_id: data.client_id.to_string(),
-                            counterparty: Some(data.counterparty.into()),
-                            version: Some(data.version.into()),
-                            signer: signer.to_string(),
-                            delay_period: data.delay_period,
-                        })
-                    }
-                    Msg::ConnectionOpenTry(MsgConnectionOpenTryData(data)) =>
-                    {
-                        #[allow(deprecated)]
-                        mk_any(&protos::ibc::core::connection::v1::MsgConnectionOpenTry {
-                            client_id: data.client_id.to_string(),
-                            previous_connection_id: String::new(),
-                            client_state: Some(data.client_state.into()),
-                            counterparty: Some(data.counterparty.into()),
-                            delay_period: data.delay_period,
-                            counterparty_versions: data
-                                .counterparty_versions
-                                .into_iter()
-                                .map(Into::into)
-                                .collect(),
-                            proof_height: Some(data.proof_height.into_height().into()),
-                            proof_init: data.proof_init.encode(),
-                            proof_client: data.proof_client.encode(),
-                            proof_consensus: data.proof_consensus.encode(),
-                            consensus_height: Some(data.consensus_height.into_height().into()),
-                            signer: signer.to_string(),
-                            host_consensus_state_proof: vec![],
-                        })
-                    }
-                    Msg::ConnectionOpenAck(MsgConnectionOpenAckData(data)) => {
-                        mk_any(&protos::ibc::core::connection::v1::MsgConnectionOpenAck {
-                            client_state: Some(data.client_state.into()),
-                            proof_height: Some(data.proof_height.into_height().into()),
-                            proof_client: data.proof_client.encode(),
-                            proof_consensus: data.proof_consensus.encode(),
-                            consensus_height: Some(data.consensus_height.into_height().into()),
-                            signer: signer.to_string(),
-                            host_consensus_state_proof: vec![],
-                            connection_id: data.connection_id.to_string(),
-                            counterparty_connection_id: data.counterparty_connection_id.to_string(),
-                            version: Some(data.version.into()),
-                            proof_try: data.proof_try.encode(),
-                        })
-                    }
-                    Msg::ConnectionOpenConfirm(data) => mk_any(
-                        &protos::ibc::core::connection::v1::MsgConnectionOpenConfirm {
-                            connection_id: data.msg.connection_id.to_string(),
-                            proof_ack: data.msg.proof_ack.encode(),
-                            proof_height: Some(data.msg.proof_height.into_height().into()),
-                            signer: signer.to_string(),
-                        },
-                    ),
-                    Msg::ChannelOpenInit(data) => {
-                        mk_any(&protos::ibc::core::channel::v1::MsgChannelOpenInit {
-                            port_id: data.msg.port_id.to_string(),
-                            channel: Some(data.msg.channel.into()),
-                            signer: signer.to_string(),
-                        })
-                    }
-                    Msg::ChannelOpenTry(data) =>
-                    {
-                        #[allow(deprecated)]
-                        mk_any(&protos::ibc::core::channel::v1::MsgChannelOpenTry {
-                            port_id: data.msg.port_id.to_string(),
-                            channel: Some(data.msg.channel.into()),
-                            counterparty_version: data.msg.counterparty_version,
-                            proof_init: data.msg.proof_init.encode(),
-                            proof_height: Some(data.msg.proof_height.into()),
-                            previous_channel_id: String::new(),
-                            signer: signer.to_string(),
-                        })
-                    }
-                    Msg::ChannelOpenAck(data) => {
-                        mk_any(&protos::ibc::core::channel::v1::MsgChannelOpenAck {
-                            port_id: data.msg.port_id.to_string(),
-                            channel_id: data.msg.channel_id.to_string(),
-                            counterparty_version: data.msg.counterparty_version,
-                            counterparty_channel_id: data.msg.counterparty_channel_id.to_string(),
-                            proof_try: data.msg.proof_try.encode(),
-                            proof_height: Some(data.msg.proof_height.into_height().into()),
-                            signer: signer.to_string(),
-                        })
-                    }
-                    Msg::ChannelOpenConfirm(data) => {
-                        mk_any(&protos::ibc::core::channel::v1::MsgChannelOpenConfirm {
-                            port_id: data.msg.port_id.to_string(),
-                            channel_id: data.msg.channel_id.to_string(),
-                            proof_height: Some(data.msg.proof_height.into_height().into()),
-                            signer: signer.to_string(),
-                            proof_ack: data.msg.proof_ack.encode(),
-                        })
-                    }
-                    Msg::RecvPacket(data) => {
-                        mk_any(&protos::ibc::core::channel::v1::MsgRecvPacket {
-                            packet: Some(data.msg.packet.into()),
-                            proof_height: Some(data.msg.proof_height.into_height().into()),
-                            signer: signer.to_string(),
-                            proof_commitment: data.msg.proof_commitment.encode(),
-                        })
-                    }
-                    Msg::AckPacket(data) => {
-                        mk_any(&protos::ibc::core::channel::v1::MsgAcknowledgement {
-                            packet: Some(data.msg.packet.into()),
-                            acknowledgement: data.msg.acknowledgement,
-                            proof_acked: data.msg.proof_acked.encode(),
-                            proof_height: Some(data.msg.proof_height.into_height().into()),
-                            signer: signer.to_string(),
-                        })
-                    }
-                    Msg::CreateClient(data) => {
-                        mk_any(&protos::ibc::core::client::v1::MsgCreateClient {
-                            client_state: Some(Any(data.msg.client_state).into()),
-                            consensus_state: Some(Any(data.msg.consensus_state).into()),
-                            signer: signer.to_string(),
-                        })
-                    }
-                    Msg::UpdateClient(MsgUpdateClientData(data)) => {
-                        mk_any(&protos::ibc::core::client::v1::MsgUpdateClient {
-                            signer: signer.to_string(),
-                            client_id: data.client_id.to_string(),
-                            client_message: Some(Any(data.client_message).into()),
-                        })
-                    }
-                };
-
-                let tx_hash = self.broadcast_tx_commit(signer, [msg_any]).await?;
-
-                tracing::info!("cosmos tx {:?} => {:?}", tx_hash, msg);
-
-                Ok(())
-            })
-            .await
-    }
-}
-
-impl<
-        Tr: ChainExt,
-        Hc: Wraps<Self> + ChainExt<StateProof = MerkleProof, Fetch<Tr> = CosmosFetch<Hc, Tr>>,
-    > DoFetchState<Hc, Tr> for Cosmos
-where
-    AnyLightClientIdentified<AnyFetch>: From<identified!(Fetch<Hc, Tr>)>,
-    AnyLightClientIdentified<AnyWait>: From<identified!(Wait<Hc, Tr>)>,
-    // required by fetch_abci_query, can be removed once that's been been removed
-    AnyLightClientIdentified<AnyData>: From<identified!(Data<Hc, Tr>)>,
-    Tr::SelfClientState: Decode<Proto>,
-    Tr::SelfConsensusState: Decode<Proto>,
-
-    Hc::StoredClientState<Tr>: Decode<Proto>,
-    Hc::StoredConsensusState<Tr>: Decode<Proto>,
-
-    Identified<Hc, Tr, IbcState<ClientStatePath<Hc::ClientId>, Hc, Tr>>: IsAggregateData,
-{
-    fn state(hc: &Hc, at: HeightOf<Hc>, path: PathOf<Hc, Tr>) -> QueueMsg<RelayerMsgTypes> {
-        seq([
-            wait(id(
-                hc.chain_id(),
-                WaitForBlock {
-                    height: at,
-                    __marker: PhantomData,
-                },
-            )),
-            fetch(id::<Hc, Tr, _>(
-                hc.chain_id(),
-                Fetch::specific(FetchAbciQuery {
-                    path,
-                    height: at,
-                    ty: AbciQueryType::State,
-                }),
-            )),
-        ])
-    }
-
-    async fn query_client_state(
-        hc: &Hc,
-        client_id: Hc::ClientId,
-        height: Hc::Height,
-    ) -> Hc::StoredClientState<Tr> {
-        let QueueMsg::Data(relayer_msg) = fetch_abci_query::<Hc, Tr>(
-            hc,
-            ClientStatePath { client_id }.into(),
-            height,
-            AbciQueryType::State,
+    async fn msg(&self, msg: Msg<Cosmos, Tr>) -> Result<(), BroadcastTxCommitError> {
+        do_msg(
+            self,
+            msg,
+            |(), client_state, consensus_state| {
+                (
+                    client_state.into_any().into(),
+                    consensus_state.into_any().into(),
+                )
+            },
+            |client_message| client_message.into_any().into(),
         )
         .await
-        else {
-            panic!()
-        };
-
-        Identified::<Hc, Tr, IbcState<ClientStatePath<Hc::ClientId>, Hc, Tr>>::try_from(relayer_msg)
-            .unwrap()
-            .t
-            .state
-    }
-}
-
-impl<Tr: ChainExt, Hc: Wraps<Self> + ChainExt<Fetch<Tr> = CosmosFetch<Hc, Tr>>> DoFetchProof<Hc, Tr>
-    for Cosmos
-where
-    AnyLightClientIdentified<AnyFetch>: From<identified!(Fetch<Hc, Tr>)>,
-    AnyLightClientIdentified<AnyWait>: From<identified!(Wait<Hc, Tr>)>,
-{
-    fn proof(hc: &Hc, at: HeightOf<Hc>, path: PathOf<Hc, Tr>) -> QueueMsg<RelayerMsgTypes> {
-        seq([
-            wait(id(
-                hc.chain_id(),
-                WaitForBlock {
-                    height: at,
-                    __marker: PhantomData,
-                },
-            )),
-            fetch(id::<Hc, Tr, _>(
-                hc.chain_id(),
-                Fetch::specific(FetchAbciQuery::<Hc, Tr> {
-                    path,
-                    height: at,
-                    ty: AbciQueryType::Proof,
-                }),
-            )),
-        ])
     }
 }
 
@@ -449,7 +225,7 @@ pub enum CosmosFetch<Hc: ChainExt, Tr: ChainExt> {
     AbciQuery(FetchAbciQuery<Hc, Tr>),
 }
 
-impl<Hc, Tr> DoFetch<Hc> for CosmosFetch<Hc, Tr>
+impl<Hc, Tr> DoFetch<Hc, Tr> for CosmosFetch<Hc, Tr>
 where
     Hc: CosmosSdkChain
         + ChainExt<
@@ -558,19 +334,6 @@ const _: () = {
             UntrustedCommit(UntrustedCommit<Cosmos, Tr>),
             TrustedValidators(TrustedValidators<Cosmos, Tr>),
             UntrustedValidators(UntrustedValidators<Cosmos, Tr>),
-        ),
-    }
-};
-
-const _: () = {
-    try_from_relayer_msg! {
-        chain = Wasm<Cosmos>,
-        generics = (Tr: ChainExt),
-        msgs = CosmosDataMsg(
-            TrustedCommit(TrustedCommit<Wasm<Cosmos>, Tr>),
-            UntrustedCommit(UntrustedCommit<Wasm<Cosmos>, Tr>),
-            TrustedValidators(TrustedValidators<Wasm<Cosmos>, Tr>),
-            UntrustedValidators(UntrustedValidators<Wasm<Cosmos>, Tr>),
         ),
     }
 };

--- a/lib/relay-message/src/chain_impls/cosmos_sdk.rs
+++ b/lib/relay-message/src/chain_impls/cosmos_sdk.rs
@@ -1,22 +1,294 @@
 use std::marker::PhantomData;
 
-use chain_utils::cosmos_sdk::CosmosSdkChain;
+use chain_utils::cosmos_sdk::{BroadcastTxCommitError, CosmosSdkChain, CosmosSdkChainExt};
 use prost::Message;
-use queue_msg::{data, QueueMsg};
+use queue_msg::{data, fetch, seq, wait, QueueMsg};
 use unionlabs::{
-    encoding::{Decode, Proto},
+    encoding::{Decode, Encode, Proto},
+    google::protobuf::any::{mk_any, IntoAny},
     ibc::core::{client::height::IsHeight, commitment::merkle_proof::MerkleProof},
     proof::{ClientStatePath, Path},
-    traits::HeightOf,
+    traits::{ClientStateOf, ConsensusStateOf, HeaderOf, HeightOf},
+    TypeUrl,
 };
 
 use crate::{
-    chain_impls::cosmos_sdk::fetch::AbciQueryType,
+    chain_impls::cosmos_sdk::fetch::{AbciQueryType, FetchAbciQuery},
     data::{AnyData, Data, IbcProof, IbcState},
+    fetch::{AnyFetch, Fetch},
     id, identified,
+    msg::{
+        Msg, MsgAckPacketData, MsgChannelOpenAckData, MsgChannelOpenConfirmData,
+        MsgChannelOpenInitData, MsgChannelOpenTryData, MsgConnectionOpenAckData,
+        MsgConnectionOpenConfirmData, MsgConnectionOpenInitData, MsgConnectionOpenTryData,
+        MsgCreateClientData, MsgRecvPacketData, MsgUpdateClientData,
+    },
     use_aggregate::IsAggregateData,
-    AnyLightClientIdentified, ChainExt, Identified, RelayerMsgTypes,
+    wait::{AnyWait, Wait, WaitForBlock},
+    AnyLightClientIdentified, ChainExt, DoFetchProof, DoFetchState, Identified, PathOf,
+    RelayerMsgTypes,
 };
+
+pub trait CosmosSdkChainSealed: CosmosSdkChain + ChainExt {}
+
+pub async fn do_msg<Hc, Tr>(
+    hc: &Hc,
+    msg: Msg<Hc, Tr>,
+    // We need to be able to customize the encoding of the client/consensus states and client messages (header) since Wasm<_> needs to wrap them in wasm.v1.*; but since the rest of the logic is exactly the same, the following two functions are used as hooks to allow for the behaviour to be otherwise reused.
+    mk_create_client_states: fn(
+        Hc::Config,
+        ClientStateOf<Tr>,
+        ConsensusStateOf<Tr>,
+    )
+        -> (protos::google::protobuf::Any, protos::google::protobuf::Any),
+    mk_client_message: fn(Tr::Header) -> protos::google::protobuf::Any,
+) -> Result<(), BroadcastTxCommitError>
+where
+    Hc: CosmosSdkChainSealed<MsgError = BroadcastTxCommitError>,
+    Tr: ChainExt,
+
+    ConsensusStateOf<Tr>: Encode<Proto> + TypeUrl,
+    ClientStateOf<Tr>: Encode<Proto> + TypeUrl,
+    HeaderOf<Tr>: Encode<Proto> + TypeUrl,
+
+    ConsensusStateOf<Hc>: Encode<Proto> + TypeUrl,
+    ClientStateOf<Hc>: Encode<Proto> + TypeUrl,
+
+    Tr::StoredClientState<Hc>: IntoAny,
+    Tr::StateProof: Encode<Proto>,
+{
+    hc.signers()
+        .with(|signer| async {
+            let msg_any = match msg.clone() {
+                Msg::ConnectionOpenInit(MsgConnectionOpenInitData(data)) => {
+                    mk_any(&protos::ibc::core::connection::v1::MsgConnectionOpenInit {
+                        client_id: data.client_id.to_string(),
+                        counterparty: Some(data.counterparty.into()),
+                        version: Some(data.version.into()),
+                        signer: signer.to_string(),
+                        delay_period: data.delay_period,
+                    })
+                }
+                Msg::ConnectionOpenTry(MsgConnectionOpenTryData(data)) => {
+                    mk_any(&protos::ibc::core::connection::v1::MsgConnectionOpenTry {
+                        client_id: data.client_id.to_string(),
+                        client_state: Some(data.client_state.into_any().into()),
+                        counterparty: Some(data.counterparty.into()),
+                        delay_period: data.delay_period,
+                        counterparty_versions: data
+                            .counterparty_versions
+                            .into_iter()
+                            .map(Into::into)
+                            .collect(),
+                        proof_height: Some(data.proof_height.into_height().into()),
+                        proof_init: data.proof_init.encode(),
+                        proof_client: data.proof_client.encode(),
+                        proof_consensus: data.proof_consensus.encode(),
+                        consensus_height: Some(data.consensus_height.into_height().into()),
+                        signer: signer.to_string(),
+                        host_consensus_state_proof: vec![],
+                        ..Default::default()
+                    })
+                }
+                Msg::ConnectionOpenAck(MsgConnectionOpenAckData(data)) => {
+                    mk_any(&protos::ibc::core::connection::v1::MsgConnectionOpenAck {
+                        client_state: Some(data.client_state.into_any().into()),
+                        proof_height: Some(data.proof_height.into_height().into()),
+                        proof_client: data.proof_client.encode(),
+                        proof_consensus: data.proof_consensus.encode(),
+                        consensus_height: Some(data.consensus_height.into_height().into()),
+                        signer: signer.to_string(),
+                        host_consensus_state_proof: vec![],
+                        connection_id: data.connection_id.to_string(),
+                        counterparty_connection_id: data.counterparty_connection_id.to_string(),
+                        version: Some(data.version.into()),
+                        proof_try: data.proof_try.encode(),
+                    })
+                }
+                Msg::ConnectionOpenConfirm(MsgConnectionOpenConfirmData { msg, __marker }) => {
+                    mk_any(
+                        &protos::ibc::core::connection::v1::MsgConnectionOpenConfirm {
+                            connection_id: msg.connection_id.to_string(),
+                            proof_ack: msg.proof_ack.encode(),
+                            proof_height: Some(msg.proof_height.into_height().into()),
+                            signer: signer.to_string(),
+                        },
+                    )
+                }
+                Msg::ChannelOpenInit(MsgChannelOpenInitData { msg, __marker }) => {
+                    mk_any(&protos::ibc::core::channel::v1::MsgChannelOpenInit {
+                        port_id: msg.port_id.to_string(),
+                        channel: Some(msg.channel.into()),
+                        signer: signer.to_string(),
+                    })
+                }
+                Msg::ChannelOpenTry(MsgChannelOpenTryData { msg, __marker }) => {
+                    mk_any(&protos::ibc::core::channel::v1::MsgChannelOpenTry {
+                        port_id: msg.port_id.to_string(),
+                        channel: Some(msg.channel.into()),
+                        counterparty_version: msg.counterparty_version,
+                        proof_init: msg.proof_init.encode(),
+                        proof_height: Some(msg.proof_height.into()),
+                        signer: signer.to_string(),
+                        ..Default::default()
+                    })
+                }
+                Msg::ChannelOpenAck(MsgChannelOpenAckData { msg, __marker }) => {
+                    mk_any(&protos::ibc::core::channel::v1::MsgChannelOpenAck {
+                        port_id: msg.port_id.to_string(),
+                        channel_id: msg.channel_id.to_string(),
+                        counterparty_version: msg.counterparty_version,
+                        counterparty_channel_id: msg.counterparty_channel_id.to_string(),
+                        proof_try: msg.proof_try.encode(),
+                        proof_height: Some(msg.proof_height.into_height().into()),
+                        signer: signer.to_string(),
+                    })
+                }
+                Msg::ChannelOpenConfirm(MsgChannelOpenConfirmData { msg, __marker }) => {
+                    mk_any(&protos::ibc::core::channel::v1::MsgChannelOpenConfirm {
+                        port_id: msg.port_id.to_string(),
+                        channel_id: msg.channel_id.to_string(),
+                        proof_height: Some(msg.proof_height.into_height().into()),
+                        signer: signer.to_string(),
+                        proof_ack: msg.proof_ack.encode(),
+                    })
+                }
+                Msg::RecvPacket(MsgRecvPacketData { msg, __marker }) => {
+                    mk_any(&protos::ibc::core::channel::v1::MsgRecvPacket {
+                        packet: Some(msg.packet.into()),
+                        proof_height: Some(msg.proof_height.into_height().into()),
+                        signer: signer.to_string(),
+                        proof_commitment: msg.proof_commitment.encode(),
+                    })
+                }
+                Msg::AckPacket(MsgAckPacketData { msg, __marker }) => {
+                    mk_any(&protos::ibc::core::channel::v1::MsgAcknowledgement {
+                        packet: Some(msg.packet.into()),
+                        acknowledgement: msg.acknowledgement,
+                        proof_acked: msg.proof_acked.encode(),
+                        proof_height: Some(msg.proof_height.into_height().into()),
+                        signer: signer.to_string(),
+                    })
+                }
+                Msg::CreateClient(MsgCreateClientData { msg, config }) => {
+                    let (client_state, consensus_state) =
+                        mk_create_client_states(config, msg.client_state, msg.consensus_state);
+
+                    mk_any(&protos::ibc::core::client::v1::MsgCreateClient {
+                        client_state: Some(client_state),
+                        consensus_state: Some(consensus_state),
+                        signer: signer.to_string(),
+                    })
+                }
+                Msg::UpdateClient(MsgUpdateClientData(msg)) => {
+                    mk_any(&protos::ibc::core::client::v1::MsgUpdateClient {
+                        signer: signer.to_string(),
+                        client_id: msg.client_id.to_string(),
+                        client_message: Some(mk_client_message(msg.client_message)),
+                    })
+                }
+            };
+
+            let tx_hash = hc.broadcast_tx_commit(signer, [msg_any]).await?;
+
+            tracing::info!("cosmos tx {:?} => {:?}", tx_hash, msg);
+
+            Ok(())
+        })
+        .await
+}
+
+impl<Hc, Tr> DoFetchState<Hc, Tr> for Hc
+where
+    Hc: CosmosSdkChainSealed + ChainExt<StateProof = MerkleProof>,
+    Tr: ChainExt,
+
+    Hc::Fetch<Tr>: From<FetchAbciQuery<Hc, Tr>>,
+
+    AnyLightClientIdentified<AnyFetch>: From<identified!(Fetch<Hc, Tr>)>,
+    AnyLightClientIdentified<AnyWait>: From<identified!(Wait<Hc, Tr>)>,
+    // required by fetch_abci_query, can be removed once that's been been removed
+    AnyLightClientIdentified<AnyData>: From<identified!(Data<Hc, Tr>)>,
+    Tr::SelfClientState: Decode<Proto>,
+    Tr::SelfConsensusState: Decode<Proto>,
+
+    Hc::StoredClientState<Tr>: Decode<Proto>,
+    Hc::StoredConsensusState<Tr>: Decode<Proto>,
+
+    Identified<Hc, Tr, IbcState<ClientStatePath<Hc::ClientId>, Hc, Tr>>: IsAggregateData,
+{
+    fn state(hc: &Hc, at: HeightOf<Hc>, path: PathOf<Hc, Tr>) -> QueueMsg<RelayerMsgTypes> {
+        seq([
+            wait(id(
+                hc.chain_id(),
+                WaitForBlock {
+                    // height: at.increment(),
+                    height: at,
+                    __marker: PhantomData,
+                },
+            )),
+            fetch(id::<Hc, Tr, _>(
+                hc.chain_id(),
+                Fetch::specific(FetchAbciQuery {
+                    path,
+                    height: at,
+                    ty: AbciQueryType::State,
+                }),
+            )),
+        ])
+    }
+
+    async fn query_client_state(
+        hc: &Hc,
+        client_id: Hc::ClientId,
+        height: Hc::Height,
+    ) -> Hc::StoredClientState<Tr> {
+        let QueueMsg::Data(relayer_msg) = fetch_abci_query::<Hc, Tr>(
+            hc,
+            ClientStatePath { client_id }.into(),
+            height,
+            AbciQueryType::State,
+        )
+        .await
+        else {
+            panic!()
+        };
+
+        Identified::<Hc, Tr, IbcState<ClientStatePath<Hc::ClientId>, Hc, Tr>>::try_from(relayer_msg)
+            .unwrap()
+            .t
+            .state
+    }
+}
+
+impl<Hc, Tr> DoFetchProof<Hc, Tr> for Hc
+where
+    Hc: ChainExt + CosmosSdkChainSealed,
+    Tr: ChainExt,
+    Hc::Fetch<Tr>: From<FetchAbciQuery<Hc, Tr>>,
+    AnyLightClientIdentified<AnyFetch>: From<identified!(Fetch<Hc, Tr>)>,
+    AnyLightClientIdentified<AnyWait>: From<identified!(Wait<Hc, Tr>)>,
+{
+    fn proof(hc: &Hc, at: HeightOf<Hc>, path: PathOf<Hc, Tr>) -> QueueMsg<RelayerMsgTypes> {
+        seq([
+            wait(id(
+                hc.chain_id(),
+                WaitForBlock {
+                    height: at,
+                    __marker: PhantomData,
+                },
+            )),
+            fetch(id::<Hc, Tr, _>(
+                hc.chain_id(),
+                Fetch::specific(FetchAbciQuery::<Hc, Tr> {
+                    path,
+                    height: at,
+                    ty: AbciQueryType::Proof,
+                }),
+            )),
+        ])
+    }
+}
 
 pub async fn fetch_abci_query<Hc, Tr>(
     c: &Hc,
@@ -589,5 +861,166 @@ pub mod tendermint_helpers {
         height: ::tendermint::block::Height,
     ) -> BoundedI64<0, { i64::MAX }> {
         i64::from(height).try_into().unwrap()
+    }
+}
+
+pub mod wasm {
+    use chain_utils::{
+        cosmos::Cosmos,
+        cosmos_sdk::{BroadcastTxCommitError, CosmosSdkChain},
+        union::Union,
+        wasm::Wasm,
+    };
+    use queue_msg::QueueMsg;
+    use serde::{Deserialize, Serialize};
+    use unionlabs::{
+        encoding::{Encode, Proto},
+        google::protobuf::any::{Any, IntoAny},
+        hash::H256,
+        ibc::lightclients::wasm,
+        traits::{ClientState, ClientStateOf, ConsensusStateOf, HeaderOf},
+        TypeUrl,
+    };
+
+    use crate::{
+        chain_impls::{
+            cosmos::{CosmosAggregateMsg, CosmosDataMsg, CosmosFetch},
+            cosmos_sdk::{
+                data::{TrustedCommit, TrustedValidators, UntrustedCommit, UntrustedValidators},
+                do_msg, CosmosSdkChainSealed,
+            },
+            union::{ProveResponse, UnionAggregateMsg, UnionDataMsg, UnionFetch},
+        },
+        fetch::FetchUpdateHeaders,
+        msg::Msg,
+        ChainExt, DoFetchUpdateHeaders, DoMsg, RelayerMsgTypes,
+    };
+
+    impl ChainExt for Wasm<Union> {
+        type Data<Tr: ChainExt> = UnionDataMsg<Wasm<Union>, Tr>;
+        type Fetch<Tr: ChainExt> = UnionFetch<Wasm<Union>, Tr>;
+        type Aggregate<Tr: ChainExt> = UnionAggregateMsg<Wasm<Union>, Tr>;
+
+        type MsgError = BroadcastTxCommitError;
+
+        type Config = WasmConfig;
+    }
+
+    const _: () = {
+        try_from_relayer_msg! {
+            chain = Wasm<Union>,
+            generics = (Tr: ChainExt),
+            msgs = UnionDataMsg(
+                UntrustedCommit(UntrustedCommit<Wasm<Union>, Tr>),
+                TrustedValidators(TrustedValidators<Wasm<Union>, Tr>),
+                UntrustedValidators(UntrustedValidators<Wasm<Union>, Tr>),
+                ProveResponse(ProveResponse<Wasm<Union>, Tr>),
+            ),
+        }
+    };
+
+    impl ChainExt for Wasm<Cosmos> {
+        type Data<Tr: ChainExt> = CosmosDataMsg<Wasm<Cosmos>, Tr>;
+        type Fetch<Tr: ChainExt> = CosmosFetch<Wasm<Cosmos>, Tr>;
+        type Aggregate<Tr: ChainExt> = CosmosAggregateMsg<Wasm<Cosmos>, Tr>;
+
+        type MsgError = BroadcastTxCommitError;
+
+        type Config = WasmConfig;
+    }
+
+    const _: () = {
+        try_from_relayer_msg! {
+            chain = Wasm<Cosmos>,
+            generics = (Tr: ChainExt),
+            msgs = CosmosDataMsg(
+                TrustedCommit(TrustedCommit<Wasm<Cosmos>, Tr>),
+                UntrustedCommit(UntrustedCommit<Wasm<Cosmos>, Tr>),
+                TrustedValidators(TrustedValidators<Wasm<Cosmos>, Tr>),
+                UntrustedValidators(UntrustedValidators<Wasm<Cosmos>, Tr>),
+            ),
+        }
+    };
+
+    impl<Hc> CosmosSdkChainSealed for Wasm<Hc>
+    where
+        Wasm<Hc>: ChainExt,
+        Hc: CosmosSdkChainSealed,
+    {
+    }
+
+    #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+    #[serde(deny_unknown_fields)]
+    #[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
+    pub struct WasmConfig {
+        pub checksum: H256,
+        // pub inner: T,
+    }
+
+    impl<Hc, Tr> DoFetchUpdateHeaders<Self, Tr> for Wasm<Hc>
+    where
+        Wasm<Hc>: ChainExt,
+        Hc: ChainExt + CosmosSdkChain + DoFetchUpdateHeaders<Self, Tr>,
+        Tr: ChainExt,
+    {
+        fn fetch_update_headers(
+            hc: &Self,
+            update_info: FetchUpdateHeaders<Self, Tr>,
+        ) -> QueueMsg<RelayerMsgTypes> {
+            Hc::fetch_update_headers(
+                hc,
+                FetchUpdateHeaders {
+                    counterparty_chain_id: update_info.counterparty_chain_id,
+                    counterparty_client_id: update_info.counterparty_client_id,
+                    update_from: update_info.update_from,
+                    update_to: update_info.update_to,
+                },
+            )
+        }
+    }
+
+    impl<Hc, Tr> DoMsg<Wasm<Hc>, Tr> for Wasm<Hc>
+    where
+        Wasm<Hc>: ChainExt<MsgError = BroadcastTxCommitError, Config = WasmConfig>,
+        Hc: CosmosSdkChainSealed<MsgError = BroadcastTxCommitError>,
+        Tr: ChainExt,
+
+        ConsensusStateOf<Tr>: Encode<Proto> + TypeUrl,
+        ClientStateOf<Tr>: Encode<Proto> + TypeUrl,
+        HeaderOf<Tr>: Encode<Proto> + TypeUrl,
+
+        ConsensusStateOf<Wasm<Hc>>: Encode<Proto> + TypeUrl,
+        ClientStateOf<Wasm<Hc>>: Encode<Proto> + TypeUrl,
+
+        Tr::StoredClientState<Wasm<Hc>>: IntoAny,
+        Tr::StateProof: Encode<Proto>,
+    {
+        async fn msg(&self, msg: Msg<Wasm<Hc>, Tr>) -> Result<(), Self::MsgError> {
+            do_msg(
+                self,
+                msg,
+                |config, client_state, consensus_state| {
+                    (
+                        Any(wasm::client_state::ClientState {
+                            latest_height: client_state.height().into(),
+                            data: client_state,
+                            checksum: config.checksum,
+                        })
+                        .into(),
+                        Any(wasm::consensus_state::ConsensusState {
+                            data: consensus_state,
+                        })
+                        .into(),
+                    )
+                },
+                |client_message| {
+                    Any(wasm::client_message::ClientMessage {
+                        data: client_message,
+                    })
+                    .into()
+                },
+            )
+            .await
+        }
     }
 }

--- a/lib/relay-message/src/chain_impls/ethereum.rs
+++ b/lib/relay-message/src/chain_impls/ethereum.rs
@@ -403,7 +403,7 @@ where
     }
 }
 
-impl<C: ChainSpec, Tr: ChainExt> DoFetch<Ethereum<C>> for EthereumFetchMsg<C, Tr>
+impl<C: ChainSpec, Tr: ChainExt> DoFetch<Ethereum<C>, Tr> for EthereumFetchMsg<C, Tr>
 where
     AnyLightClientIdentified<AnyData>: From<identified!(Data<Ethereum<C>, Tr>)>,
 

--- a/lib/relay-message/src/chain_impls/union.rs
+++ b/lib/relay-message/src/chain_impls/union.rs
@@ -4,7 +4,7 @@ use std::{
 };
 
 use chain_utils::{
-    cosmos_sdk::{BroadcastTxCommitError, CosmosSdkChain, CosmosSdkChainExt},
+    cosmos_sdk::{BroadcastTxCommitError, CosmosSdkChain},
     union::Union,
     wasm::Wraps,
 };
@@ -12,10 +12,7 @@ use frame_support_procedural::{CloneNoBound, DebugNoBound, PartialEqNoBound};
 use frunk::{hlist_pat, HList};
 use macros::apply;
 use num_bigint::BigUint;
-use protos::{
-    ibc::core::connection::v1::MsgConnectionOpenInit,
-    union::galois::api::v2::union_prover_api_client,
-};
+use protos::union::galois::api::v2::union_prover_api_client;
 use queue_msg::{
     aggregate,
     aggregation::{do_aggregate, UseAggregate},
@@ -26,12 +23,9 @@ use unionlabs::{
     bounded::BoundedI64,
     cometbls::types::canonical_vote::CanonicalVote,
     encoding::{Decode, Encode, Proto},
-    google::protobuf::any::{mk_any, Any},
+    google::protobuf::any::IntoAny,
     ibc::{
-        core::{
-            client::{height::IsHeight, msg_update_client::MsgUpdateClient},
-            commitment::merkle_proof::MerkleProof,
-        },
+        core::{client::msg_update_client::MsgUpdateClient, commitment::merkle_proof::MerkleProof},
         lightclients::cometbls,
     },
     proof::ClientStatePath,
@@ -43,7 +37,7 @@ use unionlabs::{
             simple_validator::SimpleValidator,
         },
     },
-    traits::{Chain, ClientStateOf, ConsensusStateOf, HeaderOf, HeightOf},
+    traits::{Chain, ClientStateOf, ConsensusStateOf, HeaderOf},
     union::galois::{
         poll_request::PollRequest,
         poll_response::{PollResponse, ProveRequestDone, ProveRequestFailed},
@@ -58,25 +52,22 @@ use crate::{
     aggregate::{Aggregate, AnyAggregate},
     chain_impls::cosmos_sdk::{
         data::{TrustedValidators, UntrustedCommit, UntrustedValidators},
+        do_msg,
         fetch::{
             fetch_trusted_validators, fetch_untrusted_commit, fetch_untrusted_validators,
-            AbciQueryType, FetchAbciQuery, FetchTrustedValidators, FetchUntrustedCommit,
-            FetchUntrustedValidators,
+            FetchAbciQuery, FetchTrustedValidators, FetchUntrustedCommit, FetchUntrustedValidators,
         },
-        fetch_abci_query,
+        fetch_abci_query, CosmosSdkChainSealed,
     },
     data::{AnyData, Data, IbcState},
     fetch::{AnyFetch, DoFetch, Fetch, FetchUpdateHeaders},
     id, identified,
-    msg::{
-        AnyMsg, Msg, MsgConnectionOpenAckData, MsgConnectionOpenInitData, MsgConnectionOpenTryData,
-        MsgUpdateClientData,
-    },
+    msg::{AnyMsg, Msg, MsgUpdateClientData},
     seq,
     use_aggregate::IsAggregateData,
     wait::{AnyWait, Wait, WaitForBlock},
-    AnyLightClientIdentified, ChainExt, DoAggregate, DoFetchProof, DoFetchState,
-    DoFetchUpdateHeaders, DoMsg, Identified, PathOf, RelayerMsgTypes, Wasm, WasmConfig,
+    AnyLightClientIdentified, ChainExt, DoAggregate, DoFetchUpdateHeaders, DoMsg, Identified,
+    RelayerMsgTypes,
 };
 
 impl ChainExt for Union {
@@ -89,259 +80,35 @@ impl ChainExt for Union {
     type Config = ();
 }
 
-impl ChainExt for Wasm<Union> {
-    type Data<Tr: ChainExt> = UnionDataMsg<Wasm<Union>, Tr>;
-    type Fetch<Tr: ChainExt> = UnionFetch<Wasm<Union>, Tr>;
-    type Aggregate<Tr: ChainExt> = UnionAggregateMsg<Wasm<Union>, Tr>;
+impl CosmosSdkChainSealed for Union {}
 
-    type MsgError = BroadcastTxCommitError;
-
-    type Config = WasmConfig;
-}
-
-// TODO: Deduplicate this implementation between union and cosmos, its literally just a copy-paste right now
-impl<Tr: ChainExt, Hc: ChainExt + Wraps<Self>> DoMsg<Hc, Tr> for Union
+impl<Tr> DoMsg<Union, Tr> for Union
 where
+    Tr: ChainExt,
+
     ConsensusStateOf<Tr>: Encode<Proto> + TypeUrl,
     ClientStateOf<Tr>: Encode<Proto> + TypeUrl,
     HeaderOf<Tr>: Encode<Proto> + TypeUrl,
 
-    ConsensusStateOf<Hc>: Encode<Proto> + TypeUrl,
+    ConsensusStateOf<Union>: Encode<Proto> + TypeUrl,
+    ClientStateOf<Union>: Encode<Proto> + TypeUrl,
 
-    ClientStateOf<Hc>: Encode<Proto> + TypeUrl,
-    // HeaderOf<Hc>: IntoProto,
-    // <HeaderOf<Hc> as Proto>::Proto: TypeUrl,
-    Tr::StoredClientState<Hc>: Into<protos::google::protobuf::Any>,
+    Tr::StoredClientState<Union>: IntoAny,
     Tr::StateProof: Encode<Proto>,
 {
-    async fn msg(&self, msg: Msg<Hc, Tr>) -> Result<(), BroadcastTxCommitError> {
-        self.signers
-            .with(|signer| async {
-                let msg_any = match msg.clone() {
-                    Msg::ConnectionOpenInit(MsgConnectionOpenInitData(data)) => {
-                        mk_any(&MsgConnectionOpenInit {
-                            client_id: data.client_id.to_string(),
-                            counterparty: Some(data.counterparty.into()),
-                            version: Some(data.version.into()),
-                            signer: signer.to_string(),
-                            delay_period: data.delay_period,
-                        })
-                    }
-                    Msg::ConnectionOpenTry(MsgConnectionOpenTryData(data)) =>
-                    {
-                        #[allow(deprecated)]
-                        mk_any(&protos::ibc::core::connection::v1::MsgConnectionOpenTry {
-                            client_id: data.client_id.to_string(),
-                            previous_connection_id: String::new(),
-                            client_state: Some(data.client_state.into()),
-                            counterparty: Some(data.counterparty.into()),
-                            delay_period: data.delay_period,
-                            counterparty_versions: data
-                                .counterparty_versions
-                                .into_iter()
-                                .map(Into::into)
-                                .collect(),
-                            proof_height: Some(data.proof_height.into_height().into()),
-                            proof_init: data.proof_init.encode(),
-                            proof_client: data.proof_client.encode(),
-                            proof_consensus: data.proof_consensus.encode(),
-                            consensus_height: Some(data.consensus_height.into_height().into()),
-                            signer: signer.to_string(),
-                            host_consensus_state_proof: vec![],
-                        })
-                    }
-                    Msg::ConnectionOpenAck(MsgConnectionOpenAckData(data)) => {
-                        mk_any(&protos::ibc::core::connection::v1::MsgConnectionOpenAck {
-                            client_state: Some(data.client_state.into()),
-                            proof_height: Some(data.proof_height.into_height().into()),
-                            proof_client: data.proof_client.encode(),
-                            proof_consensus: data.proof_consensus.encode(),
-                            consensus_height: Some(data.consensus_height.into_height().into()),
-                            signer: signer.to_string(),
-                            host_consensus_state_proof: vec![],
-                            connection_id: data.connection_id.to_string(),
-                            counterparty_connection_id: data.counterparty_connection_id.to_string(),
-                            version: Some(data.version.into()),
-                            proof_try: data.proof_try.encode(),
-                        })
-                    }
-                    Msg::ConnectionOpenConfirm(data) => mk_any(
-                        &protos::ibc::core::connection::v1::MsgConnectionOpenConfirm {
-                            connection_id: data.msg.connection_id.to_string(),
-                            proof_ack: data.msg.proof_ack.encode(),
-                            proof_height: Some(data.msg.proof_height.into_height().into()),
-                            signer: signer.to_string(),
-                        },
-                    ),
-                    Msg::ChannelOpenInit(data) => {
-                        mk_any(&protos::ibc::core::channel::v1::MsgChannelOpenInit {
-                            port_id: data.msg.port_id.to_string(),
-                            channel: Some(data.msg.channel.into()),
-                            signer: signer.to_string(),
-                        })
-                    }
-                    Msg::ChannelOpenTry(data) =>
-                    {
-                        #[allow(deprecated)]
-                        mk_any(&protos::ibc::core::channel::v1::MsgChannelOpenTry {
-                            port_id: data.msg.port_id.to_string(),
-                            channel: Some(data.msg.channel.into()),
-                            counterparty_version: data.msg.counterparty_version,
-                            proof_init: data.msg.proof_init.encode(),
-                            proof_height: Some(data.msg.proof_height.into()),
-                            previous_channel_id: String::new(),
-                            signer: signer.to_string(),
-                        })
-                    }
-                    Msg::ChannelOpenAck(data) => {
-                        mk_any(&protos::ibc::core::channel::v1::MsgChannelOpenAck {
-                            port_id: data.msg.port_id.to_string(),
-                            channel_id: data.msg.channel_id.to_string(),
-                            counterparty_version: data.msg.counterparty_version,
-                            counterparty_channel_id: data.msg.counterparty_channel_id.to_string(),
-                            proof_try: data.msg.proof_try.encode(),
-                            proof_height: Some(data.msg.proof_height.into_height().into()),
-                            signer: signer.to_string(),
-                        })
-                    }
-                    Msg::ChannelOpenConfirm(data) => {
-                        mk_any(&protos::ibc::core::channel::v1::MsgChannelOpenConfirm {
-                            port_id: data.msg.port_id.to_string(),
-                            channel_id: data.msg.channel_id.to_string(),
-                            proof_height: Some(data.msg.proof_height.into_height().into()),
-                            signer: signer.to_string(),
-                            proof_ack: data.msg.proof_ack.encode(),
-                        })
-                    }
-                    Msg::RecvPacket(data) => {
-                        mk_any(&protos::ibc::core::channel::v1::MsgRecvPacket {
-                            packet: Some(data.msg.packet.into()),
-                            proof_height: Some(data.msg.proof_height.into_height().into()),
-                            signer: signer.to_string(),
-                            proof_commitment: data.msg.proof_commitment.encode(),
-                        })
-                    }
-                    Msg::AckPacket(data) => {
-                        mk_any(&protos::ibc::core::channel::v1::MsgAcknowledgement {
-                            packet: Some(data.msg.packet.into()),
-                            acknowledgement: data.msg.acknowledgement,
-                            proof_acked: data.msg.proof_acked.encode(),
-                            proof_height: Some(data.msg.proof_height.into_height().into()),
-                            signer: signer.to_string(),
-                        })
-                    }
-                    Msg::CreateClient(data) => {
-                        mk_any(&protos::ibc::core::client::v1::MsgCreateClient {
-                            client_state: Some(Any(data.msg.client_state).into()),
-                            consensus_state: Some(Any(data.msg.consensus_state).into()),
-                            signer: signer.to_string(),
-                        })
-                    }
-                    Msg::UpdateClient(MsgUpdateClientData(data)) => {
-                        mk_any(&protos::ibc::core::client::v1::MsgUpdateClient {
-                            signer: signer.to_string(),
-                            client_id: data.client_id.to_string(),
-                            client_message: Some(Any(data.client_message).into()),
-                        })
-                    }
-                };
-
-                let tx_hash = self.broadcast_tx_commit(signer, [msg_any]).await?;
-
-                tracing::info!("cosmos tx {:?} => {:?}", tx_hash, msg);
-
-                Ok(())
-            })
-            .await
-    }
-}
-
-impl<
-        Tr: ChainExt,
-        Hc: ChainExt<StateProof = MerkleProof, Fetch<Tr> = UnionFetch<Hc, Tr>> + Wraps<Self>,
-    > DoFetchState<Hc, Tr> for Union
-where
-    AnyLightClientIdentified<AnyFetch>: From<identified!(Fetch<Hc, Tr>)>,
-    AnyLightClientIdentified<AnyWait>: From<identified!(Wait<Hc, Tr>)>,
-    // required by fetch_abci_query, can be removed once that's been been removed
-    AnyLightClientIdentified<AnyData>: From<identified!(Data<Hc, Tr>)>,
-    Tr::SelfClientState: Decode<Proto>,
-    Tr::SelfConsensusState: Decode<Proto>,
-
-    Hc::StoredClientState<Tr>: Decode<Proto>,
-    Hc::StoredConsensusState<Tr>: Decode<Proto>,
-
-    Identified<Hc, Tr, IbcState<ClientStatePath<Hc::ClientId>, Hc, Tr>>: IsAggregateData,
-{
-    fn state(hc: &Hc, at: HeightOf<Hc>, path: PathOf<Hc, Tr>) -> QueueMsg<RelayerMsgTypes> {
-        seq([
-            wait(id(
-                hc.chain_id(),
-                WaitForBlock {
-                    // height: at.increment(),
-                    height: at,
-                    __marker: PhantomData,
-                },
-            )),
-            fetch(id::<Hc, Tr, _>(
-                hc.chain_id(),
-                Fetch::specific(FetchAbciQuery {
-                    path,
-                    height: at,
-                    ty: AbciQueryType::State,
-                }),
-            )),
-        ])
-    }
-
-    async fn query_client_state(
-        hc: &Hc,
-        client_id: Hc::ClientId,
-        height: Hc::Height,
-    ) -> Hc::StoredClientState<Tr> {
-        let QueueMsg::Data(relayer_msg) = fetch_abci_query::<Hc, Tr>(
-            hc,
-            ClientStatePath { client_id }.into(),
-            height,
-            AbciQueryType::State,
+    async fn msg(&self, msg: Msg<Union, Tr>) -> Result<(), BroadcastTxCommitError> {
+        do_msg(
+            self,
+            msg,
+            |(), client_state, consensus_state| {
+                (
+                    client_state.into_any().into(),
+                    consensus_state.into_any().into(),
+                )
+            },
+            |client_message| client_message.into_any().into(),
         )
         .await
-        else {
-            panic!()
-        };
-
-        Identified::<Hc, Tr, IbcState<ClientStatePath<Hc::ClientId>, Hc, Tr>>::try_from(relayer_msg)
-            .unwrap()
-            .t
-            .state
-    }
-}
-
-impl<Tr: ChainExt, Hc: ChainExt<Fetch<Tr> = UnionFetch<Hc, Tr>> + Wraps<Self>> DoFetchProof<Hc, Tr>
-    for Union
-where
-    AnyLightClientIdentified<AnyFetch>: From<identified!(Fetch<Hc, Tr>)>,
-    AnyLightClientIdentified<AnyWait>: From<identified!(Wait<Hc, Tr>)>,
-{
-    fn proof(hc: &Hc, at: HeightOf<Hc>, path: PathOf<Hc, Tr>) -> QueueMsg<RelayerMsgTypes> {
-        seq([
-            wait(id(
-                hc.chain_id(),
-                WaitForBlock {
-                    // height: at.increment(),
-                    height: at,
-                    __marker: PhantomData,
-                },
-            )),
-            fetch(id::<Hc, Tr, _>(
-                hc.chain_id(),
-                Fetch::specific(FetchAbciQuery::<Hc, Tr> {
-                    path,
-                    height: at,
-                    ty: AbciQueryType::Proof,
-                }),
-            )),
-        ])
     }
 }
 
@@ -431,7 +198,7 @@ pub enum UnionDataMsg<Hc: ChainExt, Tr: ChainExt> {
     #[display(fmt = "UntrustedValidators")]
     UntrustedValidators(UntrustedValidators<Hc, Tr>),
     #[display(fmt = "ProveResponse")]
-    ProveResponse(ProveResponse<Tr>),
+    ProveResponse(ProveResponse<Hc, Tr>),
 }
 
 #[derive(
@@ -470,7 +237,7 @@ pub enum UnionFetch<Hc: ChainExt, Tr: ChainExt> {
     AbciQuery(FetchAbciQuery<Hc, Tr>),
 }
 
-impl<Hc, Tr> DoFetch<Hc> for UnionFetch<Hc, Tr>
+impl<Hc, Tr> DoFetch<Hc, Tr> for UnionFetch<Hc, Tr>
 where
     Hc: Wraps<Union>
         + CosmosSdkChain
@@ -590,7 +357,7 @@ where
     identified!(TrustedValidators<Hc, Tr>): IsAggregateData,
     identified!(UntrustedValidators<Hc, Tr>): IsAggregateData,
 
-    Identified<Hc, Tr, ProveResponse<Tr>>: IsAggregateData,
+    Identified<Hc, Tr, ProveResponse<Hc, Tr>>: IsAggregateData,
 
     identified!(AggregateProveRequest<Hc, Tr>): UseAggregate<RelayerMsgTypes>,
     identified!(AggregateHeader<Hc, Tr>): UseAggregate<RelayerMsgTypes>,
@@ -624,27 +391,14 @@ const _: () = {
             UntrustedCommit(UntrustedCommit<Union, Tr>),
             TrustedValidators(TrustedValidators<Union, Tr>),
             UntrustedValidators(UntrustedValidators<Union, Tr>),
-            ProveResponse(ProveResponse<Tr>),
-        ),
-    }
-};
-
-const _: () = {
-    try_from_relayer_msg! {
-        chain = Wasm<Union>,
-        generics = (Tr: ChainExt),
-        msgs = UnionDataMsg(
-            UntrustedCommit(UntrustedCommit<Wasm<Union>, Tr>),
-            TrustedValidators(TrustedValidators<Wasm<Union>, Tr>),
-            UntrustedValidators(UntrustedValidators<Wasm<Union>, Tr>),
-            ProveResponse(ProveResponse<Tr>),
+            ProveResponse(ProveResponse<Union, Tr>),
         ),
     }
 };
 
 #[apply(msg_struct)]
-#[cover(Tr)]
-pub struct ProveResponse<Tr: ChainExt> {
+#[cover(Hc, Tr)]
+pub struct ProveResponse<Hc: ChainExt, Tr: ChainExt> {
     pub prove_response: prove_response::ProveResponse,
 }
 
@@ -860,11 +614,11 @@ where
     Hc: ChainExt<Header = <Union as Chain>::Header>,
     Tr: ChainExt,
 
-    Identified<Hc, Tr, ProveResponse<Tr>>: IsAggregateData,
+    Identified<Hc, Tr, ProveResponse<Hc, Tr>>: IsAggregateData,
 
     AnyLightClientIdentified<AnyMsg>: From<identified!(Msg<Tr, Hc>)>,
 {
-    type AggregatedData = HList![Identified<Hc, Tr, ProveResponse<Tr>>];
+    type AggregatedData = HList![Identified<Hc, Tr, ProveResponse<Hc, Tr>>];
 
     fn aggregate(
         Identified {

--- a/lib/relay-message/src/fetch.rs
+++ b/lib/relay-message/src/fetch.rs
@@ -66,7 +66,7 @@ impl HandleFetch<RelayerMsgTypes> for AnyLightClientIdentified<AnyFetch> {
     }
 }
 
-pub trait DoFetch<Hc: ChainExt>: Sized + Debug + Clone + PartialEq {
+pub trait DoFetch<Hc: ChainExt, Tr: ChainExt>: Sized + Debug + Clone + PartialEq {
     fn do_fetch(c: &Hc, _: Self) -> impl Future<Output = QueueMsg<RelayerMsgTypes>>;
 }
 
@@ -152,7 +152,7 @@ pub struct LightClientSpecificFetch<Hc: ChainExt, Tr: ChainExt>(pub Hc::Fetch<Tr
 impl<Hc, Tr> Fetch<Hc, Tr>
 where
     Hc: ChainExt + DoFetchState<Hc, Tr> + DoFetchProof<Hc, Tr> + DoFetchUpdateHeaders<Hc, Tr>,
-    Hc::Fetch<Tr>: DoFetch<Hc>,
+    Hc::Fetch<Tr>: DoFetch<Hc, Tr>,
     Tr: ChainExt,
     AnyLightClientIdentified<AnyData>: From<identified!(Data<Hc, Tr>)>,
     AnyLightClientIdentified<AnyFetch>: From<identified!(Fetch<Hc, Tr>)>,

--- a/voyager/src/main.rs
+++ b/voyager/src/main.rs
@@ -333,13 +333,16 @@ mod tests {
     use relay_message::{
         aggregate::AggregateCreateClient,
         chain_impls::{
-            cosmos_sdk::fetch::{AbciQueryType, FetchAbciQuery},
+            cosmos_sdk::{
+                fetch::{AbciQueryType, FetchAbciQuery},
+                wasm::WasmConfig,
+            },
             ethereum::EthereumConfig,
         },
         event::IbcEvent,
         fetch::{FetchSelfClientState, FetchSelfConsensusState},
         msg::{MsgChannelOpenInitData, MsgConnectionOpenInitData},
-        RelayerMsgTypes, WasmConfig,
+        RelayerMsgTypes,
     };
     use unionlabs::{
         ethereum::config::Minimal,


### PR DESCRIPTION
- deduplicate more code between union/ cosmos/ wasm in `relay-message`
- clean up some unused/ unnecessary types in `relay-message` (`Wasm*Msg`)
- move the wasm impls from `relay-message/src/lib.rs` to `relay-message/src/chain_impls/cosmos_sdk.rs`
- add some static_assertions to `relay-message`
  - these are mostly for aid while refactoring, as voyager won't compile if these don't hold, but the error messages from these static assertions are much clearer than what you get elsewhere