### PR TITLE
fix(ci): auth nixbuild for scheduled link checker

### DIFF
--- a/.github/workflows/check-links.yml
+++ b/.github/workflows/check-links.yml
@@ -21,7 +21,6 @@ jobs:
     permissions:
       contents: read
       issues: write
-    if: github.event_name == 'schedule'
     steps:
       - uses: actions/checkout@v4
         with:


### PR DESCRIPTION
Passing example run: https://github.com/unionlabs/union/actions/runs/8443323394/job/23126682675