### PR TITLE
chore: prep for v0.21.0

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -484,6 +484,7 @@
         "treefmt-nix": "treefmt-nix",
         "v0_19_0": "v0_19_0",
         "v0_20_0": "v0_20_0",
+        "v0_21_0": "v0_21_0",
         "wasmd": "wasmd",
         "wasmvm": "wasmvm",
         "wasmvm-1_5_0": "wasmvm-1_5_0"
@@ -594,6 +595,23 @@
       "original": {
         "owner": "unionlabs",
         "ref": "release-v0.20.0",
+        "repo": "union",
+        "type": "github"
+      }
+    },
+    "v0_21_0": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1712676277,
+        "narHash": "sha256-1eGLpjn74VwCsOMvDAI/n9N6/vaMLKrr1Ws8G0Yqf7o=",
+        "owner": "unionlabs",
+        "repo": "union",
+        "rev": "5651650302f5d09987f2524b686ac55b8839d243",
+        "type": "github"
+      },
+      "original": {
+        "owner": "unionlabs",
+        "ref": "release-v0.21.0",
         "repo": "union",
         "type": "github"
       }

--- a/flake.nix
+++ b/flake.nix
@@ -123,6 +123,10 @@
       url = "github:unionlabs/union/release-v0.20.0";
       flake = false;
     };
+    v0_21_0 = {
+      url = "github:unionlabs/union/release-v0.21.0";
+      flake = false;
+    };
   };
   outputs =
     inputs@{ self

--- a/unionvisor/unionvisor.nix
+++ b/unionvisor/unionvisor.nix
@@ -87,7 +87,7 @@
           mkBundle {
             name = "testnet-next";
             versions = uniondBundleVersions.complete;
-            nextVersion = "v0.21.0";
+            nextVersion = "v0.22.0";
             genesis = ../networks/genesis/union-testnet-7/genesis.json;
             meta = {
               binary_name = "uniond";

--- a/versions/versions.json
+++ b/versions/versions.json
@@ -15,7 +15,7 @@
     "seeds": "b37de4c50e26f7cde4c7b6ce06046a6693ffef2c@union.testnet.6.seed.poisonphang.com:26656"
   },
   "union-testnet-7": {
-    "versions": ["v0.20.0"],
+    "versions": ["v0.20.0", "v0.21.0"],
     "current": "v0.20.0",
     "seeds": ""
   }


### PR DESCRIPTION
Prep work for the v0.21.0 release. The `current` version in `versions/versions.json` will be updated after this is live on testntet as it only impacts docs. 
The seeds for testnet 7 are included in #1681, which will be merged once we're ready to have the public launch testnet 7 nodes.