### PR TITLE
fix: extend direnv timeout

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -1,2 +1,3 @@
 [[ -f .envrc.local ]] && source_env .envrc.local
 use flake
+export DIRENV_WARN_TIMEOUT=1m


### PR DESCRIPTION
This extends the timeout period for direnv. Currently it's too short so it always emits this warning:

```sh
direnv: ([...]) is taking a while to execute. Use CTRL-C to give up
```

ref: https://github.com/direnv/direnv/issues/1084#issuecomment-1713366532