### PR TITLE
feat(evm): remove unecessary source port from ibc modules

### DIFF
--- a/evm/contracts/apps/ucs/00-pingpong/PingPong.sol
+++ b/evm/contracts/apps/ucs/00-pingpong/PingPong.sol
@@ -47,7 +47,6 @@ contract PingPong is IBCAppBase {
     using PingPongLib for *;
 
     IBCHandler private ibcHandler;
-    string private portId;
     string private channelId;
     uint64 private revisionNumber;
     uint64 private timeout;
@@ -74,7 +73,6 @@ contract PingPong is IBCAppBase {
             revert PingPongLib.ErrNoChannel();
         }
         ibcHandler.sendPacket(
-            portId,
             channelId,
             // No height timeout
             IbcCoreClientV1Height.Data({revision_number: 0, revision_height: 0}),
@@ -177,7 +175,6 @@ contract PingPong is IBCAppBase {
         string calldata _counterpartyVersion
     ) external virtual override onlyIBC {
         // Store the port/channel needed to send packets.
-        portId = _portId;
         channelId = _channelId;
     }
 
@@ -186,7 +183,6 @@ contract PingPong is IBCAppBase {
         string calldata _channelId
     ) external virtual override onlyIBC {
         // Symmetric to onChanOpenAck
-        portId = _portId;
         channelId = _channelId;
     }
 

--- a/evm/contracts/core/04-channel/IBCPacket.sol
+++ b/evm/contracts/core/04-channel/IBCPacket.sol
@@ -1,6 +1,8 @@
 pragma solidity ^0.8.23;
 
+import "solady/utils/LibString.sol";
 import "@openzeppelin/utils/Strings.sol";
+
 import "../../proto/ibc/core/channel/v1/channel.sol";
 import "../25-handler/IBCMsgs.sol";
 import "../02-client/IBCHeight.sol";
@@ -63,6 +65,7 @@ library IBCPacketLib {
  */
 contract IBCPacket is IBCStore, IIBCPacket, ModuleManager {
     using IBCHeight for IbcCoreClientV1Height.Data;
+    using LibString for *;
 
     /**
      * @dev sendPacket is called by a module in order to send an IBC packet on a channel.
@@ -70,12 +73,12 @@ contract IBCPacket is IBCStore, IIBCPacket, ModuleManager {
      * is returned if one occurs.
      */
     function sendPacket(
-        string calldata sourcePort,
         string calldata sourceChannel,
         IbcCoreClientV1Height.Data calldata timeoutHeight,
         uint64 timeoutTimestamp,
         bytes calldata data
     ) external override returns (uint64) {
+        string memory sourcePort = msg.sender.toHexString();
         if (
             !authenticateCapability(
                 channelCapabilityPath(sourcePort, sourceChannel)
@@ -273,7 +276,7 @@ contract IBCPacket is IBCStore, IIBCPacket, ModuleManager {
     }
 
     function _writeAcknowledgement(
-        string calldata destinationPort,
+        string memory destinationPort,
         string calldata destinationChannel,
         uint64 sequence,
         bytes memory acknowledgement
@@ -306,11 +309,11 @@ contract IBCPacket is IBCStore, IIBCPacket, ModuleManager {
      * which will be verified by the counterparty chain using AcknowledgePacket.
      */
     function writeAcknowledgement(
-        string calldata destinationPort,
         string calldata destinationChannel,
         uint64 sequence,
         bytes calldata acknowledgement
     ) external override {
+        string memory destinationPort = msg.sender.toHexString();
         if (
             !authenticateCapability(
                 channelCapabilityPath(destinationPort, destinationChannel)
@@ -603,7 +606,7 @@ contract IBCPacket is IBCStore, IIBCPacket, ModuleManager {
     }
 
     function ensureChannelState(
-        string calldata portId,
+        string memory portId,
         string calldata channelId
     ) internal returns (IbcCoreChannelV1Channel.Data storage) {
         IbcCoreChannelV1Channel.Data storage channel =

--- a/evm/contracts/core/04-channel/IIBCPacket.sol
+++ b/evm/contracts/core/04-channel/IIBCPacket.sol
@@ -9,7 +9,6 @@ interface IIBCPacket {
      * is returned if one occurs.
      */
     function sendPacket(
-        string calldata sourcePort,
         string calldata sourceChannel,
         IbcCoreClientV1Height.Data calldata timeoutHeight,
         uint64 timeoutTimestamp,
@@ -27,7 +26,6 @@ interface IIBCPacket {
      * which will be verified by the counterparty chain using AcknowledgePacket.
      */
     function writeAcknowledgement(
-        string calldata destinationPortId,
         string calldata destinationChannel,
         uint64 sequence,
         bytes calldata acknowledgement

--- a/evm/contracts/core/25-handler/IBCPacketHandler.sol
+++ b/evm/contracts/core/25-handler/IBCPacketHandler.sol
@@ -13,7 +13,6 @@ abstract contract IBCPacketHandler is IIBCPacket, ModuleManager {
     address ibcPacket;
 
     function sendPacket(
-        string calldata sourcePort,
         string calldata sourceChannel,
         IbcCoreClientV1Height.Data calldata timeoutHeight,
         uint64 timeoutTimestamp,
@@ -30,7 +29,6 @@ abstract contract IBCPacketHandler is IIBCPacket, ModuleManager {
     }
 
     function writeAcknowledgement(
-        string calldata destinationPortId,
         string calldata destinationChannel,
         uint64 sequence,
         bytes calldata acknowledgement

--- a/evm/tests/src/25-handler/IBCPacketHandler.t.sol
+++ b/evm/tests/src/25-handler/IBCPacketHandler.t.sol
@@ -241,7 +241,6 @@ contract IBCPacketHandlerTest is TestPlus {
         vm.assume(timeoutTimestamp > LATEST_TIMESTAMP);
         vm.prank(address(app));
         handler.sendPacket(
-            address(app).toHexString(),
             channelId,
             ClientHeight.Data({
                 revision_number: 0,
@@ -261,7 +260,6 @@ contract IBCPacketHandlerTest is TestPlus {
         vm.assume(timeoutTimestamp > LATEST_TIMESTAMP);
         vm.prank(address(app));
         handler.sendPacket(
-            address(app).toHexString(),
             channelId,
             ClientHeight.Data({
                 revision_number: 0,
@@ -303,7 +301,6 @@ contract IBCPacketHandlerTest is TestPlus {
         vm.expectRevert(IBCPacketLib.ErrUnauthorized.selector);
         vm.prank(malicious);
         handler.sendPacket(
-            address(app).toHexString(),
             channelId,
             ClientHeight.Data({
                 revision_number: 0,
@@ -332,7 +329,6 @@ contract IBCPacketHandlerTest is TestPlus {
         );
         vm.prank(address(app));
         handler.sendPacket(
-            address(app).toHexString(),
             channelId,
             ClientHeight.Data({
                 revision_number: 0,
@@ -363,7 +359,6 @@ contract IBCPacketHandlerTest is TestPlus {
         vm.prank(address(app));
         vm.expectRevert(IBCPacketLib.ErrInvalidTimeoutHeight.selector);
         handler.sendPacket(
-            address(app).toHexString(),
             channelId,
             ClientHeight.Data({
                 revision_number: 0,
@@ -384,7 +379,6 @@ contract IBCPacketHandlerTest is TestPlus {
         vm.prank(address(app));
         vm.expectRevert(IBCPacketLib.ErrInvalidTimeoutTimestamp.selector);
         handler.sendPacket(
-            address(app).toHexString(),
             channelId,
             ClientHeight.Data({
                 revision_number: 0,
@@ -622,9 +616,7 @@ contract IBCPacketHandlerTest is TestPlus {
     ) public {
         vm.assume(acknowledgement.length > 0);
         vm.prank(address(app));
-        handler.writeAcknowledgement(
-            address(app).toHexString(), channelId, sequence, acknowledgement
-        );
+        handler.writeAcknowledgement(channelId, sequence, acknowledgement);
     }
 
     function test_writeAcknowledgement_alreadyExist(
@@ -634,14 +626,10 @@ contract IBCPacketHandlerTest is TestPlus {
         vm.assume(acknowledgement.length > 0);
         client.pushValidMembership();
         vm.prank(address(app));
-        handler.writeAcknowledgement(
-            address(app).toHexString(), channelId, sequence, acknowledgement
-        );
+        handler.writeAcknowledgement(channelId, sequence, acknowledgement);
         vm.prank(address(app));
         vm.expectRevert(IBCPacketLib.ErrAcknowledgementAlreadyExists.selector);
-        handler.writeAcknowledgement(
-            address(app).toHexString(), channelId, sequence, acknowledgement
-        );
+        handler.writeAcknowledgement(channelId, sequence, acknowledgement);
     }
 
     function test_writeAcknowledgement_emptyAcknowledgement(uint64 sequence)
@@ -649,9 +637,7 @@ contract IBCPacketHandlerTest is TestPlus {
     {
         vm.prank(address(app));
         vm.expectRevert(IBCPacketLib.ErrAcknowledgementIsEmpty.selector);
-        handler.writeAcknowledgement(
-            address(app).toHexString(), channelId, sequence, bytes("")
-        );
+        handler.writeAcknowledgement(channelId, sequence, bytes(""));
     }
 
     function test_writeAcknowledgement_unauthorized(
@@ -663,9 +649,7 @@ contract IBCPacketHandlerTest is TestPlus {
         vm.assume(acknowledgement.length > 0);
         vm.prank(address(malicious));
         vm.expectRevert(IBCPacketLib.ErrUnauthorized.selector);
-        handler.writeAcknowledgement(
-            address(app).toHexString(), channelId, sequence, acknowledgement
-        );
+        handler.writeAcknowledgement(channelId, sequence, acknowledgement);
     }
 
     function test_acknowledgePacket_ok(
@@ -681,7 +665,6 @@ contract IBCPacketHandlerTest is TestPlus {
         vm.assume(timeoutTimestamp < type(uint64).max / 1e9);
         vm.prank(address(app));
         handler.sendPacket(
-            address(app).toHexString(),
             channelId,
             ClientHeight.Data({
                 revision_number: 0,
@@ -718,7 +701,6 @@ contract IBCPacketHandlerTest is TestPlus {
         vm.assume(timeoutTimestamp < type(uint64).max / 1e9);
         vm.prank(address(app));
         handler.sendPacket(
-            address(app).toHexString(),
             channelId,
             ClientHeight.Data({
                 revision_number: 0,
@@ -769,7 +751,6 @@ contract IBCPacketHandlerTest is TestPlus {
         vm.assume(timeoutTimestamp < type(uint64).max / 1e9);
         vm.prank(address(app));
         handler.sendPacket(
-            address(app).toHexString(),
             channelId,
             ClientHeight.Data({
                 revision_number: 0,
@@ -832,7 +813,6 @@ contract IBCPacketHandlerTest is TestPlus {
         vm.assume(timeoutTimestamp < type(uint64).max / 1e9);
         vm.prank(address(app));
         handler.sendPacket(
-            address(app).toHexString(),
             channelId,
             ClientHeight.Data({
                 revision_number: 0,
@@ -869,7 +849,6 @@ contract IBCPacketHandlerTest is TestPlus {
         vm.assume(timeoutTimestamp < type(uint64).max / 1e9);
         vm.prank(address(app));
         handler.sendPacket(
-            address(app).toHexString(),
             channelId,
             ClientHeight.Data({
                 revision_number: 0,
@@ -909,7 +888,6 @@ contract IBCPacketHandlerTest is TestPlus {
         vm.assume(timeoutTimestamp < type(uint64).max / 1e9);
         vm.prank(address(app));
         handler.sendPacket(
-            address(app).toHexString(),
             channelId,
             ClientHeight.Data({
                 revision_number: 0,
@@ -945,89 +923,6 @@ contract IBCPacketHandlerTest is TestPlus {
         vm.assume(relayer != address(0) && relayer != address(app));
         vm.prank(address(app));
         handler.sendPacket(
-            address(app).toHexString(),
-            channelId,
-            ClientHeight.Data({revision_number: 0, revision_height: 0}),
-            0,
-            payload
-        );
-        client.pushValidMembership();
-        vm.prank(relayer);
-        vm.expectRevert(IBCPacketLib.ErrInvalidPacketCommitment.selector);
-        handler.timeoutPacket(
-            MsgMocks.packetTimeout(
-                address(app).toHexString(),
-                channelId,
-                LATEST_HEIGHT,
-                0,
-                0,
-                abi.encodePacked(payload, hex"00")
-            )
-        );
-    }
-
-    function test_timeoutPacket_notSent(
-        address relayer,
-        bytes memory payload
-    ) public {
-        vm.assume(relayer != address(0) && relayer != address(app));
-        client.pushValidMembership();
-        vm.prank(relayer);
-        vm.expectRevert(IBCPacketLib.ErrPacketCommitmentNotFound.selector);
-        handler.timeoutPacket(
-            MsgMocks.packetTimeout(
-                address(app).toHexString(),
-                channelId,
-                LATEST_HEIGHT,
-                0,
-                0,
-                payload
-            )
-        );
-    }
-
-    function test_timeoutPacket_invalidDestinationPort(
-        address relayer,
-        bytes memory payload
-    ) public {
-        vm.assume(relayer != address(0) && relayer != address(app));
-        IBCMsgs.MsgPacketTimeout memory msg_ = MsgMocks.packetTimeout(
-            address(app).toHexString(), channelId, LATEST_HEIGHT, 0, 0, payload
-        );
-        msg_.packet.destination_port = "invalid";
-        client.pushValidMembership();
-        vm.prank(relayer);
-        vm.expectRevert(
-            IBCPacketLib.ErrDestinationAndCounterpartyPortMismatch.selector
-        );
-        handler.timeoutPacket(msg_);
-    }
-
-    function test_timeoutPacket_invalidDestinationChannel(
-        address relayer,
-        bytes memory payload
-    ) public {
-        vm.assume(relayer != address(0) && relayer != address(app));
-        IBCMsgs.MsgPacketTimeout memory msg_ = MsgMocks.packetTimeout(
-            address(app).toHexString(), channelId, LATEST_HEIGHT, 0, 0, payload
-        );
-        msg_.packet.destination_channel = "invalid";
-        client.pushValidMembership();
-        vm.prank(relayer);
-        vm.expectRevert(
-            IBCPacketLib.ErrDestinationAndCounterpartyChannelMismatch.selector
-        );
-        handler.timeoutPacket(msg_);
-    }
-
-    function test_timeoutPacket_noTimeout(
-        address relayer,
-        bytes memory payload
-    ) public {
-        vm.assume(relayer != address(0) && relayer != address(app));
-        vm.prank(address(app));
-        handler.sendPacket(
-            address(app).toHexString(),
             channelId,
             ClientHeight.Data({revision_number: 0, revision_height: 0}),
             0,
@@ -1057,7 +952,6 @@ contract IBCPacketHandlerTest is TestPlus {
         vm.assume(timeoutHeight > LATEST_HEIGHT + 1);
         vm.prank(address(app));
         handler.sendPacket(
-            address(app).toHexString(),
             channelId,
             ClientHeight.Data({
                 revision_number: 0,
@@ -1099,7 +993,6 @@ contract IBCPacketHandlerTest is TestPlus {
         vm.assume(timeoutHeight > LATEST_HEIGHT + 1);
         vm.prank(address(app));
         handler.sendPacket(
-            address(app).toHexString(),
             channelId,
             ClientHeight.Data({
                 revision_number: 0,
@@ -1154,7 +1047,6 @@ contract IBCPacketHandlerTest is TestPlus {
         vm.assume(timeoutHeight > LATEST_HEIGHT + 1);
         vm.prank(address(app));
         handler.sendPacket(
-            address(app).toHexString(),
             channelId,
             ClientHeight.Data({
                 revision_number: 0,
@@ -1196,7 +1088,6 @@ contract IBCPacketHandlerTest is TestPlus {
         vm.assume(timeoutHeight > LATEST_HEIGHT + 1);
         vm.prank(address(app));
         handler.sendPacket(
-            address(app).toHexString(),
             channelId,
             ClientHeight.Data({
                 revision_number: 0,
@@ -1243,7 +1134,6 @@ contract IBCPacketHandlerTest is TestPlus {
         );
         vm.prank(address(app));
         handler.sendPacket(
-            address(app).toHexString(),
             channelId,
             ClientHeight.Data({revision_number: 0, revision_height: 0}),
             (timeoutTimestamp - 1) * 1e9,
@@ -1287,7 +1177,6 @@ contract IBCPacketHandlerTest is TestPlus {
         );
         vm.prank(address(app));
         handler.sendPacket(
-            address(app).toHexString(),
             channelId,
             ClientHeight.Data({revision_number: 0, revision_height: 0}),
             (timeoutTimestamp - 1) * 1e9,


### PR DESCRIPTION
In this PR we remove the `sourcePort` from the public interface of modules and instead recompute it in the IBC handler as `sourcePort = hex(msg.sender)`.
We were no longer supporting arbitrary port and instead forced the port to be the caller address, hex encoded.

Note that this breaks the IBC handler API (for solidity modules, `sendPacket/writeAck` no longer require a port) and the UCS01/UCS02 protocols where `send` no longer require the local port.

It also changes the UCS01 `send`, where the timeoutHeight is now an IBCHeight and an extra timeoutTimestamp parameter has been added