### PR TITLE
feat(voyager): remove display requirement from messages

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -598,7 +598,6 @@ dependencies = [
  "chain-utils",
  "contracts",
  "dashmap",
- "derive_more",
  "enumorph",
  "ethers",
  "frame-support-procedural",
@@ -4400,7 +4399,6 @@ name = "queue-msg"
 version = "0.1.0"
 dependencies = [
  "arbitrary",
- "derive_more",
  "either",
  "enumorph",
  "frame-support-procedural",
@@ -4618,7 +4616,6 @@ dependencies = [
  "chain-utils",
  "contracts",
  "dashmap",
- "derive_more",
  "enumorph",
  "ethers",
  "frame-support-procedural",
@@ -7071,7 +7068,6 @@ dependencies = [
  "arbitrary",
  "block-message",
  "chain-utils",
- "derive_more",
  "hex-literal",
  "queue-msg",
  "relay-message",

--- a/lib/block-message/Cargo.toml
+++ b/lib/block-message/Cargo.toml
@@ -15,7 +15,6 @@ beacon-api               = { workspace = true }
 chain-utils              = { workspace = true }
 contracts                = { workspace = true, features = ["providers"] }
 dashmap                  = { workspace = true }
-derive_more              = { workspace = true, features = ["display"] }
 enumorph                 = { workspace = true }
 ethers                   = { workspace = true, features = ["rustls", "ws"] }
 frame-support-procedural = { workspace = true }

--- a/lib/block-message/src/aggregate.rs
+++ b/lib/block-message/src/aggregate.rs
@@ -1,4 +1,4 @@
-use std::{collections::VecDeque, fmt::Display};
+use std::collections::VecDeque;
 
 use frunk::{hlist_pat, HList};
 use macros::apply;
@@ -22,17 +22,6 @@ pub enum Aggregate<C: ChainExt> {
     FetchBlockRange(AggregateFetchBlockRange<C>),
     #[serde(untagged)]
     ChainSpecific(ChainSpecificAggregate<C>),
-}
-
-impl<C: ChainExt> Display for Aggregate<C> {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        match self {
-            Aggregate::FetchBlockRange(fetch_block_range) => {
-                write!(f, "FetchBlockRange({}..)", fetch_block_range.from_height)
-            }
-            Aggregate::ChainSpecific(agg) => write!(f, "ChainSpecific({})", agg.0),
-        }
-    }
 }
 
 impl HandleAggregate<BlockMessageTypes> for AnyChainIdentified<AnyAggregate> {

--- a/lib/block-message/src/chain_impls/cosmos_sdk.rs
+++ b/lib/block-message/src/chain_impls/cosmos_sdk.rs
@@ -314,15 +314,7 @@ where
     }
 }
 
-#[derive(
-    DebugNoBound,
-    CloneNoBound,
-    PartialEqNoBound,
-    Serialize,
-    Deserialize,
-    derive_more::Display,
-    Enumorph,
-)]
+#[derive(DebugNoBound, CloneNoBound, PartialEqNoBound, Serialize, Deserialize, Enumorph)]
 #[cfg_attr(
     feature = "arbitrary",
     derive(arbitrary::Arbitrary),
@@ -336,7 +328,6 @@ where
     deny_unknown_fields
 )]
 pub enum CosmosSdkData<C: CosmosSdkChainSealed> {
-    #[display(fmt = "ClientType")]
     ClientType(ClientType<C>),
 }
 
@@ -358,19 +349,11 @@ pub struct ClientType<#[cover] C: CosmosSdkChainSealed> {
 
 // FETCH
 
-#[derive(
-    DebugNoBound,
-    CloneNoBound,
-    PartialEqNoBound,
-    Serialize,
-    Deserialize,
-    derive_more::Display,
-    Enumorph,
-)]
+#[derive(DebugNoBound, CloneNoBound, PartialEqNoBound, Serialize, Deserialize, Enumorph)]
 #[cfg_attr(
     feature = "arbitrary",
     derive(arbitrary::Arbitrary),
-    arbitrary(bound = "C: CosmosSdkChainSealed")
+    arbitrary(bound = "")
 )]
 #[serde(
     tag = "@type",
@@ -380,13 +363,9 @@ pub struct ClientType<#[cover] C: CosmosSdkChainSealed> {
     deny_unknown_fields
 )]
 pub enum CosmosSdkFetch<C: CosmosSdkChainSealed> {
-    #[display(fmt = "FetchBlocks({}..{})", "_0.from_height", "_0.to_height")]
     FetchBlocks(FetchBlocks<C>),
-    #[display(fmt = "FetchTransactions({}, {})", "_0.height", "_0.page")]
     FetchTransactions(FetchTransactions<C>),
-    #[display(fmt = "ClientTypeFromConnectionId({})", "_0.connection_id")]
     FetchClientTypeFromConnectionId(ClientTypeFromConnectionId),
-    #[display(fmt = "ClientTypeFromClientId({})", "_0.client_id")]
     FetchClientTypeFromClientId(ClientTypeFromClientId<C>),
 }
 
@@ -412,15 +391,7 @@ pub struct ClientTypeFromClientId<C: CosmosSdkChain> {
     pub client_id: C::ClientId,
 }
 
-#[derive(
-    DebugNoBound,
-    CloneNoBound,
-    PartialEqNoBound,
-    Serialize,
-    Deserialize,
-    derive_more::Display,
-    Enumorph,
-)]
+#[derive(DebugNoBound, CloneNoBound, PartialEqNoBound, Serialize, Deserialize, Enumorph)]
 #[cfg_attr(
     feature = "arbitrary",
     derive(arbitrary::Arbitrary),
@@ -434,7 +405,6 @@ pub struct ClientTypeFromClientId<C: CosmosSdkChain> {
     deny_unknown_fields
 )]
 pub enum CosmosSdkAggregate<C: CosmosSdkChain> {
-    #[display(fmt = "AggregateEventWithClientType")]
     AggregateEventWithClientType(AggregateEventWithClientType<C>),
 }
 

--- a/lib/block-message/src/chain_impls/ethereum.rs
+++ b/lib/block-message/src/chain_impls/ethereum.rs
@@ -551,15 +551,7 @@ where
     )
 }
 
-#[derive(
-    DebugNoBound,
-    CloneNoBound,
-    PartialEqNoBound,
-    Serialize,
-    Deserialize,
-    derive_more::Display,
-    Enumorph,
-)]
+#[derive(DebugNoBound, CloneNoBound, PartialEqNoBound, Serialize, Deserialize, Enumorph)]
 #[cfg_attr(
     feature = "arbitrary",
     derive(arbitrary::Arbitrary),
@@ -573,16 +565,11 @@ where
     deny_unknown_fields
 )]
 pub enum EthereumFetch<C: ChainSpec> {
-    #[display(fmt = "FetchEvents")]
     FetchEvents(FetchEvents<C>),
-    #[display(fmt = "FetchGetLogs")]
     FetchGetLogs(FetchGetLogs),
-    #[display(fmt = "FetchBeaconBlockRange")]
     FetchBeaconBlockRange(FetchBeaconBlockRange),
 
-    #[display(fmt = "FetchChannel")]
     FetchChannel(FetchChannel<Ethereum<C>>),
-    #[display(fmt = "FetchConnection")]
     FetchConnection(FetchConnection<Ethereum<C>>),
 }
 
@@ -618,15 +605,7 @@ pub struct FetchConnection<Hc: EthereumChainExt> {
     pub path: ConnectionPath,
 }
 
-#[derive(
-    DebugNoBound,
-    CloneNoBound,
-    PartialEqNoBound,
-    Serialize,
-    Deserialize,
-    derive_more::Display,
-    Enumorph,
-)]
+#[derive(DebugNoBound, CloneNoBound, PartialEqNoBound, Serialize, Deserialize, Enumorph)]
 #[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 #[serde(
     tag = "@type",
@@ -636,9 +615,7 @@ pub struct FetchConnection<Hc: EthereumChainExt> {
     deny_unknown_fields
 )]
 pub enum EthereumAggregate<C: ChainSpec> {
-    #[display(fmt = "AggregateWithChannel")]
     AggregateWithChannel(AggregateWithChannel<Ethereum<C>>),
-    #[display(fmt = "AggregateWithChannel")]
     AggregateWithConnection(AggregateWithConnection<Ethereum<C>>),
 }
 
@@ -990,15 +967,7 @@ where
     }
 }
 
-#[derive(
-    DebugNoBound,
-    CloneNoBound,
-    PartialEqNoBound,
-    Serialize,
-    Deserialize,
-    derive_more::Display,
-    Enumorph,
-)]
+#[derive(DebugNoBound, CloneNoBound, PartialEqNoBound, Serialize, Deserialize, Enumorph)]
 #[cfg_attr(
     feature = "arbitrary",
     derive(arbitrary::Arbitrary),
@@ -1012,9 +981,7 @@ where
     deny_unknown_fields
 )]
 pub enum EthereumData<C: ChainSpec> {
-    #[display(fmt = "Channel")]
     Channel(ChannelData<Ethereum<C>>),
-    #[display(fmt = "Connection")]
     Connection(ConnectionData<Ethereum<C>>),
 }
 

--- a/lib/block-message/src/chain_impls/scroll.rs
+++ b/lib/block-message/src/chain_impls/scroll.rs
@@ -183,28 +183,15 @@ where
     }
 }
 
-#[derive(
-    DebugNoBound,
-    CloneNoBound,
-    PartialEqNoBound,
-    Serialize,
-    Deserialize,
-    derive_more::Display,
-    Enumorph,
-)]
+#[derive(DebugNoBound, CloneNoBound, PartialEqNoBound, Serialize, Deserialize, Enumorph)]
 #[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 #[serde(deny_unknown_fields)]
 pub enum ScrollFetch {
-    #[display(fmt = "FetchEvents")]
     FetchEvents(FetchEvents<Mainnet>),
-    #[display(fmt = "FetchGetLogs({}..{})", "_0.from_slot", "_0.to_slot")]
     FetchGetLogs(FetchGetLogs),
-    #[display(fmt = "FetchBeaconBlockRange")]
     FetchBeaconBlockRange(FetchBeaconBlockRange),
 
-    #[display(fmt = "FetchChannel")]
     FetchChannel(FetchChannel<Scroll>),
-    #[display(fmt = "FetchConnection")]
     FetchConnection(FetchConnection<Scroll>),
 }
 
@@ -217,13 +204,7 @@ pub struct FetchBatchIndex {
 }
 
 #[derive(
-    DebugNoBound,
-    CloneNoBound,
-    PartialEqNoBound,
-    Serialize,
-    Deserialize,
-    derive_more::Display,
-    enumorph::Enumorph,
+    DebugNoBound, CloneNoBound, PartialEqNoBound, Serialize, Deserialize, enumorph::Enumorph,
 )]
 #[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 #[serde(
@@ -234,9 +215,7 @@ pub struct FetchBatchIndex {
     deny_unknown_fields
 )]
 pub enum ScrollAggregate {
-    #[display(fmt = "AggregateWithChannel")]
     AggregateWithChannel(AggregateWithChannel<Scroll>),
-    #[display(fmt = "AggregateWithChannel")]
     AggregateWithConnection(AggregateWithConnection<Scroll>),
 }
 
@@ -258,21 +237,11 @@ where
     }
 }
 
-#[derive(
-    DebugNoBound,
-    CloneNoBound,
-    PartialEqNoBound,
-    Serialize,
-    Deserialize,
-    derive_more::Display,
-    Enumorph,
-)]
+#[derive(DebugNoBound, CloneNoBound, PartialEqNoBound, Serialize, Deserialize, Enumorph)]
 #[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 #[serde(deny_unknown_fields)]
 pub enum ScrollData {
-    #[display(fmt = "Channel")]
     Channel(ChannelData<Scroll>),
-    #[display(fmt = "Connection")]
     Connection(ConnectionData<Scroll>),
 }
 

--- a/lib/block-message/src/data.rs
+++ b/lib/block-message/src/data.rs
@@ -1,5 +1,3 @@
-use std::fmt::Display;
-
 use macros::apply;
 use queue_msg::{data, queue_msg, HandleData, QueueError, QueueMsg, QueueMsgTypes};
 use unionlabs::{events::IbcEvent, hash::H256, ClientType};
@@ -24,16 +22,6 @@ impl HandleData<BlockMessageTypes> for AnyChainIdentified<AnyData> {
         _store: &<BlockMessageTypes as QueueMsgTypes>::Store,
     ) -> Result<QueueMsg<BlockMessageTypes>, QueueError> {
         Ok(data(self))
-    }
-}
-
-impl<C: ChainExt> Display for Data<C> {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        match self {
-            Data::IbcEvent(event) => write!(f, "IbcEvent({})", event.event.name()),
-            Data::LatestHeight(lh) => write!(f, "LatestHeight({})", lh.0),
-            Data::ChainSpecific(cs) => write!(f, "{}", cs.0),
-        }
     }
 }
 

--- a/lib/block-message/src/fetch.rs
+++ b/lib/block-message/src/fetch.rs
@@ -1,4 +1,4 @@
-use std::fmt::{Debug, Display};
+use std::fmt::Debug;
 
 use chain_utils::GetChain;
 use futures::Future;
@@ -24,18 +24,6 @@ pub enum Fetch<C: ChainExt> {
 
     #[serde(untagged)]
     ChainSpecific(ChainSpecificFetch<C>),
-}
-
-impl<C: ChainExt> Display for Fetch<C> {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        match self {
-            Fetch::FetchBlock(fb) => write!(f, "FetchBlock({})", fb.height),
-            Fetch::FetchBlockRange(fbr) => {
-                write!(f, "FetchBlockRange({}..{})", fbr.from_height, fbr.to_height)
-            }
-            Fetch::ChainSpecific(cs) => write!(f, "{}", cs.0),
-        }
-    }
 }
 
 impl HandleFetch<BlockMessageTypes> for AnyChainIdentified<AnyFetch> {

--- a/lib/block-message/src/lib.rs
+++ b/lib/block-message/src/lib.rs
@@ -1,9 +1,6 @@
 #![feature(trait_alias)]
 
-use std::{
-    collections::VecDeque,
-    fmt::{Debug, Display},
-};
+use std::{collections::VecDeque, fmt::Debug};
 
 use chain_utils::{cosmos::Cosmos, ethereum::Ethereum, scroll::Scroll, union::Union, Chains};
 use frame_support_procedural::{CloneNoBound, DebugNoBound, PartialEqNoBound};
@@ -45,13 +42,7 @@ impl QueueMsgTypes for BlockMessageTypes {
 }
 
 #[derive(
-    DebugNoBound,
-    CloneNoBound,
-    PartialEqNoBound,
-    Serialize,
-    Deserialize,
-    derive_more::Display,
-    enumorph::Enumorph,
+    DebugNoBound, CloneNoBound, PartialEqNoBound, Serialize, Deserialize, enumorph::Enumorph,
 )]
 #[cfg_attr(
     feature = "arbitrary",
@@ -74,7 +65,6 @@ pub enum AnyChainIdentified<T: AnyChain> {
 
 pub trait AnyChain {
     type Inner<C: ChainExt>: Debug
-        + Display
         + Clone
         + PartialEq
         + Serialize
@@ -113,14 +103,6 @@ pub fn id<C: Chain, T: Debug + Clone + PartialEq>(
     t: T,
 ) -> Identified<C, T> {
     Identified::new(chain_id, t)
-}
-
-impl<C: Chain, Data: std::fmt::Display + Debug + Clone + PartialEq> std::fmt::Display
-    for Identified<C, Data>
-{
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(f, "{{{}: {}}}", self.chain_id, self.t)
-    }
 }
 
 macro_rules! any_enum {

--- a/lib/block-message/src/wait.rs
+++ b/lib/block-message/src/wait.rs
@@ -1,5 +1,3 @@
-use std::fmt::Display;
-
 use chain_utils::{Chains, GetChain};
 use macros::apply;
 use queue_msg::{
@@ -53,14 +51,6 @@ where
                     ])
                 }
             }
-        }
-    }
-}
-
-impl<C: ChainExt> Display for Wait<C> {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        match self {
-            Wait::Height(h) => write!(f, "Height({})", h.height),
         }
     }
 }

--- a/lib/queue-msg/Cargo.toml
+++ b/lib/queue-msg/Cargo.toml
@@ -22,8 +22,7 @@ tracing                  = { workspace = true }
 unionlabs                = { workspace = true }
 
 [dev-dependencies]
-derive_more = { workspace = true, features = ["display"] }
-enumorph    = "0.1.2"
+enumorph = "0.1.2"
 
 [features]
 default = []

--- a/lib/relay-message/Cargo.toml
+++ b/lib/relay-message/Cargo.toml
@@ -14,7 +14,6 @@ beacon-api               = { workspace = true }
 chain-utils              = { workspace = true }
 contracts                = { workspace = true, features = ["providers"] }
 dashmap                  = { workspace = true }
-derive_more              = { workspace = true, features = ["display"] }
 enumorph                 = { workspace = true }
 ethers                   = { workspace = true, features = ["rustls", "ws"] }
 frame-support-procedural = { workspace = true }

--- a/lib/relay-message/src/aggregate.rs
+++ b/lib/relay-message/src/aggregate.rs
@@ -1,4 +1,4 @@
-use std::{collections::VecDeque, fmt::Display, marker::PhantomData};
+use std::{collections::VecDeque, marker::PhantomData};
 
 use frame_support_procedural::{CloneNoBound, DebugNoBound, PartialEqNoBound};
 use frunk::{hlist_pat, HList};
@@ -195,66 +195,6 @@ impl<Hc: ChainExt, Tr: ChainExt> identified!(Aggregate<Hc, Tr>) {
             Aggregate::AckPacket(ack_packet) => do_aggregate(id(chain_id, ack_packet), data),
             Aggregate::WaitForTrustedHeight(agg) => do_aggregate(id(chain_id, agg), data),
             Aggregate::FetchCounterpartyStateproof(agg) => do_aggregate(id(chain_id, agg), data),
-        }
-    }
-}
-
-impl<Hc: ChainExt, Tr: ChainExt> Display for Aggregate<Hc, Tr> {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        match self {
-            Aggregate::ConnectionOpenTry(_) => write!(f, "ConnectionOpenTry"),
-            Aggregate::ConnectionOpenAck(_) => write!(f, "ConnectionOpenAck"),
-            Aggregate::ConnectionOpenConfirm(_) => write!(f, "ConnectionOpenConfirm"),
-            Aggregate::ChannelOpenTry(_) => write!(f, "ChannelOpenTry"),
-            Aggregate::ChannelOpenAck(_) => write!(f, "ChannelOpenAck"),
-            Aggregate::ChannelOpenConfirm(_) => write!(f, "ChannelOpenConfirm"),
-            Aggregate::RecvPacket(_) => write!(f, "RecvPacket"),
-            Aggregate::AckPacket(_) => write!(f, "AckPacket"),
-            Aggregate::ConnectionFetchFromChannelEnd(_) => {
-                write!(f, "ConnectionFetchFromChannelEnd")
-            }
-            Aggregate::ChannelHandshakeMsgAfterUpdate(_) => {
-                write!(f, "ChannelHandshakeUpdateClient")
-            }
-            Aggregate::PacketUpdateClient(msg) => {
-                write!(
-                    f,
-                    "PacketUpdateClient::{}",
-                    match msg.packet_event {
-                        PacketEvent::Send(_) => "Send",
-                        PacketEvent::Recv(_) => "Recv",
-                    }
-                )
-            }
-            Aggregate::WaitForTrustedHeight(_) => write!(f, "WaitForTrustedHeight"),
-            Aggregate::FetchCounterpartyStateproof(_) => {
-                write!(f, "FetchCounterpartyStateproof")
-            }
-            Aggregate::UpdateClient(_) => write!(f, "UpdateClient"),
-            Aggregate::UpdateClientFromHeight(_) => write!(f, "UpdateClientFromHeight"),
-            Aggregate::CreateClient(_) => write!(f, "CreateClient"),
-            Aggregate::AggregateMsgAfterUpdate(msg) => {
-                write!(f, "AggregateMsgAfterUpdate::")?;
-                match msg {
-                    AggregateMsgAfterUpdate::ConnectionOpenTry(_) => {
-                        write!(f, "ConnectionOpenTry")
-                    }
-                    AggregateMsgAfterUpdate::ConnectionOpenAck(_) => {
-                        write!(f, "ConnectionOpenAck")
-                    }
-                    AggregateMsgAfterUpdate::ConnectionOpenConfirm(_) => {
-                        write!(f, "ConnectionOpenConfirm")
-                    }
-                    AggregateMsgAfterUpdate::ChannelOpenTry(_) => write!(f, "ChannelOpenTry"),
-                    AggregateMsgAfterUpdate::ChannelOpenAck(_) => write!(f, "ChannelOpenAck"),
-                    AggregateMsgAfterUpdate::ChannelOpenConfirm(_) => {
-                        write!(f, "ChannelOpenConfirm")
-                    }
-                    AggregateMsgAfterUpdate::RecvPacket(_) => write!(f, "RecvPacket"),
-                    AggregateMsgAfterUpdate::AckPacket(_) => write!(f, "AckPacket"),
-                }
-            }
-            Aggregate::LightClientSpecific(agg) => write!(f, "LightClientSpecific({})", agg.0),
         }
     }
 }

--- a/lib/relay-message/src/chain_impls/cosmos.rs
+++ b/lib/relay-message/src/chain_impls/cosmos.rs
@@ -382,13 +382,7 @@ where
 }
 
 #[derive(
-    DebugNoBound,
-    CloneNoBound,
-    PartialEqNoBound,
-    Serialize,
-    Deserialize,
-    derive_more::Display,
-    enumorph::Enumorph,
+    DebugNoBound, CloneNoBound, PartialEqNoBound, Serialize, Deserialize, enumorph::Enumorph,
 )]
 #[serde(
     bound(serialize = "", deserialize = ""),
@@ -403,24 +397,14 @@ where
     arbitrary(bound = "Tr: ChainExt")
 )]
 pub enum CosmosDataMsg<Hc: ChainExt, Tr: ChainExt> {
-    #[display(fmt = "TrustedCommit")]
     TrustedCommit(TrustedCommit<Hc, Tr>),
-    #[display(fmt = "UntrustedCommit")]
     UntrustedCommit(UntrustedCommit<Hc, Tr>),
-    #[display(fmt = "TrustedValidators")]
     TrustedValidators(TrustedValidators<Hc, Tr>),
-    #[display(fmt = "UntrustedValidators")]
     UntrustedValidators(UntrustedValidators<Hc, Tr>),
 }
 
 #[derive(
-    DebugNoBound,
-    CloneNoBound,
-    PartialEqNoBound,
-    Serialize,
-    Deserialize,
-    derive_more::Display,
-    enumorph::Enumorph,
+    DebugNoBound, CloneNoBound, PartialEqNoBound, Serialize, Deserialize, enumorph::Enumorph,
 )]
 #[serde(
     bound(serialize = "", deserialize = ""),
@@ -435,15 +419,10 @@ pub enum CosmosDataMsg<Hc: ChainExt, Tr: ChainExt> {
     arbitrary(bound = "Hc: ChainExt, Tr: ChainExt")
 )]
 pub enum CosmosFetch<Hc: ChainExt, Tr: ChainExt> {
-    #[display(fmt = "FetchTrustedCommit")]
     FetchTrustedCommit(FetchTrustedCommit<Hc, Tr>),
-    #[display(fmt = "FetchUntrustedCommit")]
     FetchUntrustedCommit(FetchUntrustedCommit<Hc, Tr>),
-    #[display(fmt = "FetchTrustedValidators")]
     FetchTrustedValidators(FetchTrustedValidators<Hc, Tr>),
-    #[display(fmt = "FetchUntrustedValidators")]
     FetchUntrustedValidators(FetchUntrustedValidators<Hc, Tr>),
-    #[display(fmt = "FetchAbciQuery")]
     AbciQuery(FetchAbciQuery<Hc, Tr>),
 }
 
@@ -492,13 +471,7 @@ where
 }
 
 #[derive(
-    DebugNoBound,
-    CloneNoBound,
-    PartialEqNoBound,
-    Serialize,
-    Deserialize,
-    derive_more::Display,
-    enumorph::Enumorph,
+    DebugNoBound, CloneNoBound, PartialEqNoBound, Serialize, Deserialize, enumorph::Enumorph,
 )]
 #[serde(
     bound(serialize = "", deserialize = ""),
@@ -513,7 +486,6 @@ where
     arbitrary(bound = "Hc: ChainExt, Tr: ChainExt")
 )]
 pub enum CosmosAggregateMsg<Hc: ChainExt, Tr: ChainExt> {
-    #[display(fmt = "AggregateHeader")]
     AggregateHeader(AggregateHeader<Hc, Tr>),
 }
 

--- a/lib/relay-message/src/chain_impls/ethereum.rs
+++ b/lib/relay-message/src/chain_impls/ethereum.rs
@@ -765,13 +765,7 @@ try_from_relayer_msg! {
 }
 
 #[derive(
-    DebugNoBound,
-    CloneNoBound,
-    PartialEqNoBound,
-    Serialize,
-    Deserialize,
-    derive_more::Display,
-    enumorph::Enumorph,
+    DebugNoBound, CloneNoBound, PartialEqNoBound, Serialize, Deserialize, enumorph::Enumorph,
 )]
 #[serde(
     bound(serialize = "", deserialize = ""),
@@ -785,32 +779,18 @@ try_from_relayer_msg! {
     arbitrary(bound = "C: ChainSpec, Tr: ChainExt")
 )]
 pub enum EthereumFetchMsg<C: ChainSpec, Tr: ChainExt> {
-    #[display(fmt = "FinalityUpdate")]
     FetchFinalityUpdate(FetchFinalityUpdate),
-    #[display(fmt = "LightClientUpdates")]
     FetchLightClientUpdates(FetchLightClientUpdates),
-    #[display(fmt = "LightClientUpdate")]
     FetchLightClientUpdate(FetchLightClientUpdate),
-    #[display(fmt = "Bootstrap")]
     FetchBootstrap(FetchBootstrap),
-    #[display(fmt = "AccountUpdate")]
     FetchAccountUpdate(FetchAccountUpdate),
-    #[display(fmt = "BeaconGenesis")]
     FetchBeaconGenesis(FetchBeaconGenesis),
-    #[display(fmt = "GetProof::{}", "_0.path")]
     FetchGetProof(GetProof<Ethereum<C>, Tr>),
-    #[display(fmt = "IbcState::{}", "_0.path")]
     FetchIbcState(FetchIbcState<Ethereum<C>, Tr>),
 }
 
 #[derive(
-    DebugNoBound,
-    CloneNoBound,
-    PartialEqNoBound,
-    Serialize,
-    Deserialize,
-    derive_more::Display,
-    enumorph::Enumorph,
+    DebugNoBound, CloneNoBound, PartialEqNoBound, Serialize, Deserialize, enumorph::Enumorph,
 )]
 #[serde(
     bound(serialize = "", deserialize = ""),
@@ -825,28 +805,16 @@ pub enum EthereumFetchMsg<C: ChainSpec, Tr: ChainExt> {
 )]
 #[allow(clippy::large_enum_variant)]
 pub enum EthereumDataMsg<C: ChainSpec, Tr: ChainExt> {
-    #[display(fmt = "FinalityUpdate")]
     FinalityUpdate(FinalityUpdate<C, Tr>),
-    #[display(fmt = "LightClientUpdates")]
     LightClientUpdates(LightClientUpdates<C, Tr>),
-    #[display(fmt = "LightClientUpdate")]
     LightClientUpdate(LightClientUpdate<C, Tr>),
-    #[display(fmt = "Bootstrap")]
     Bootstrap(BootstrapData<C, Tr>),
-    #[display(fmt = "AccountUpdate")]
     AccountUpdate(AccountUpdateData<C, Tr>),
-    #[display(fmt = "BeaconGenesis")]
     BeaconGenesis(BeaconGenesisData<C, Tr>),
 }
 
 #[derive(
-    DebugNoBound,
-    CloneNoBound,
-    PartialEqNoBound,
-    Serialize,
-    Deserialize,
-    derive_more::Display,
-    enumorph::Enumorph,
+    DebugNoBound, CloneNoBound, PartialEqNoBound, Serialize, Deserialize, enumorph::Enumorph,
 )]
 #[serde(
     bound(serialize = "", deserialize = ""),
@@ -861,11 +829,8 @@ pub enum EthereumDataMsg<C: ChainSpec, Tr: ChainExt> {
 )]
 #[allow(clippy::large_enum_variant)]
 pub enum EthereumAggregateMsg<C: ChainSpec, Tr: ChainExt> {
-    #[display(fmt = "CreateUpdate")]
     CreateUpdate(CreateUpdateData<C, Tr>),
-    #[display(fmt = "MakeCreateUpdates")]
     MakeCreateUpdates(MakeCreateUpdatesData<C, Tr>),
-    #[display(fmt = "MakeCreateUpdatesFromLightClientUpdates")]
     MakeCreateUpdatesFromLightClientUpdates(MakeCreateUpdatesFromLightClientUpdatesData<C, Tr>),
 }
 

--- a/lib/relay-message/src/chain_impls/scroll.rs
+++ b/lib/relay-message/src/chain_impls/scroll.rs
@@ -369,15 +369,7 @@ where
     }
 }
 
-#[derive(
-    DebugNoBound,
-    CloneNoBound,
-    PartialEqNoBound,
-    Serialize,
-    Deserialize,
-    derive_more::Display,
-    Enumorph,
-)]
+#[derive(DebugNoBound, CloneNoBound, PartialEqNoBound, Serialize, Deserialize, Enumorph)]
 #[serde(
     bound(serialize = "", deserialize = ""),
     tag = "@type",
@@ -390,22 +382,16 @@ where
     arbitrary(bound = "")
 )]
 pub enum ScrollFetch<Tr: ChainExt> {
-    #[display(fmt = "GetProof::{}", "_0.path")]
     FetchGetProof(GetProof<Scroll, Tr>),
-    #[display(fmt = "IbcState::{}", "_0.path")]
     FetchIbcState(FetchIbcState<Scroll, Tr>),
 
     // - scroll rollup contract root proof
-    #[display(fmt = "FetchRollupContractRootProof")]
     FetchRollupContractRootProof(FetchRollupContractRootProof),
     // - scroll latest batch index proof against rollup contract
-    #[display(fmt = "FetchLatestBatchIndexProof")]
     FetchLatestBatchIndexProof(FetchLatestBatchIndexProof),
     // - scroll finalized root at batch index against rollup contract
-    #[display(fmt = "FetchScrollFinalizedRootProof")]
     FetchScrollFinalizedRootProof(FetchScrollFinalizedRootProof),
     // - ibc contract root against finalized root on L2
-    #[display(fmt = "FetchIbcContractRootProof")]
     FetchIbcContractRootProof(FetchIbcContractRootProof),
 }
 
@@ -439,15 +425,7 @@ pub struct FetchIbcContractRootProof {
     pub ibc_contract_address: H160,
 }
 
-#[derive(
-    DebugNoBound,
-    CloneNoBound,
-    PartialEqNoBound,
-    Serialize,
-    Deserialize,
-    derive_more::Display,
-    Enumorph,
-)]
+#[derive(DebugNoBound, CloneNoBound, PartialEqNoBound, Serialize, Deserialize, Enumorph)]
 #[serde(
     bound(serialize = "", deserialize = ""),
     tag = "@type",
@@ -460,13 +438,9 @@ pub struct FetchIbcContractRootProof {
     arbitrary(bound = "")
 )]
 pub enum ScrollData<Tr: ChainExt> {
-    #[display(fmt = "RollupContractRootProof")]
     RollupContractRootProof(RollupContractRootProof<Tr>),
-    #[display(fmt = "LatestBatchIndexProof")]
     LatestBatchIndexProof(LatestBatchIndexProof<Tr>),
-    #[display(fmt = "ScrollFinalizedRootProof")]
     ScrollFinalizedRootProof(ScrollFinalizedRootProof<Tr>),
-    #[display(fmt = "IbcContractRootProof")]
     IbcContractRootProof(IbcContractRootProof<Tr>),
 }
 
@@ -510,15 +484,7 @@ pub struct IbcContractRootProof<#[cover] Tr: ChainExt> {
     pub proof: AccountProof,
 }
 
-#[derive(
-    DebugNoBound,
-    CloneNoBound,
-    PartialEqNoBound,
-    Serialize,
-    Deserialize,
-    derive_more::Display,
-    Enumorph,
-)]
+#[derive(DebugNoBound, CloneNoBound, PartialEqNoBound, Serialize, Deserialize, Enumorph)]
 #[serde(
     bound(serialize = "", deserialize = ""),
     tag = "@type",
@@ -531,7 +497,6 @@ pub struct IbcContractRootProof<#[cover] Tr: ChainExt> {
     arbitrary(bound = "")
 )]
 pub enum ScrollAggregate<Tr: ChainExt> {
-    #[display(fmt = "AggregateHeader")]
     AggregateHeader(AggregateHeader<Tr>),
 }
 

--- a/lib/relay-message/src/chain_impls/union.rs
+++ b/lib/relay-message/src/chain_impls/union.rs
@@ -400,13 +400,7 @@ where
 }
 
 #[derive(
-    DebugNoBound,
-    CloneNoBound,
-    PartialEqNoBound,
-    Serialize,
-    Deserialize,
-    derive_more::Display,
-    enumorph::Enumorph,
+    DebugNoBound, CloneNoBound, PartialEqNoBound, Serialize, Deserialize, enumorph::Enumorph,
 )]
 #[serde(
     bound(serialize = "", deserialize = ""),
@@ -422,24 +416,14 @@ where
     arbitrary(bound = "Tr: ChainExt")
 )]
 pub enum UnionDataMsg<Hc: ChainExt, Tr: ChainExt> {
-    #[display(fmt = "UntrustedCommit")]
     UntrustedCommit(UntrustedCommit<Hc, Tr>),
-    #[display(fmt = "TrustedValidators")]
     TrustedValidators(TrustedValidators<Hc, Tr>),
-    #[display(fmt = "UntrustedValidators")]
     UntrustedValidators(UntrustedValidators<Hc, Tr>),
-    #[display(fmt = "ProveResponse")]
     ProveResponse(ProveResponse<Tr>),
 }
 
 #[derive(
-    DebugNoBound,
-    CloneNoBound,
-    PartialEqNoBound,
-    Serialize,
-    Deserialize,
-    derive_more::Display,
-    enumorph::Enumorph,
+    DebugNoBound, CloneNoBound, PartialEqNoBound, Serialize, Deserialize, enumorph::Enumorph,
 )]
 #[serde(
     bound(serialize = "", deserialize = ""),
@@ -456,15 +440,10 @@ pub enum UnionDataMsg<Hc: ChainExt, Tr: ChainExt> {
 )]
 pub enum UnionFetch<Hc: ChainExt, Tr: ChainExt> {
     // FetchTrustedCommit { height: Height },
-    #[display(fmt = "FetchUntrustedCommit")]
     FetchUntrustedCommit(FetchUntrustedCommit<Hc, Tr>),
-    #[display(fmt = "FetchTrustedValidators")]
     FetchTrustedValidators(FetchTrustedValidators<Hc, Tr>),
-    #[display(fmt = "FetchUntrustedValidators")]
     FetchUntrustedValidators(FetchUntrustedValidators<Hc, Tr>),
-    #[display(fmt = "FetchProveRequest")]
     FetchProveRequest(FetchProveRequest),
-    #[display(fmt = "FetchAbciQuery")]
     AbciQuery(FetchAbciQuery<Hc, Tr>),
 }
 
@@ -552,13 +531,7 @@ where
 }
 
 #[derive(
-    DebugNoBound,
-    CloneNoBound,
-    PartialEqNoBound,
-    Serialize,
-    Deserialize,
-    derive_more::Display,
-    enumorph::Enumorph,
+    DebugNoBound, CloneNoBound, PartialEqNoBound, Serialize, Deserialize, enumorph::Enumorph,
 )]
 #[serde(
     bound(serialize = "", deserialize = ""),
@@ -573,9 +546,7 @@ where
     arbitrary(bound = "Hc: ChainExt, Tr: ChainExt")
 )]
 pub enum UnionAggregateMsg<Hc: ChainExt, Tr: ChainExt> {
-    #[display(fmt = "AggregateProveRequest")]
     AggregateProveRequest(AggregateProveRequest<Hc, Tr>),
-    #[display(fmt = "AggregateHeader")]
     AggregateHeader(AggregateHeader<Hc, Tr>),
 }
 

--- a/lib/relay-message/src/data.rs
+++ b/lib/relay-message/src/data.rs
@@ -53,30 +53,6 @@ impl HandleData<RelayMessageTypes> for AnyLightClientIdentified<AnyData> {
     }
 }
 
-impl<Hc: ChainExt, Tr: ChainExt> std::fmt::Display for Data<Hc, Tr> {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        match self {
-            Data::SelfClientState(_) => write!(f, "SelfClientState"),
-            Data::SelfConsensusState(_) => write!(f, "SelfConsensusState"),
-            Data::LatestHeight(LatestHeight { height, .. }) => write!(f, "LatestHeight({height})"),
-            Data::PacketAcknowledgement(_) => write!(f, "PacketAcknowledgement"),
-            Data::ClientStateProof(_) => write!(f, "ClientStateProof"),
-            Data::ClientConsensusStateProof(_) => write!(f, "ClientConsensusStateProof"),
-            Data::ConnectionProof(_) => write!(f, "ConnectionProof"),
-            Data::ChannelEndProof(_) => write!(f, "ChannelEndProof"),
-            Data::CommitmentProof(_) => write!(f, "CommitmentProof"),
-            Data::AcknowledgementProof(_) => write!(f, "AcknowledgementProof"),
-            Data::ClientState(_) => write!(f, "ClientState"),
-            Data::ClientConsensusState(_) => write!(f, "ClientConsensusState"),
-            Data::Connection(_) => write!(f, "Connection"),
-            Data::ChannelEnd(_) => write!(f, "ChannelEnd"),
-            Data::Commitment(_) => write!(f, "Commitment"),
-            Data::Acknowledgement(_) => write!(f, "Acknowledgement"),
-            Data::LightClientSpecific(data) => write!(f, "LightClientSpecific({})", data.0),
-        }
-    }
-}
-
 #[queue_msg]
 pub struct SelfClientState<Hc: ChainExt, #[cover] Tr: ChainExt> {
     pub self_client_state: ClientStateOf<Hc>,

--- a/lib/relay-message/src/effect.rs
+++ b/lib/relay-message/src/effect.rs
@@ -1,5 +1,3 @@
-use std::fmt::Display;
-
 use chain_utils::GetChain;
 use macros::apply;
 use queue_msg::{queue_msg, HandleEffect, QueueError, QueueMsg, QueueMsgTypes};
@@ -72,25 +70,6 @@ where
 {
     pub async fn handle(self, c: &Hc) -> Result<(), Hc::MsgError> {
         <Hc as DoMsg<Hc, Tr>>::msg(c, self).await
-    }
-}
-
-impl<Hc: ChainExt, Tr: ChainExt> Display for Effect<Hc, Tr> {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        match self {
-            Effect::ConnectionOpenInit(_) => write!(f, "ConnectionOpenInit"),
-            Effect::ConnectionOpenTry(_) => write!(f, "ConnectionOpenTry"),
-            Effect::ConnectionOpenAck(_) => write!(f, "ConnectionOpenAck"),
-            Effect::ConnectionOpenConfirm(_) => write!(f, "ConnectionOpenConfirm"),
-            Effect::ChannelOpenInit(_) => write!(f, "ChannelOpenInit"),
-            Effect::ChannelOpenTry(_) => write!(f, "ChannelOpenTry"),
-            Effect::ChannelOpenAck(_) => write!(f, "ChannelOpenAck"),
-            Effect::ChannelOpenConfirm(_) => write!(f, "ChannelOpenConfirm"),
-            Effect::RecvPacket(_) => write!(f, "RecvPacket"),
-            Effect::AckPacket(_) => write!(f, "AckPacket"),
-            Effect::CreateClient(_) => write!(f, "CreateClient"),
-            Effect::UpdateClient(_) => write!(f, "UpdateClient"),
-        }
     }
 }
 

--- a/lib/relay-message/src/event.rs
+++ b/lib/relay-message/src/event.rs
@@ -1,4 +1,4 @@
-use std::{fmt::Display, marker::PhantomData};
+use std::marker::PhantomData;
 
 use chain_utils::GetChain;
 use frame_support_procedural::{CloneNoBound, DebugNoBound, PartialEqNoBound};
@@ -330,15 +330,6 @@ impl<Hc: ChainExt, Tr: ChainExt> Event<Hc, Tr> {
     }
 }
 
-impl<Hc: ChainExt, Tr: ChainExt> Display for Event<Hc, Tr> {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        match self {
-            Event::Ibc(_) => write!(f, "Ibc"),
-            Event::Command(cmd) => write!(f, "{cmd}"),
-        }
-    }
-}
-
 #[queue_msg]
 pub struct IbcEvent<Hc: ChainExt, Tr: ChainExt> {
     pub tx_hash: H256,
@@ -346,29 +337,19 @@ pub struct IbcEvent<Hc: ChainExt, Tr: ChainExt> {
     pub event: unionlabs::events::IbcEvent<ClientIdOf<Hc>, ClientTypeOf<Hc>, ClientIdOf<Tr>>,
 }
 
-impl<Hc: ChainExt, Tr: ChainExt> Display for IbcEvent<Hc, Tr> {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        f.write_str(self.event.name())
-    }
-}
-
-#[derive(
-    DebugNoBound, CloneNoBound, PartialEqNoBound, Serialize, Deserialize, derive_more::Display,
-)]
+#[derive(DebugNoBound, CloneNoBound, PartialEqNoBound, Serialize, Deserialize)]
 #[serde(
     bound(serialize = "", deserialize = ""),
     tag = "@type",
     content = "@value",
     rename_all = "snake_case"
 )]
-#[display(fmt = "Command::{}")]
 #[cfg_attr(
     feature = "arbitrary",
     derive(arbitrary::Arbitrary),
-    arbitrary(bound = "Hc: ChainExt, Tr: ChainExt")
+    arbitrary(bound = "")
 )]
 pub enum Command<Hc: ChainExt, Tr: ChainExt> {
-    #[display(fmt = "UpdateClient({client_id})")]
     UpdateClient {
         client_id: ClientIdOf<Hc>,
         #[serde(skip)]

--- a/lib/relay-message/src/fetch.rs
+++ b/lib/relay-message/src/fetch.rs
@@ -1,8 +1,4 @@
-use std::{
-    fmt::{Debug, Display},
-    marker::PhantomData,
-    num::NonZeroU64,
-};
+use std::{fmt::Debug, marker::PhantomData, num::NonZeroU64};
 
 use chain_utils::GetChain;
 use futures::Future;
@@ -68,31 +64,6 @@ impl HandleFetch<RelayMessageTypes> for AnyLightClientIdentified<AnyFetch> {
 
 pub trait DoFetch<Hc: ChainExt>: Sized + Debug + Clone + PartialEq {
     fn do_fetch(c: &Hc, _: Self) -> impl Future<Output = QueueMsg<RelayMessageTypes>>;
-}
-
-impl<Hc: ChainExt, Tr: ChainExt> Display for Fetch<Hc, Tr> {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        let path_display = |path: &_| match path {
-            proof::Path::ClientStatePath(_) => "ClientState",
-            proof::Path::ClientConsensusStatePath(_) => "ClientConsensusState",
-            proof::Path::ConnectionPath(_) => "Connection",
-            proof::Path::ChannelEndPath(_) => "ChannelEnd",
-            proof::Path::CommitmentPath(_) => "Commitment",
-            proof::Path::AcknowledgementPath(_) => "Acknowledgement",
-        };
-
-        match self {
-            Fetch::State(fetch) => write!(f, "State({})", path_display(&fetch.path)),
-            Fetch::Proof(fetch) => write!(f, "Proof({})", path_display(&fetch.path)),
-            Fetch::LatestHeight(_) => write!(f, "LatestHeight"),
-            Fetch::LatestClientState(_) => write!(f, "LatestClientState"),
-            Fetch::SelfClientState(_) => write!(f, "SelfClientState"),
-            Fetch::SelfConsensusState(_) => write!(f, "SelfConsensusState"),
-            Fetch::PacketAcknowledgement(_) => write!(f, "PacketAcknowledgement"),
-            Fetch::UpdateHeaders(_) => write!(f, "UpdateHeaders"),
-            Fetch::LightClientSpecific(fetch) => write!(f, "LightClientSpecific({})", fetch.0),
-        }
-    }
 }
 
 #[queue_msg]

--- a/lib/relay-message/src/wait.rs
+++ b/lib/relay-message/src/wait.rs
@@ -1,5 +1,3 @@
-use std::fmt::Display;
-
 use chain_utils::{ChainNotFoundError, GetChain};
 use macros::apply;
 use queue_msg::{
@@ -142,16 +140,6 @@ where
                     ])
                 }
             }
-        }
-    }
-}
-
-impl<Hc: ChainExt, Tr: ChainExt> Display for Wait<Hc, Tr> {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        match self {
-            Wait::Block(block) => write!(f, "Block({})", block.height),
-            Wait::Timestamp(ts) => write!(f, "Timestamp({})", ts.timestamp),
-            Wait::TrustedHeight(th) => write!(f, "TrustedHeight({})", th.height),
         }
     }
 }

--- a/lib/voyager-message/Cargo.toml
+++ b/lib/voyager-message/Cargo.toml
@@ -9,7 +9,6 @@ version      = "0.1.0"
 arbitrary     = { workspace = true, optional = true, features = ["derive"] }
 block-message = { workspace = true }
 chain-utils   = { workspace = true }
-derive_more   = { workspace = true, features = ["display"] }
 queue-msg     = { workspace = true }
 relay-message = { workspace = true }
 serde         = { workspace = true, features = ["derive"] }

--- a/lib/voyager-message/src/lib.rs
+++ b/lib/voyager-message/src/lib.rs
@@ -128,7 +128,7 @@ impl FromQueueMsg<BlockMessageTypes> for VoyagerMessageTypes {
     }
 }
 
-#[derive(Debug, Clone, PartialEq, Serialize, Deserialize, derive_more::Display)]
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 #[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 #[serde(tag = "@type", content = "@value", rename_all = "snake_case")]
 pub enum VoyagerMsg {
@@ -151,7 +151,7 @@ impl HandleEffect<VoyagerMessageTypes> for VoyagerMsg {
     }
 }
 
-#[derive(Debug, Clone, PartialEq, Serialize, Deserialize, derive_more::Display)]
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 #[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 #[serde(tag = "@type", content = "@value", rename_all = "snake_case")]
 pub enum VoyagerWait {
@@ -179,7 +179,7 @@ impl HandleWait<VoyagerMessageTypes> for VoyagerWait {
     }
 }
 
-#[derive(Debug, Clone, PartialEq, Serialize, Deserialize, derive_more::Display)]
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 #[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 #[serde(tag = "@type", content = "@value", rename_all = "snake_case")]
 pub enum VoyagerAggregate {
@@ -217,7 +217,7 @@ impl HandleAggregate<VoyagerMessageTypes> for VoyagerAggregate {
     }
 }
 
-#[derive(Debug, Clone, PartialEq, Serialize, Deserialize, derive_more::Display)]
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 #[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 #[serde(tag = "@type", content = "@value", rename_all = "snake_case")]
 pub enum VoyagerEvent {
@@ -240,7 +240,7 @@ impl HandleEvent<VoyagerMessageTypes> for VoyagerEvent {
     }
 }
 
-#[derive(Debug, Clone, PartialEq, Serialize, Deserialize, derive_more::Display)]
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 #[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 #[serde(tag = "@type", content = "@value", rename_all = "snake_case")]
 pub enum VoyagerData {
@@ -392,7 +392,7 @@ impl HandleData<VoyagerMessageTypes> for VoyagerData {
     }
 }
 
-#[derive(Debug, Clone, PartialEq, Serialize, Deserialize, derive_more::Display)]
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 #[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 #[serde(tag = "@type", content = "@value", rename_all = "snake_case")]
 pub enum VoyagerFetch {


### PR DESCRIPTION
No longer needed for debugging since we dump the message id with every log now (using a span). Cleans up a lot of annoying boilerplate 👌