### PR TITLE
feat(lightclients): clean up errors

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2224,7 +2224,7 @@ dependencies = [
 [[package]]
 name = "ethers"
 version = "2.0.10"
-source = "git+https://github.com/unionlabs/ethers-rs?branch=ethers-core-wasm#dd64d33c3a9ad2eaad6f2806c88663ebbcab22c0"
+source = "git+https://github.com/unionlabs/ethers-rs?branch=ethers-core-wasm#fd10abba9a9d5347b71bd4cde6418a6f6f2f1279"
 dependencies = [
  "ethers-addressbook",
  "ethers-contract",
@@ -2239,7 +2239,7 @@ dependencies = [
 [[package]]
 name = "ethers-addressbook"
 version = "2.0.10"
-source = "git+https://github.com/unionlabs/ethers-rs?branch=ethers-core-wasm#dd64d33c3a9ad2eaad6f2806c88663ebbcab22c0"
+source = "git+https://github.com/unionlabs/ethers-rs?branch=ethers-core-wasm#fd10abba9a9d5347b71bd4cde6418a6f6f2f1279"
 dependencies = [
  "ethers-core",
  "once_cell",
@@ -2250,7 +2250,7 @@ dependencies = [
 [[package]]
 name = "ethers-contract"
 version = "2.0.10"
-source = "git+https://github.com/unionlabs/ethers-rs?branch=ethers-core-wasm#dd64d33c3a9ad2eaad6f2806c88663ebbcab22c0"
+source = "git+https://github.com/unionlabs/ethers-rs?branch=ethers-core-wasm#fd10abba9a9d5347b71bd4cde6418a6f6f2f1279"
 dependencies = [
  "const-hex",
  "ethers-contract-abigen",
@@ -2268,7 +2268,7 @@ dependencies = [
 [[package]]
 name = "ethers-contract-abigen"
 version = "2.0.10"
-source = "git+https://github.com/unionlabs/ethers-rs?branch=ethers-core-wasm#dd64d33c3a9ad2eaad6f2806c88663ebbcab22c0"
+source = "git+https://github.com/unionlabs/ethers-rs?branch=ethers-core-wasm#fd10abba9a9d5347b71bd4cde6418a6f6f2f1279"
 dependencies = [
  "Inflector",
  "const-hex",
@@ -2291,7 +2291,7 @@ dependencies = [
 [[package]]
 name = "ethers-contract-derive"
 version = "2.0.10"
-source = "git+https://github.com/unionlabs/ethers-rs?branch=ethers-core-wasm#dd64d33c3a9ad2eaad6f2806c88663ebbcab22c0"
+source = "git+https://github.com/unionlabs/ethers-rs?branch=ethers-core-wasm#fd10abba9a9d5347b71bd4cde6418a6f6f2f1279"
 dependencies = [
  "Inflector",
  "const-hex",
@@ -2306,7 +2306,7 @@ dependencies = [
 [[package]]
 name = "ethers-core"
 version = "2.0.10"
-source = "git+https://github.com/unionlabs/ethers-rs?branch=ethers-core-wasm#dd64d33c3a9ad2eaad6f2806c88663ebbcab22c0"
+source = "git+https://github.com/unionlabs/ethers-rs?branch=ethers-core-wasm#fd10abba9a9d5347b71bd4cde6418a6f6f2f1279"
 dependencies = [
  "arrayvec",
  "bytes",
@@ -2336,7 +2336,7 @@ dependencies = [
 [[package]]
 name = "ethers-etherscan"
 version = "2.0.10"
-source = "git+https://github.com/unionlabs/ethers-rs?branch=ethers-core-wasm#dd64d33c3a9ad2eaad6f2806c88663ebbcab22c0"
+source = "git+https://github.com/unionlabs/ethers-rs?branch=ethers-core-wasm#fd10abba9a9d5347b71bd4cde6418a6f6f2f1279"
 dependencies = [
  "ethers-core",
  "reqwest",
@@ -2350,7 +2350,7 @@ dependencies = [
 [[package]]
 name = "ethers-middleware"
 version = "2.0.10"
-source = "git+https://github.com/unionlabs/ethers-rs?branch=ethers-core-wasm#dd64d33c3a9ad2eaad6f2806c88663ebbcab22c0"
+source = "git+https://github.com/unionlabs/ethers-rs?branch=ethers-core-wasm#fd10abba9a9d5347b71bd4cde6418a6f6f2f1279"
 dependencies = [
  "async-trait",
  "auto_impl",
@@ -2376,7 +2376,7 @@ dependencies = [
 [[package]]
 name = "ethers-providers"
 version = "2.0.10"
-source = "git+https://github.com/unionlabs/ethers-rs?branch=ethers-core-wasm#dd64d33c3a9ad2eaad6f2806c88663ebbcab22c0"
+source = "git+https://github.com/unionlabs/ethers-rs?branch=ethers-core-wasm#fd10abba9a9d5347b71bd4cde6418a6f6f2f1279"
 dependencies = [
  "async-trait",
  "auto_impl",
@@ -2413,7 +2413,7 @@ dependencies = [
 [[package]]
 name = "ethers-signers"
 version = "2.0.10"
-source = "git+https://github.com/unionlabs/ethers-rs?branch=ethers-core-wasm#dd64d33c3a9ad2eaad6f2806c88663ebbcab22c0"
+source = "git+https://github.com/unionlabs/ethers-rs?branch=ethers-core-wasm#fd10abba9a9d5347b71bd4cde6418a6f6f2f1279"
 dependencies = [
  "async-trait",
  "coins-bip32",
@@ -2431,7 +2431,7 @@ dependencies = [
 [[package]]
 name = "ethers-solc"
 version = "2.0.10"
-source = "git+https://github.com/unionlabs/ethers-rs?branch=ethers-core-wasm#dd64d33c3a9ad2eaad6f2806c88663ebbcab22c0"
+source = "git+https://github.com/unionlabs/ethers-rs?branch=ethers-core-wasm#fd10abba9a9d5347b71bd4cde6418a6f6f2f1279"
 dependencies = [
  "cfg-if",
  "const-hex",
@@ -4665,7 +4665,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "efb6c9a1dd1def8e2124d17e83a20af56f1570d6c2d2bd9e266ccb768df3840e"
 dependencies = [
  "anyhow",
- "itertools 0.11.0",
+ "itertools 0.10.5",
  "proc-macro2",
  "quote",
  "syn 2.0.56",
@@ -7089,7 +7089,7 @@ checksum = "97fee6b57c6a41524a810daee9286c02d7752c4253064d0b05472833a438f675"
 dependencies = [
  "cfg-if",
  "digest 0.10.7",
- "rand 0.8.5",
+ "rand 0.4.6",
  "static_assertions",
 ]
 

--- a/lib/chain-utils/src/ethereum.rs
+++ b/lib/chain-utils/src/ethereum.rs
@@ -11,7 +11,7 @@ use contracts::{
         GetConnectionCall, GetConnectionReturn, GetConsensusStateCall, GetConsensusStateReturn,
         GetHashedPacketAcknowledgementCommitmentCall,
         GetHashedPacketAcknowledgementCommitmentReturn, GetHashedPacketCommitmentCall,
-        GetHashedPacketCommitmentReturn, HasPacketReceiptCall, HasPacketReceiptReturn, IBCHandler,
+        GetHashedPacketCommitmentReturn, HasPacketReceiptCall, IBCHandler,
         IbcCoreConnectionV1ConnectionEndData, NextClientSequenceCall, NextConnectionSequenceCall,
         OwnershipTransferredFilter,
     },

--- a/lib/scroll-codec/src/lib.rs
+++ b/lib/scroll-codec/src/lib.rs
@@ -130,7 +130,7 @@ pub fn commit_batch(
     }
 }
 
-#[derive(Debug, thiserror::Error)]
+#[derive(Debug, PartialEq, thiserror::Error)]
 pub enum CommitBatchError {
     #[error("error decoding parent batch header")]
     ParentBatchHeaderDecode(#[from] BatchHeaderDecodeError),

--- a/lib/unionlabs/src/cosmos/ics23/batch_entry.rs
+++ b/lib/unionlabs/src/cosmos/ics23/batch_entry.rs
@@ -14,11 +14,14 @@ pub enum BatchEntry {
     Nonexist(NonExistenceProof),
 }
 
-#[derive(Debug)]
+#[derive(Debug, PartialEq, Clone, thiserror::Error)]
 pub enum TryFromBatchEntryError {
+    #[error(transparent)]
     MissingField(MissingField),
-    Exist(TryFromExistenceProofError),
-    Nonexist(TryFromNonExistenceProofError),
+    #[error("invalid existence proof")]
+    Exist(#[from] TryFromExistenceProofError),
+    #[error("invalid non existence proof")]
+    Nonexist(#[from] TryFromNonExistenceProofError),
 }
 
 impl TryFrom<protos::cosmos::ics23::v1::BatchEntry> for BatchEntry {

--- a/lib/unionlabs/src/cosmos/ics23/batch_proof.rs
+++ b/lib/unionlabs/src/cosmos/ics23/batch_proof.rs
@@ -7,9 +7,10 @@ pub struct BatchProof {
     pub entries: Vec<BatchEntry>,
 }
 
-#[derive(Debug)]
+#[derive(Debug, PartialEq, Clone, thiserror::Error)]
 pub enum TryFromBatchProofError {
-    Entries(TryFromBatchEntryError),
+    #[error("invalid entries")]
+    Entries(#[from] TryFromBatchEntryError),
 }
 
 impl TryFrom<protos::cosmos::ics23::v1::BatchProof> for BatchProof {

--- a/lib/unionlabs/src/cosmos/ics23/commitment_proof.rs
+++ b/lib/unionlabs/src/cosmos/ics23/commitment_proof.rs
@@ -18,13 +18,18 @@ pub enum CommitmentProof {
     CompressedBatch(CompressedBatchProof),
 }
 
-#[derive(Debug)]
+#[derive(Debug, PartialEq, Clone, thiserror::Error)]
 pub enum TryFromCommitmentProofError {
+    #[error(transparent)]
     MissingField(MissingField),
-    Exist(TryFromExistenceProofError),
-    Nonexist(TryFromNonExistenceProofError),
-    Batch(TryFromBatchProofError),
-    CompressedBatch(TryFromCompressedBatchProofProofError),
+    #[error("invalid existence proof")]
+    Exist(#[from] TryFromExistenceProofError),
+    #[error("invalid non existence proof")]
+    Nonexist(#[from] TryFromNonExistenceProofError),
+    #[error("invalid batch proof")]
+    Batch(#[from] TryFromBatchProofError),
+    #[error("invalid compressed batch proof")]
+    CompressedBatch(#[from] TryFromCompressedBatchProofProofError),
 }
 
 impl TryFrom<protos::cosmos::ics23::v1::CommitmentProof> for CommitmentProof {

--- a/lib/unionlabs/src/cosmos/ics23/compressed_batch_entry.rs
+++ b/lib/unionlabs/src/cosmos/ics23/compressed_batch_entry.rs
@@ -35,11 +35,14 @@ impl From<CompressedBatchEntry> for protos::cosmos::ics23::v1::CompressedBatchEn
     }
 }
 
-#[derive(Debug)]
+#[derive(Debug, PartialEq, Clone, thiserror::Error)]
 pub enum TryFromCompressedBatchEntryProofError {
+    #[error(transparent)]
     MissingField(MissingField),
-    Exist(TryFromCompressedExistenceProofError),
-    Nonexist(TryFromCompressedNonExistenceProofError),
+    #[error("invalid compressed existence proof")]
+    Exist(#[from] TryFromCompressedExistenceProofError),
+    #[error("invalid compressed non existence proof")]
+    Nonexist(#[from] TryFromCompressedNonExistenceProofError),
 }
 
 impl TryFrom<protos::cosmos::ics23::v1::CompressedBatchEntry> for CompressedBatchEntry {

--- a/lib/unionlabs/src/cosmos/ics23/compressed_batch_proof.rs
+++ b/lib/unionlabs/src/cosmos/ics23/compressed_batch_proof.rs
@@ -11,10 +11,12 @@ pub struct CompressedBatchProof {
     pub lookup_inners: Vec<InnerOp>,
 }
 
-#[derive(Debug)]
+#[derive(Debug, PartialEq, Clone, thiserror::Error)]
 pub enum TryFromCompressedBatchProofProofError {
-    Entries(TryFromCompressedBatchEntryProofError),
-    LookupInners(TryFromInnerOpError),
+    #[error("invalid entries")]
+    Entries(#[from] TryFromCompressedBatchEntryProofError),
+    #[error("invalid lookup inners")]
+    LookupInners(#[from] TryFromInnerOpError),
 }
 
 impl TryFrom<protos::cosmos::ics23::v1::CompressedBatchProof> for CompressedBatchProof {

--- a/lib/unionlabs/src/cosmos/ics23/compressed_existence_proof.rs
+++ b/lib/unionlabs/src/cosmos/ics23/compressed_existence_proof.rs
@@ -19,11 +19,14 @@ pub struct CompressedExistenceProof {
     pub path: Vec<BoundedI32<0, { i32::MAX }>>,
 }
 
-#[derive(Debug)]
+#[derive(Debug, PartialEq, Clone, thiserror::Error)]
 pub enum TryFromCompressedExistenceProofError {
+    #[error(transparent)]
     MissingField(MissingField),
-    Leaf(TryFromLeafOpError),
-    Path(BoundedIntError<i32>),
+    #[error("invalid leaf")]
+    Leaf(#[from] TryFromLeafOpError),
+    #[error("invalid path")]
+    Path(#[source] BoundedIntError<i32>),
 }
 
 impl TryFrom<protos::cosmos::ics23::v1::CompressedExistenceProof> for CompressedExistenceProof {

--- a/lib/unionlabs/src/cosmos/ics23/compressed_non_existence_proof.rs
+++ b/lib/unionlabs/src/cosmos/ics23/compressed_non_existence_proof.rs
@@ -20,11 +20,14 @@ pub struct CompressedNonExistenceProof {
     pub right: Option<CompressedExistenceProof>,
 }
 
-#[derive(Debug)]
+#[derive(Debug, PartialEq, Clone, thiserror::Error)]
 pub enum TryFromCompressedNonExistenceProofError {
+    #[error(transparent)]
     MissingField(MissingField),
-    Left(TryFromCompressedExistenceProofError),
-    Right(TryFromCompressedExistenceProofError),
+    #[error("left proof invalid")]
+    Left(#[source] TryFromCompressedExistenceProofError),
+    #[error("right proof invalid")]
+    Right(#[source] TryFromCompressedExistenceProofError),
 }
 
 impl TryFrom<protos::cosmos::ics23::v1::CompressedNonExistenceProof>

--- a/lib/unionlabs/src/cosmos/ics23/inner_spec.rs
+++ b/lib/unionlabs/src/cosmos/ics23/inner_spec.rs
@@ -56,16 +56,25 @@ impl From<InnerSpec> for protos::cosmos::ics23::v1::InnerSpec {
     }
 }
 
-#[derive(Debug)]
+#[derive(Debug, PartialEq, Clone, thiserror::Error)]
 pub enum TryFromInnerSpecError {
-    Hash(UnknownEnumVariant<i32>),
-    ChildOrder(BoundedIntError<usize>),
-    ChildSize(BoundedIntError<usize>),
-    MinPrefixLength(BoundedIntError<usize>),
-    MaxPrefixLength(BoundedIntError<usize>),
+    #[error("invalid hash")]
+    Hash(#[from] UnknownEnumVariant<i32>),
+    #[error("invalid child order")]
+    ChildOrder(#[source] BoundedIntError<usize>),
+    #[error("invalid child size")]
+    ChildSize(#[source] BoundedIntError<usize>),
+    #[error("invalid min prefix length")]
+    MinPrefixLength(#[source] BoundedIntError<usize>),
+    #[error("invalid max prefix length")]
+    MaxPrefixLength(#[source] BoundedIntError<usize>),
+    #[error("negative child order")]
     NegativeChildOrder,
+    #[error("negative child size")]
     NegativeChildSize,
+    #[error("negative min prefix length")]
     NegativeMinPrefixLength,
+    #[error("negative max prefix length")]
     NegativeMaxPrefixLength,
 }
 

--- a/lib/unionlabs/src/cosmos/ics23/non_existence_proof.rs
+++ b/lib/unionlabs/src/cosmos/ics23/non_existence_proof.rs
@@ -14,10 +14,13 @@ pub struct NonExistenceProof {
     pub right: Option<ExistenceProof>,
 }
 
-#[derive(Debug)]
+#[derive(Debug, PartialEq, Clone, thiserror::Error)]
 pub enum TryFromNonExistenceProofError {
+    #[error(transparent)]
     MissingField(MissingField),
+    #[error("left proof invalid")]
     Left(TryFromExistenceProofError),
+    #[error("right proof invalid")]
     Right(TryFromExistenceProofError),
 }
 

--- a/lib/unionlabs/src/cosmos/ics23/proof_spec.rs
+++ b/lib/unionlabs/src/cosmos/ics23/proof_spec.rs
@@ -39,12 +39,17 @@ impl From<ProofSpec> for protos::cosmos::ics23::v1::ProofSpec {
     }
 }
 
-#[derive(Debug)]
+#[derive(Debug, PartialEq, Clone, thiserror::Error)]
 pub enum TryFromProofSpecError {
+    #[error(transparent)]
     MissingField(MissingField),
-    LeafSpec(TryFromLeafOpError),
-    InnerSpec(TryFromInnerSpecError),
+    #[error("invalid leaf spec")]
+    LeafSpec(#[from] TryFromLeafOpError),
+    #[error("invalid inner spec")]
+    InnerSpec(#[from] TryFromInnerSpecError),
+    #[error("negative max depth")]
     NegativeMinDepth,
+    #[error("negative min depth")]
     NegativeMaxDepth,
 }
 

--- a/lib/unionlabs/src/cosmwasm/wasm/union/custom_query.rs
+++ b/lib/unionlabs/src/cosmwasm/wasm/union/custom_query.rs
@@ -4,7 +4,7 @@ use cosmwasm_std::{Binary, Deps, QueryRequest};
 
 use crate::bls::BlsPublicKey;
 
-#[derive(thiserror::Error, Debug, PartialEq)]
+#[derive(thiserror::Error, Debug, PartialEq, Clone)]
 pub enum Error {
     #[error("error while running `fast_aggregate_verify` query ({0})")]
     FastAggregateVerify(String),

--- a/lib/unionlabs/src/google/protobuf/duration.rs
+++ b/lib/unionlabs/src/google/protobuf/duration.rs
@@ -276,7 +276,6 @@ impl Duration {
 
         // false positive (fixed in newer versions)
         // https://github.com/rust-lang/rust-clippy/pull/10811
-        #[allow(clippy::match_wild_err_arm)]
         #[allow(clippy::cast_possible_truncation)] // invariant checked above
         match BoundedI32::new(value as i32) {
             Ok(ok) => ok,
@@ -287,11 +286,13 @@ impl Duration {
     }
 }
 
-#[derive(Debug)]
+#[derive(Debug, PartialEq, Clone, thiserror::Error)]
 pub enum DurationError {
+    #[error("invalid seconds")]
     Seconds(BoundedIntError<i64>),
+    #[error("invalid nanos")]
     Nanos(BoundedIntError<i32>),
-    /// The nanos field was the incorrect sign.
+    #[error("incorrect sign for nanos")]
     Sign,
 }
 

--- a/lib/unionlabs/src/google/protobuf/timestamp.rs
+++ b/lib/unionlabs/src/google/protobuf/timestamp.rs
@@ -265,10 +265,12 @@ impl From<Timestamp> for protos::google::protobuf::Timestamp {
     }
 }
 
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone, PartialEq, thiserror::Error)]
 pub enum TryFromTimestampError {
-    Seconds(BoundedIntError<i64>),
-    Nanos(BoundedIntError<i32>),
+    #[error("invalid seconds")]
+    Seconds(#[source] BoundedIntError<i64>),
+    #[error("invalid nanos")]
+    Nanos(#[source] BoundedIntError<i32>),
 }
 
 impl TryFrom<protos::google::protobuf::Timestamp> for Timestamp {

--- a/lib/unionlabs/src/ibc/core/commitment/merkle_proof.rs
+++ b/lib/unionlabs/src/ibc/core/commitment/merkle_proof.rs
@@ -10,9 +10,10 @@ pub struct MerkleProof {
     pub proofs: Vec<CommitmentProof>,
 }
 
-#[derive(Debug)]
+#[derive(Debug, PartialEq, Clone, thiserror::Error)]
 pub enum TryFromMerkleProofError {
-    Proofs(TryFromCommitmentProofError),
+    #[error("invalid proofs")]
+    Proofs(#[from] TryFromCommitmentProofError),
 }
 
 impl TryFrom<protos::ibc::core::commitment::v1::MerkleProof> for MerkleProof {

--- a/lib/unionlabs/src/ibc/core/commitment/merkle_root.rs
+++ b/lib/unionlabs/src/ibc/core/commitment/merkle_root.rs
@@ -24,7 +24,7 @@ impl From<MerkleRoot> for protos::ibc::core::commitment::v1::MerkleRoot {
     }
 }
 
-#[derive(Debug)]
+#[derive(Debug, PartialEq, Clone)]
 pub enum TryFromMerkleRootError {
     Hash(InvalidLength),
 }

--- a/lib/unionlabs/src/ibc/lightclients/cometbls/client_state.rs
+++ b/lib/unionlabs/src/ibc/lightclients/cometbls/client_state.rs
@@ -39,8 +39,9 @@ impl From<ClientState> for protos::union::ibc::lightclients::cometbls::v1::Clien
     }
 }
 
-#[derive(Debug)]
+#[derive(Debug, PartialEq, Clone, thiserror::Error)]
 pub enum TryFromClientStateError {
+    #[error(transparent)]
     MissingField(MissingField),
 }
 

--- a/lib/unionlabs/src/ibc/lightclients/cometbls/consensus_state.rs
+++ b/lib/unionlabs/src/ibc/lightclients/cometbls/consensus_state.rs
@@ -20,7 +20,7 @@ pub struct ConsensusState {
     pub next_validators_hash: H256,
 }
 
-#[derive(Debug)]
+#[derive(Debug, PartialEq, Clone)]
 pub enum TryFromConsensusStateError {
     MissingField(MissingField),
     Root(TryFromMerkleRootError),

--- a/lib/unionlabs/src/ibc/lightclients/ethereum/account_proof.rs
+++ b/lib/unionlabs/src/ibc/lightclients/ethereum/account_proof.rs
@@ -14,7 +14,7 @@ pub struct AccountProof {
     pub proof: Vec<Vec<u8>>,
 }
 
-#[derive(Debug)]
+#[derive(Debug, PartialEq, Clone)]
 pub enum TryFromAccountProofError {
     ContractAddress(InvalidLength),
     StorageRoot(InvalidLength),

--- a/lib/unionlabs/src/ibc/lightclients/ethereum/account_update.rs
+++ b/lib/unionlabs/src/ibc/lightclients/ethereum/account_update.rs
@@ -22,7 +22,7 @@ impl From<AccountUpdate> for protos::union::ibc::lightclients::ethereum::v1::Acc
     }
 }
 
-#[derive(Debug)]
+#[derive(Debug, PartialEq, Clone)]
 pub enum TryFromAccountUpdateError {
     MissingField(MissingField),
     AccountProof(TryFromAccountProofError),

--- a/lib/unionlabs/src/ibc/lightclients/ethereum/beacon_block_header.rs
+++ b/lib/unionlabs/src/ibc/lightclients/ethereum/beacon_block_header.rs
@@ -31,7 +31,7 @@ impl From<BeaconBlockHeader> for protos::union::ibc::lightclients::ethereum::v1:
     }
 }
 
-#[derive(Debug)]
+#[derive(Debug, PartialEq, Clone)]
 pub enum TryFromBeaconBlockHeaderError {
     ParentRoot(InvalidLength),
     StateRoot(InvalidLength),

--- a/lib/unionlabs/src/ibc/lightclients/ethereum/client_state.rs
+++ b/lib/unionlabs/src/ibc/lightclients/ethereum/client_state.rs
@@ -61,7 +61,7 @@ impl From<ClientState> for protos::union::ibc::lightclients::ethereum::v1::Clien
     }
 }
 
-#[derive(Debug)]
+#[derive(Debug, PartialEq)]
 pub enum TryFromClientStateError {
     MissingField(MissingField),
     ChainId(FromDecStrErr),

--- a/lib/unionlabs/src/ibc/lightclients/ethereum/consensus_state.rs
+++ b/lib/unionlabs/src/ibc/lightclients/ethereum/consensus_state.rs
@@ -35,7 +35,7 @@ impl From<ConsensusState> for protos::union::ibc::lightclients::ethereum::v1::Co
     }
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone, PartialEq)]
 pub enum TryFromConsensusStateError {
     CurrentSyncCommittee(InvalidLength),
     NextSyncCommittee(InvalidLength),

--- a/lib/unionlabs/src/ibc/lightclients/ethereum/execution_payload_header.rs
+++ b/lib/unionlabs/src/ibc/lightclients/ethereum/execution_payload_header.rs
@@ -132,7 +132,7 @@ impl<C: BYTES_PER_LOGS_BLOOM + MAX_EXTRA_DATA_BYTES> From<ExecutionPayloadHeader
     }
 }
 
-#[derive(Debug)]
+#[derive(Debug, PartialEq, Clone)]
 pub enum TryFromExecutionPayloadHeaderError {
     ParentHash(InvalidLength),
     FeeRecipient(InvalidLength),

--- a/lib/unionlabs/src/ibc/lightclients/ethereum/fork.rs
+++ b/lib/unionlabs/src/ibc/lightclients/ethereum/fork.rs
@@ -27,7 +27,7 @@ impl From<Fork> for protos::union::ibc::lightclients::ethereum::v1::Fork {
     }
 }
 
-#[derive(Debug)]
+#[derive(Debug, PartialEq, Clone)]
 pub enum TryFromForkError {
     Version(InvalidLength),
 }

--- a/lib/unionlabs/src/ibc/lightclients/ethereum/fork_parameters.rs
+++ b/lib/unionlabs/src/ibc/lightclients/ethereum/fork_parameters.rs
@@ -42,7 +42,7 @@ impl From<ForkParameters> for protos::union::ibc::lightclients::ethereum::v1::Fo
     }
 }
 
-#[derive(Debug)]
+#[derive(Debug, PartialEq, Clone)]
 pub enum TryFromForkParametersError {
     MissingField(MissingField),
     InvalidLength(InvalidLength),

--- a/lib/unionlabs/src/ibc/lightclients/ethereum/header.rs
+++ b/lib/unionlabs/src/ibc/lightclients/ethereum/header.rs
@@ -34,7 +34,7 @@ impl<C: SYNC_COMMITTEE_SIZE + BYTES_PER_LOGS_BLOOM + MAX_EXTRA_DATA_BYTES> From<
     }
 }
 
-#[derive(Debug)]
+#[derive(Debug, PartialEq, Clone)]
 pub enum TryFromHeaderError {
     MissingField(MissingField),
     TrustedSyncCommittee(TryFromTrustedSyncCommitteeError),

--- a/lib/unionlabs/src/ibc/lightclients/ethereum/light_client_header.rs
+++ b/lib/unionlabs/src/ibc/lightclients/ethereum/light_client_header.rs
@@ -46,7 +46,7 @@ impl<C: BYTES_PER_LOGS_BLOOM + MAX_EXTRA_DATA_BYTES> From<LightClientHeader<C>>
     }
 }
 
-#[derive(Debug)]
+#[derive(Debug, PartialEq, Clone)]
 pub enum TryFromLightClientHeaderError {
     MissingField(MissingField),
     BeaconBlockHeader(TryFromBeaconBlockHeaderError),

--- a/lib/unionlabs/src/ibc/lightclients/ethereum/misbehaviour.rs
+++ b/lib/unionlabs/src/ibc/lightclients/ethereum/misbehaviour.rs
@@ -34,7 +34,7 @@ impl<C: SYNC_COMMITTEE_SIZE + BYTES_PER_LOGS_BLOOM + MAX_EXTRA_DATA_BYTES> From<
     }
 }
 
-#[derive(Debug)]
+#[derive(Debug, PartialEq, Clone)]
 pub enum TryFromMisbehaviourError {
     MissingField(MissingField),
     TrustedSyncCommittee(TryFromTrustedSyncCommitteeError),

--- a/lib/unionlabs/src/ibc/lightclients/ethereum/proof.rs
+++ b/lib/unionlabs/src/ibc/lightclients/ethereum/proof.rs
@@ -13,10 +13,12 @@ pub struct Proof {
     pub proof: Vec<Vec<u8>>,
 }
 
-#[derive(Debug)]
+#[derive(Debug, PartialEq, Clone, thiserror::Error)]
 pub enum TryFromProofError {
-    Key(InvalidLength),
-    Value(InvalidLength),
+    #[error("unable to decode key")]
+    Key(#[source] InvalidLength),
+    #[error("unable to decode value")]
+    Value(#[source] InvalidLength),
 }
 
 impl TryFrom<protos::union::ibc::lightclients::ethereum::v1::Proof> for Proof {

--- a/lib/unionlabs/src/ibc/lightclients/ethereum/storage_proof.rs
+++ b/lib/unionlabs/src/ibc/lightclients/ethereum/storage_proof.rs
@@ -19,9 +19,10 @@ impl From<StorageProof> for protos::union::ibc::lightclients::ethereum::v1::Stor
     }
 }
 
-#[derive(Debug)]
+#[derive(Debug, PartialEq, Clone, thiserror::Error)]
 pub enum TryFromStorageProofError {
-    Proofs(TryFromProofError),
+    #[error("unable to decode proofs")]
+    Proofs(#[from] TryFromProofError),
 }
 
 impl TryFrom<protos::union::ibc::lightclients::ethereum::v1::StorageProof> for StorageProof {
@@ -34,7 +35,7 @@ impl TryFrom<protos::union::ibc::lightclients::ethereum::v1::StorageProof> for S
             proofs: value
                 .proofs
                 .into_iter()
-                .map(|proof| proof.try_into().map_err(TryFromStorageProofError::Proofs))
+                .map(TryInto::try_into)
                 .collect::<Result<_, _>>()?,
         })
     }

--- a/lib/unionlabs/src/ibc/lightclients/ethereum/sync_aggregate.rs
+++ b/lib/unionlabs/src/ibc/lightclients/ethereum/sync_aggregate.rs
@@ -39,7 +39,7 @@ impl<C: SYNC_COMMITTEE_SIZE> From<SyncAggregate<C>>
     }
 }
 
-#[derive(Debug)]
+#[derive(Debug, PartialEq, Clone)]
 pub enum TryFromSyncAggregateError {
     Bits(ssz::types::Error),
     Signature(InvalidLength),

--- a/lib/unionlabs/src/ibc/lightclients/ethereum/sync_committee.rs
+++ b/lib/unionlabs/src/ibc/lightclients/ethereum/sync_committee.rs
@@ -31,7 +31,7 @@ impl<C: SYNC_COMMITTEE_SIZE> From<SyncCommittee<C>>
     }
 }
 
-#[derive(Debug)]
+#[derive(Debug, PartialEq, Clone)]
 pub enum TryFromSyncCommitteeError {
     /// One of the `pubkeys` had an invalid length
     PubKey(InvalidLength),

--- a/lib/unionlabs/src/ibc/lightclients/ethereum/trusted_sync_committee.rs
+++ b/lib/unionlabs/src/ibc/lightclients/ethereum/trusted_sync_committee.rs
@@ -1,4 +1,3 @@
-use frame_support_procedural::DebugNoBound;
 use macros::model;
 use ssz::{Decode, Encode, TreeHash};
 
@@ -76,7 +75,7 @@ impl<C: SYNC_COMMITTEE_SIZE> From<TrustedSyncCommittee<C>>
     }
 }
 
-#[derive(DebugNoBound)]
+#[derive(Debug, PartialEq, Clone)]
 pub enum TryFromTrustedSyncCommitteeError {
     MissingField(MissingField),
     SyncCommittee(TryFromSyncCommitteeError),

--- a/lib/unionlabs/src/ibc/lightclients/scroll/client_state.rs
+++ b/lib/unionlabs/src/ibc/lightclients/scroll/client_state.rs
@@ -44,16 +44,22 @@ impl From<ClientState> for protos::union::ibc::lightclients::scroll::v1::ClientS
     }
 }
 
-#[derive(Debug)]
+#[derive(Debug, PartialEq, thiserror::Error)]
 pub enum TryFromClientStateError {
-    L1ClientId(FromDecStrErr),
-    ChainId(FromDecStrErr),
-    LatestBatchIndexSlot(InvalidLength),
-    RollupContractAddress(InvalidLength),
-    RollupFinalizedStateRootsSlot(InvalidLength),
-    IbcContractAddress(InvalidLength),
-    IbcCommitmentSlot(InvalidLength),
-    RollupCommittedBatchesSlot(InvalidLength),
+    #[error("unable to parse chain id")]
+    ChainId(#[source] FromDecStrErr),
+    #[error("invalid latest batch index slot")]
+    LatestBatchIndexSlot(#[source] InvalidLength),
+    #[error("invalid rollup contract address")]
+    RollupContractAddress(#[source] InvalidLength),
+    #[error("invalid rollup finalized state roots slot")]
+    RollupFinalizedStateRootsSlot(#[source] InvalidLength),
+    #[error("invalid ibc contract address")]
+    IbcContractAddress(#[source] InvalidLength),
+    #[error("invalid ibc commitment slot")]
+    IbcCommitmentSlot(#[source] InvalidLength),
+    #[error("invalid ibc committed batches slot")]
+    RollupCommittedBatchesSlot(#[source] InvalidLength),
 }
 
 impl TryFrom<protos::union::ibc::lightclients::scroll::v1::ClientState> for ClientState {

--- a/lib/unionlabs/src/ibc/lightclients/scroll/consensus_state.rs
+++ b/lib/unionlabs/src/ibc/lightclients/scroll/consensus_state.rs
@@ -21,9 +21,10 @@ impl From<ConsensusState> for protos::union::ibc::lightclients::scroll::v1::Cons
     }
 }
 
-#[derive(Debug)]
+#[derive(Debug, PartialEq, thiserror::Error)]
 pub enum TryFromConsensusStateError {
-    IbcStorageRoot(InvalidLength),
+    #[error("invalid ibc storage root")]
+    IbcStorageRoot(#[source] InvalidLength),
 }
 
 impl TryFrom<protos::union::ibc::lightclients::scroll::v1::ConsensusState> for ConsensusState {

--- a/lib/unionlabs/src/ibc/lightclients/scroll/header.rs
+++ b/lib/unionlabs/src/ibc/lightclients/scroll/header.rs
@@ -63,7 +63,7 @@ impl From<Header> for protos::union::ibc::lightclients::scroll::v1::Header {
     }
 }
 
-#[derive(Debug)]
+#[derive(Debug, PartialEq, Clone)]
 pub enum TryFromHeaderError {
     MissingField(MissingField),
     L1AccountProof(TryFromAccountProofError),

--- a/lib/unionlabs/src/ibc/lightclients/tendermint/client_state.rs
+++ b/lib/unionlabs/src/ibc/lightclients/tendermint/client_state.rs
@@ -48,14 +48,20 @@ impl From<ClientState> for protos::ibc::lightclients::tendermint::v1::ClientStat
     }
 }
 
-#[derive(Debug)]
+#[derive(Debug, PartialEq, Clone, thiserror::Error)]
 pub enum TryFromClientStateError {
+    #[error(transparent)]
     MissingField(MissingField),
-    TrustLevel(TryFromFractionError),
-    TrustingPeriod(DurationError),
-    UnbondingPeriod(DurationError),
-    MaxClockDrift(DurationError),
-    ProofSpecs(TryFromProofSpecError),
+    #[error("invalid trust level")]
+    TrustLevel(#[source] TryFromFractionError),
+    #[error("invalid trusting period")]
+    TrustingPeriod(#[source] DurationError),
+    #[error("invalid unbonding period")]
+    UnbondingPeriod(#[source] DurationError),
+    #[error("invalid max clock drift")]
+    MaxClockDrift(#[source] DurationError),
+    #[error("invalid proof specs")]
+    ProofSpecs(#[source] TryFromProofSpecError),
 }
 
 impl TryFrom<protos::ibc::lightclients::tendermint::v1::ClientState> for ClientState {

--- a/lib/unionlabs/src/ibc/lightclients/tendermint/consensus_state.rs
+++ b/lib/unionlabs/src/ibc/lightclients/tendermint/consensus_state.rs
@@ -18,7 +18,7 @@ pub struct ConsensusState {
     pub next_validators_hash: H256,
 }
 
-#[derive(Debug)]
+#[derive(Debug, PartialEq, Clone)]
 pub enum TryFromConsensusStateError {
     MissingField(MissingField),
     Root(TryFromMerkleRootError),

--- a/lib/unionlabs/src/ibc/lightclients/tendermint/fraction.rs
+++ b/lib/unionlabs/src/ibc/lightclients/tendermint/fraction.rs
@@ -17,8 +17,9 @@ impl From<Fraction> for protos::ibc::lightclients::tendermint::v1::Fraction {
     }
 }
 
-#[derive(Debug)]
+#[derive(Debug, PartialEq, Clone, thiserror::Error)]
 pub enum TryFromFractionError {
+    #[error("zero denominator")]
     ZeroDenominator,
 }
 
@@ -38,7 +39,6 @@ impl TryFrom<protos::ibc::lightclients::tendermint::v1::Fraction> for Fraction {
     }
 }
 
-// TODO(benluelo): This will be replaced with tendermint once the solidity contract types are regenerated
 #[cfg(feature = "ethabi")]
 impl From<Fraction> for contracts::glue::IbcLightclientsTendermintV1FractionData {
     fn from(value: Fraction) -> Self {
@@ -54,6 +54,7 @@ impl From<contracts::glue::IbcLightclientsTendermintV1FractionData> for Fraction
     fn from(value: contracts::glue::IbcLightclientsTendermintV1FractionData) -> Self {
         Self {
             numerator: value.numerator,
+            // TODO: Don't panic here lol
             denominator: NonZeroU64::new(value.denominator).expect("non-zero denominator"),
         }
     }

--- a/lib/unionlabs/src/ibc/lightclients/tendermint/header.rs
+++ b/lib/unionlabs/src/ibc/lightclients/tendermint/header.rs
@@ -28,7 +28,7 @@ impl From<Header> for protos::ibc::lightclients::tendermint::v1::Header {
     }
 }
 
-#[derive(Debug)]
+#[derive(Debug, PartialEq, Clone)]
 pub enum TryFromHeaderError {
     MissingField(MissingField),
     SignedHeader(TryFromSignedHeaderError),

--- a/lib/unionlabs/src/ibc/lightclients/wasm/client_state.rs
+++ b/lib/unionlabs/src/ibc/lightclients/wasm/client_state.rs
@@ -28,6 +28,16 @@ where
     }
 }
 
+impl<Data: Decode<Proto, Error: PartialEq>> PartialEq for TryFromWasmClientStateError<Data> {
+    fn eq(&self, other: &Self) -> bool {
+        match (self, other) {
+            (Self::Data(this), Self::Data(other)) => this == other,
+            (Self::CodeId(this), Self::CodeId(other)) => this == other,
+            _ => false,
+        }
+    }
+}
+
 #[derive(DebugNoBound)]
 pub enum TryFromWasmClientStateError<Data: Decode<Proto>> {
     Data(DecodeErrorOf<Proto, Data>),

--- a/lib/unionlabs/src/ibc/lightclients/wasm/consensus_state.rs
+++ b/lib/unionlabs/src/ibc/lightclients/wasm/consensus_state.rs
@@ -1,3 +1,4 @@
+use frame_support_procedural::DebugNoBound;
 use macros::model;
 
 use crate::encoding::{Decode, DecodeErrorOf, Encode, Proto};
@@ -17,9 +18,17 @@ impl<Data: Encode<Proto>> From<ConsensusState<Data>>
     }
 }
 
-#[derive(Debug)]
+#[derive(DebugNoBound)]
 pub enum TryFromWasmConsensusStateError<Data: Decode<Proto>> {
     Data(DecodeErrorOf<Proto, Data>),
+}
+
+impl<Data: Decode<Proto, Error: PartialEq>> PartialEq for TryFromWasmConsensusStateError<Data> {
+    fn eq(&self, other: &Self) -> bool {
+        match (self, other) {
+            (Self::Data(this), Self::Data(other)) => this == other,
+        }
+    }
 }
 
 impl<Data> TryFrom<protos::ibc::lightclients::wasm::v1::ConsensusState> for ConsensusState<Data>

--- a/lib/unionlabs/src/ics24.rs
+++ b/lib/unionlabs/src/ics24.rs
@@ -206,16 +206,22 @@ impl<Hc: Chain, Tr: Chain> IbcPath<Hc, Tr> for NextClientSequencePath {
     type Value = u64;
 }
 
-#[derive(Debug)]
+#[derive(Debug, PartialEq, thiserror::Error)]
 pub enum PathParseError {
+    #[error("invalid static segment, expected `{expected}` but found `{found}`")]
     InvalidStaticSegment {
         expected: &'static str,
         found: String,
     },
+    #[error("missing static segment `{0}`")]
     MissingStaticSegment(&'static str),
+    // TODO: Figure out a way to provide more context here?
+    #[error("missing segment")]
     MissingSegment,
+    #[error("too many segments")]
     TooManySegments,
     // contains the stringified parse error
+    #[error("error parsing segment: {0}")]
     Parse(String),
 }
 

--- a/lib/unionlabs/src/lib.rs
+++ b/lib/unionlabs/src/lib.rs
@@ -92,9 +92,11 @@ pub mod errors;
 #[allow(clippy::missing_panics_doc)]
 pub mod test_utils;
 
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone, PartialEq, thiserror::Error)]
 pub enum TryFromProtoBytesError<E> {
-    TryFromProto(E),
+    #[error("unable to convert from the raw prost type")]
+    TryFromProto(#[source] E),
+    #[error("unable to decode from raw proto bytes")]
     Decode(prost::DecodeError),
 }
 

--- a/lib/unionlabs/src/tendermint/crypto/public_key.rs
+++ b/lib/unionlabs/src/tendermint/crypto/public_key.rs
@@ -38,7 +38,7 @@ impl From<PublicKey> for protos::tendermint::crypto::PublicKey {
     }
 }
 
-#[derive(Debug)]
+#[derive(Debug, PartialEq, Clone)]
 pub enum TryFromPublicKeyError {
     MissingField(MissingField),
 }

--- a/lib/unionlabs/src/tendermint/types/validator.rs
+++ b/lib/unionlabs/src/tendermint/types/validator.rs
@@ -27,7 +27,7 @@ impl From<Validator> for protos::tendermint::types::Validator {
     }
 }
 
-#[derive(Debug)]
+#[derive(Debug, PartialEq, Clone)]
 pub enum TryFromValidatorError {
     MissingField(MissingField),
     Address(InvalidLength),

--- a/lib/unionlabs/src/tendermint/types/validator_set.rs
+++ b/lib/unionlabs/src/tendermint/types/validator_set.rs
@@ -23,7 +23,7 @@ impl From<ValidatorSet> for protos::tendermint::types::ValidatorSet {
     }
 }
 
-#[derive(Debug)]
+#[derive(Debug, PartialEq, Clone)]
 pub enum TryFromValidatorSetError {
     Validators(TryFromValidatorError),
     MissingField(MissingField),

--- a/light-clients/cometbls-light-client/src/contract.rs
+++ b/light-clients/cometbls-light-client/src/contract.rs
@@ -2,7 +2,7 @@ use cosmwasm_std::{entry_point, DepsMut, Env, MessageInfo, Response};
 use ics008_wasm_client::{
     define_cosmwasm_light_client_contract,
     storage_utils::{save_proto_client_state, save_proto_consensus_state},
-    InstantiateMsg,
+    CustomQueryOf, InstantiateMsg,
 };
 use protos::ibc::lightclients::wasm::v1::{
     ClientState as ProtoClientState, ConsensusState as ProtoConsensusState,
@@ -19,28 +19,26 @@ use crate::{client::CometblsLightClient, errors::Error};
 // of IBC (probably v9). When that feature is implemented, we can move this to the ics008 macro.
 #[entry_point]
 pub fn instantiate(
-    mut deps: DepsMut,
+    mut deps: DepsMut<CustomQueryOf<CometblsLightClient>>,
     _env: Env,
     _info: MessageInfo,
     msg: InstantiateMsg,
 ) -> Result<Response, Error> {
     let client_state =
-        ClientState::decode_as::<Proto>(&msg.client_state).map_err(|e| Error::DecodeFromProto {
-            reason: format!("{:?}", e),
-        })?;
+        ClientState::decode_as::<Proto>(&msg.client_state).map_err(Error::ClientStateDecode)?;
 
     if client_state.chain_id.len() > 31 {
-        return Err(Error::InvalidChainID);
+        return Err(Error::InvalidChainId);
     }
 
-    save_proto_consensus_state(
+    save_proto_consensus_state::<CometblsLightClient>(
         deps.branch(),
         ProtoConsensusState {
             data: msg.consensus_state.into(),
         },
         &client_state.latest_height,
     );
-    save_proto_client_state(
+    save_proto_client_state::<CometblsLightClient>(
         deps,
         ProtoClientState {
             data: msg.client_state.into(),

--- a/light-clients/cometbls-light-client/src/errors.rs
+++ b/light-clients/cometbls-light-client/src/errors.rs
@@ -1,12 +1,16 @@
-use cosmwasm_std::StdError;
-use thiserror::Error as ThisError;
+use ics008_wasm_client::IbcClientError;
 use unionlabs::{
     encoding::{DecodeErrorOf, Proto},
     hash::H256,
-    ibc::{core::client::height::Height, lightclients::cometbls::header::Header},
+    ibc::{
+        core::{client::height::Height, commitment::merkle_proof::MerkleProof},
+        lightclients::cometbls,
+    },
 };
 
-#[derive(ThisError, Debug, PartialEq)]
+use crate::{client::CometblsLightClient, zkp_verifier::ZkpVerifier};
+
+#[derive(thiserror::Error, Debug, PartialEq)]
 pub enum InvalidHeaderError {
     #[error("signed header's height ({signed_height}) must be greater than trusted height ({trusted_height})")]
     SignedHeaderHeightMustBeMoreRecent {
@@ -20,61 +24,31 @@ pub enum InvalidHeaderError {
     },
     #[error("header with timestamp ({0}) is expired")]
     HeaderExpired(u64),
-    #[error("negative header timestamp seconds ({0})")]
-    NegativeTimestamp(i64),
-    #[error("negative header timestamp nanos ({0})")]
-    NegativeTimestampNanos(i32),
     #[error("signed header timestamp ({signed_timestamp}) cannot exceed the max clock drift ({max_clock_drift})")]
     SignedHeaderCannotExceedMaxClockDrift {
         signed_timestamp: u64,
         max_clock_drift: u64,
     },
-    #[error("commit hash ({commit_hash}) does not match with the signed header root ({signed_header_root})")]
-    SignedHeaderMismatchWithCommitHash {
-        commit_hash: H256,
-        signed_header_root: H256,
-    },
     #[error("the validators hash ({actual}) doesn't match the trusted validators hash ({expected}) for an adjacent block")]
     InvalidValidatorsHash { expected: H256, actual: H256 },
 }
 
-#[derive(ThisError, Debug, PartialEq)]
+#[derive(thiserror::Error, Debug, PartialEq)]
 pub enum Error {
-    #[error("{0}")]
-    Std(#[from] StdError),
-
     #[error("math operation with overflow")]
     MathOverflow,
-
-    #[error("timestamp is negative ({0})")]
-    NegativeTimestamp(i64),
-
-    #[error("error while decoding proto ({reason})")]
-    DecodeFromProto { reason: String },
 
     #[error("unimplemented feature")]
     Unimplemented,
 
-    #[error("Unable to decode header: {0:?}")]
-    HeaderDecode(DecodeErrorOf<Proto, Header>),
+    #[error("unable to decode merkle proof")]
+    MerkleProofDecode(#[source] DecodeErrorOf<Proto, MerkleProof>),
 
-    #[error("Unknown type url")]
-    UnknownTypeUrl,
+    #[error("unable to decode client state")]
+    ClientStateDecode(#[source] DecodeErrorOf<Proto, cometbls::client_state::ClientState>),
 
     #[error("Client state not found")]
     ClientStateNotFound,
-
-    #[error("Invalid proof format")]
-    InvalidProofFormat,
-
-    #[error("Invalid client id")]
-    InvalidClientId,
-
-    #[error("Invalid public key: {0}")]
-    InvalidPublicKey(String),
-
-    #[error("Invalid height")]
-    InvalidHeight,
 
     #[error(transparent)]
     InvalidHeader(#[from] InvalidHeaderError),
@@ -82,68 +56,8 @@ pub enum Error {
     #[error("Invalid ZKP: {0:?}")]
     InvalidZKP(cometbls_groth16_verifier::Error),
 
-    #[error("Invalid sync committee")]
-    InvalidSyncCommittee,
-
-    #[error("Merkle root cannot be calculated")]
-    UnableToCalculateMerkleRoot,
-
-    #[error("No next sync committee")]
-    NoNextSyncCommittee,
-
     #[error("Consensus state not found for {0}")]
     ConsensusStateNotFound(Height),
-
-    #[error("Overflow happened during summing durations.")]
-    DurationAdditionOverflow,
-
-    #[error("Timestamp not set")]
-    TimestampNotSet,
-
-    #[error("Verification error: {0}")]
-    Verification(String),
-
-    #[error("Unexpected timestamp: Expected timestamp {0}, got {1}")]
-    UnexpectedTimestamp(u64, u64),
-
-    #[error("Future period")]
-    FuturePeriod,
-
-    #[error("Cannot generate proof")]
-    CannotGenerateProof,
-
-    #[error("Invalid chain version")]
-    InvalidChainVersion,
-
-    #[error("Invalid path {0}")]
-    InvalidPath(String),
-
-    #[error("Invalid membership value")]
-    InvalidValue,
-
-    #[error("Invalid commitment key. Expected {0}, got {1}.")]
-    InvalidCommitmentKey(String, String),
-
-    #[error("Missing field in the protobuf encoded data")]
-    MissingProtoField,
-
-    #[error("Client's store period must be equal to update's finalized period")]
-    StorePeriodMustBeEqualToFinalizedPeriod,
-
-    #[error("Proof is empty")]
-    EmptyProof,
-
-    #[error("Batching proofs are not supported")]
-    BatchingProofsNotSupported,
-
-    #[error("Expected value: '{0}' and stored value '{1}' doesn't match")]
-    ExpectedAndStoredValueMismatch(String, String),
-
-    #[error("Custom query: {0}")]
-    CustomQuery(String),
-
-    #[error("Wasm client error: {0}")]
-    Wasm(String),
 
     #[error("verify membership error: {0}")]
     VerifyMembership(#[from] ics23::ibc_api::VerifyMembershipError),
@@ -155,44 +69,19 @@ pub enum Error {
     MigrateFieldsChanged,
 
     #[error("the chain id cannot be more than 31 bytes long to fit in the bn254 scalar field")]
-    InvalidChainID,
+    InvalidChainId,
 }
 
-impl Error {
-    pub fn invalid_public_key<S: ToString>(s: S) -> Error {
-        Error::InvalidPublicKey(s.to_string())
-    }
-
-    pub fn invalid_commitment_key<B1: AsRef<[u8]>, B2: AsRef<[u8]>>(
-        expected: B1,
-        got: B2,
-    ) -> Error {
-        Error::InvalidCommitmentKey(hex::encode(expected), hex::encode(got))
-    }
-
-    pub fn stored_value_mismatch<B1: AsRef<[u8]>, B2: AsRef<[u8]>>(expected: B1, got: B2) -> Error {
-        Error::ExpectedAndStoredValueMismatch(hex::encode(expected), hex::encode(got))
-    }
-
-    pub fn custom_query<S: ToString>(s: S) -> Error {
-        Error::CustomQuery(s.to_string())
+// required for IbcClient trait
+impl<T: ZkpVerifier> From<Error> for IbcClientError<CometblsLightClient<T>> {
+    fn from(value: Error) -> Self {
+        IbcClientError::ClientSpecific(value)
     }
 }
 
-impl From<ics008_wasm_client::storage_utils::Error> for Error {
-    fn from(error: ics008_wasm_client::storage_utils::Error) -> Self {
-        match error {
-            ics008_wasm_client::storage_utils::Error::ClientStateNotFound => {
-                Error::ClientStateNotFound
-            }
-            ics008_wasm_client::storage_utils::Error::ClientStateDecode => Error::DecodeFromProto {
-                reason: error.to_string(),
-            },
-            ics008_wasm_client::storage_utils::Error::ConsensusStateDecode => {
-                Error::DecodeFromProto {
-                    reason: error.to_string(),
-                }
-            }
-        }
+// convenience
+impl<T: ZkpVerifier> From<InvalidHeaderError> for IbcClientError<CometblsLightClient<T>> {
+    fn from(value: InvalidHeaderError) -> Self {
+        IbcClientError::ClientSpecific(Error::InvalidHeader(value))
     }
 }

--- a/light-clients/cometbls-light-client/src/zkp_verifier.rs
+++ b/light-clients/cometbls-light-client/src/zkp_verifier.rs
@@ -1,6 +1,6 @@
 use unionlabs::{hash::H256, ibc::lightclients::cometbls::light_header::LightHeader};
 
-pub trait ZKPVerifier {
+pub trait ZkpVerifier {
     fn verify_zkp(
         chain_id: &str,
         trusted_validators_hash: H256,
@@ -11,11 +11,11 @@ pub trait ZKPVerifier {
     }
 }
 
-impl ZKPVerifier for () {}
+impl ZkpVerifier for () {}
 
 pub struct MockZKPVerifier;
 
-impl ZKPVerifier for MockZKPVerifier {
+impl ZkpVerifier for MockZKPVerifier {
     fn verify_zkp(
         _chain_id: &str,
         _trusted_validators_hash: H256,

--- a/light-clients/ethereum-light-client/src/contract.rs
+++ b/light-clients/ethereum-light-client/src/contract.rs
@@ -2,7 +2,7 @@ use cosmwasm_std::{entry_point, DepsMut, Env, MessageInfo, Response};
 use ics008_wasm_client::{
     define_cosmwasm_light_client_contract,
     storage_utils::{save_proto_client_state, save_proto_consensus_state},
-    InstantiateMsg,
+    CustomQueryOf, InstantiateMsg,
 };
 use protos::ibc::lightclients::wasm::v1::{
     ClientState as ProtoClientState, ConsensusState as ProtoConsensusState,
@@ -19,7 +19,7 @@ use crate::{client::EthereumLightClient, errors::Error};
 // of IBC (probably v9). When that feature is implemented, we can move this to the ics008 macro.
 #[entry_point]
 pub fn instantiate(
-    mut deps: DepsMut,
+    mut deps: DepsMut<CustomQueryOf<EthereumLightClient>>,
     _env: Env,
     _info: MessageInfo,
     msg: InstantiateMsg,
@@ -29,7 +29,7 @@ pub fn instantiate(
             reason: format!("{:?}", e),
         })?;
 
-    save_proto_consensus_state(
+    save_proto_consensus_state::<EthereumLightClient>(
         deps.branch(),
         ProtoConsensusState {
             data: msg.consensus_state.into(),
@@ -39,7 +39,7 @@ pub fn instantiate(
             revision_height: client_state.latest_slot,
         },
     );
-    save_proto_client_state(
+    save_proto_client_state::<EthereumLightClient>(
         deps,
         ProtoClientState {
             data: msg.client_state.into(),

--- a/light-clients/tendermint-light-client/src/contract.rs
+++ b/light-clients/tendermint-light-client/src/contract.rs
@@ -25,18 +25,16 @@ pub fn instantiate(
     msg: InstantiateMsg,
 ) -> Result<Response, Error> {
     let client_state =
-        ClientState::decode_as::<Proto>(&msg.client_state).map_err(|e| Error::DecodeFromProto {
-            reason: format!("{:?}", e),
-        })?;
+        ClientState::decode_as::<Proto>(&msg.client_state).map_err(Error::ClientStateDecode)?;
 
-    save_proto_consensus_state(
+    save_proto_consensus_state::<TendermintLightClient>(
         deps.branch(),
         ProtoConsensusState {
             data: msg.consensus_state.into(),
         },
         &client_state.latest_height,
     );
-    save_proto_client_state(
+    save_proto_client_state::<TendermintLightClient>(
         deps,
         ProtoClientState {
             data: msg.client_state.into(),

--- a/light-clients/tendermint-light-client/src/errors.rs
+++ b/light-clients/tendermint-light-client/src/errors.rs
@@ -1,12 +1,16 @@
-use cosmwasm_std::StdError;
-use thiserror::Error as ThisError;
+use ics008_wasm_client::IbcClientError;
 use unionlabs::{
     encoding::{DecodeErrorOf, Proto},
     hash::H256,
-    ibc::{core::client::height::Height, lightclients::cometbls::header::Header},
+    ibc::{
+        core::{client::height::Height, commitment::merkle_proof::MerkleProof},
+        lightclients::{cometbls::header::Header, tendermint},
+    },
 };
 
-#[derive(ThisError, Debug, PartialEq)]
+use crate::client::TendermintLightClient;
+
+#[derive(thiserror::Error, Debug, PartialEq)]
 pub enum InvalidHeaderError {
     #[error("signed header's height ({signed_height}) must be greater than trusted height ({trusted_height})")]
     SignedHeaderHeightMustBeMoreRecent {
@@ -27,128 +31,51 @@ pub enum InvalidHeaderError {
         signed_timestamp: u64,
         max_clock_drift: u64,
     },
-    #[error("commit hash ({commit_hash}) does not match with the signed header root ({signed_header_root})")]
-    SignedHeaderMismatchWithCommitHash {
-        commit_hash: H256,
-        signed_header_root: H256,
-    },
 }
 
-#[derive(ThisError, Debug, PartialEq)]
+#[derive(thiserror::Error, Debug, PartialEq)]
 pub enum Error {
-    #[error("{0}")]
-    Std(#[from] StdError),
-
     #[error("math operation with overflow")]
     MathOverflow,
 
     #[error("timestamp is negative ({0})")]
     NegativeTimestamp(i64),
 
-    #[error("error while decoding proto ({reason})")]
-    DecodeFromProto { reason: String },
-
     #[error("unimplemented feature")]
+    // TODO: Remove this from this variant
     Unimplemented,
 
-    #[error("Unable to decode header: {0:?}")]
-    HeaderDecode(DecodeErrorOf<Proto, Header>),
+    #[error("unable to decode header")]
+    HeaderDecode(#[source] DecodeErrorOf<Proto, Header>),
 
-    #[error("Unknown type url")]
-    UnknownTypeUrl,
+    #[error("unable to decode merkle proof")]
+    MerkleProofDecode(#[source] DecodeErrorOf<Proto, MerkleProof>),
 
-    #[error("Client state not found")]
-    ClientStateNotFound,
+    #[error("unable to decode client state")]
+    ClientStateDecode(#[source] DecodeErrorOf<Proto, tendermint::client_state::ClientState>),
 
-    #[error("Invalid proof format")]
-    InvalidProofFormat,
+    #[error("the ibc height.revision_height does not fit in an i64 ({0})")]
+    IbcHeightTooLargeForTendermintHeight(u64),
 
-    #[error("Invalid client id")]
-    InvalidClientId,
+    #[error("trusted revision number ({trusted_revision_number}) does not match the header ({header_revision_number})")]
+    RevisionNumberMismatch {
+        trusted_revision_number: u64,
+        header_revision_number: u64,
+    },
 
-    #[error("Invalid public key: {0}")]
-    InvalidPublicKey(String),
-
-    #[error("Invalid height")]
-    InvalidHeight,
-
-    #[error("trusted revision number ({trusted_rn}) does not match the header ({header_rn})")]
-    RevisionNumberMismatch { trusted_rn: u64, header_rn: u64 },
-
-    #[error(transparent)]
+    #[error("invalid header")]
     InvalidHeader(#[from] InvalidHeaderError),
 
-    #[error("Invalid ZKP")]
-    InvalidZKP,
-
-    #[error("Invalid sync committee")]
-    InvalidSyncCommittee,
-
-    #[error("Merkle root cannot be calculated")]
-    UnableToCalculateMerkleRoot,
-
-    #[error("No next sync committee")]
-    NoNextSyncCommittee,
-
-    #[error("Consensus state not found for {0}")]
+    #[error("consensus state not found for {0}")]
+    // TODO: Move this variant into IbcClientError
     ConsensusStateNotFound(Height),
 
-    #[error("Overflow happened during summing durations.")]
-    DurationAdditionOverflow,
-
-    #[error("Timestamp not set")]
-    TimestampNotSet,
-
-    #[error("Verification error: {0}")]
-    Verification(String),
-
-    #[error("Unexpected timestamp: Expected timestamp {0}, got {1}")]
-    UnexpectedTimestamp(u64, u64),
-
-    #[error("Future period")]
-    FuturePeriod,
-
-    #[error("Cannot generate proof")]
-    CannotGenerateProof,
-
-    #[error("Invalid chain version")]
-    InvalidChainVersion,
-
-    #[error("Invalid chain id ({0})")]
+    // NOTE: This is only emitted when it's not possible to parse the revision number from the chain id; perhaps make this more descriptive?
+    #[error("invalid chain id ({0})")]
     InvalidChainId(String),
-
-    #[error("Invalid path {0}")]
-    InvalidPath(String),
-
-    #[error("Invalid membership value")]
-    InvalidValue,
 
     #[error("trusted validators hash ({0}) does not match the saved one ({1})")]
     TrustedValidatorsMismatch(H256, H256),
-
-    #[error("Invalid commitment key. Expected {0}, got {1}.")]
-    InvalidCommitmentKey(String, String),
-
-    #[error("Missing field in the protobuf encoded data")]
-    MissingProtoField,
-
-    #[error("Client's store period must be equal to update's finalized period")]
-    StorePeriodMustBeEqualToFinalizedPeriod,
-
-    #[error("Proof is empty")]
-    EmptyProof,
-
-    #[error("Batching proofs are not supported")]
-    BatchingProofsNotSupported,
-
-    #[error("Expected value: '{0}' and stored value '{1}' doesn't match")]
-    ExpectedAndStoredValueMismatch(String, String),
-
-    #[error("Custom query: {0}")]
-    CustomQuery(String),
-
-    #[error("Wasm client error: {0}")]
-    Wasm(String),
 
     #[error("verify membership error: {0}")]
     VerifyMembership(#[from] ics23::ibc_api::VerifyMembershipError),
@@ -166,41 +93,23 @@ pub enum Error {
     MigrateFieldsChanged,
 }
 
-impl Error {
-    pub fn invalid_public_key<S: ToString>(s: S) -> Error {
-        Error::InvalidPublicKey(s.to_string())
-    }
-
-    pub fn invalid_commitment_key<B1: AsRef<[u8]>, B2: AsRef<[u8]>>(
-        expected: B1,
-        got: B2,
-    ) -> Error {
-        Error::InvalidCommitmentKey(hex::encode(expected), hex::encode(got))
-    }
-
-    pub fn stored_value_mismatch<B1: AsRef<[u8]>, B2: AsRef<[u8]>>(expected: B1, got: B2) -> Error {
-        Error::ExpectedAndStoredValueMismatch(hex::encode(expected), hex::encode(got))
-    }
-
-    pub fn custom_query<S: ToString>(s: S) -> Error {
-        Error::CustomQuery(s.to_string())
+// required for IbcClient trait
+impl From<Error> for IbcClientError<TendermintLightClient> {
+    fn from(value: Error) -> Self {
+        IbcClientError::ClientSpecific(value)
     }
 }
 
-impl From<ics008_wasm_client::storage_utils::Error> for Error {
-    fn from(error: ics008_wasm_client::storage_utils::Error) -> Self {
-        match error {
-            ics008_wasm_client::storage_utils::Error::ClientStateNotFound => {
-                Error::ClientStateNotFound
-            }
-            ics008_wasm_client::storage_utils::Error::ClientStateDecode => Error::DecodeFromProto {
-                reason: error.to_string(),
-            },
-            ics008_wasm_client::storage_utils::Error::ConsensusStateDecode => {
-                Error::DecodeFromProto {
-                    reason: error.to_string(),
-                }
-            }
-        }
+// convenience
+impl From<InvalidHeaderError> for IbcClientError<TendermintLightClient> {
+    fn from(value: InvalidHeaderError) -> Self {
+        IbcClientError::ClientSpecific(Error::InvalidHeader(value))
     }
 }
+
+// would be nice, but both foreign types :(
+// impl From<ics23::ibc_api::VerifyMembershipError> for IbcClientError<TendermintLightClient> {
+//     fn from(value: ics23::ibc_api::VerifyMembershipError) -> Self {
+//         IbcClientError::ClientSpecific(Error::VerifyMembership(value))
+//     }
+// }


### PR DESCRIPTION
- implement `std::error::Error` for a ton of error enums in `unionlabs`
- clean up errors in all of the light clients
  - removed unused/ irrelevant variants
    - no more sync committee error variants in the tendermint lc!
    - "Dude i was copy pasting the whole lc everytime" ~ @aeryz
- `ics008_wasm_client::storage_utils` fns are now generic over `T: IbcClient`
- made `IbcClientError<T>` more usable, and it is now used as the error return type for all of the fallible methods on `IbcClient`
  - `<T as IbcClient>::Error` now must impl `Into<IbcClientError<T>>`
  
## Future work

- normalize more non-client-specific variants out of the client errors and into `IbcClientError<T>` (`Unimplemented`, `ConsensusStateNotFound`, possibly more?)
- clean up `ics008_wasm_client::storage_utils` further