### PR TITLE
feat: optionally return the type from parse wasm client type

### DIFF
--- a/lib/unionlabs/src/lib.rs
+++ b/lib/unionlabs/src/lib.rs
@@ -11,7 +11,7 @@
 extern crate alloc;
 
 use core::{
-    fmt::{Debug, Display},
+    fmt::{self, Debug, Display},
     ptr::addr_of,
     str::FromStr,
 };
@@ -132,7 +132,7 @@ macro_rules! export_wasm_client_type {
 
 /// This type is used to discriminate 08-wasm light clients.
 /// We need to be able to determine the light client from the light client code itself (not instantiated yet).
-/// Light clients supported by voyager must export a `#[no_mangle] static WASM_CLIENT_TYPE: WasmClientType = WasmClientType::...` variable.
+/// Light clients supported by voyager must export a `#[no_mangle] static WASM_CLIENT_TYPE_<TYPE>: u8 = 0` variable.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
 #[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 pub enum WasmClientType {
@@ -175,6 +175,19 @@ impl FromStr for WasmClientType {
             "Scroll" => Ok(WasmClientType::Scroll),
             "Arbitrum" => Ok(WasmClientType::Arbitrum),
             _ => Err(WasmClientTypeParseError::UnknownType(s.to_string())),
+        }
+    }
+}
+
+impl Display for WasmClientType {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::EthereumMinimal => write!(f, "EthereumMinimal"),
+            Self::EthereumMainnet => write!(f, "EthereumMainnet"),
+            Self::Cometbls => write!(f, "Cometbls"),
+            Self::Tendermint => write!(f, "Tendermint"),
+            Self::Scroll => write!(f, "Scroll"),
+            Self::Arbitrum => write!(f, "Arbitrum"),
         }
     }
 }

--- a/networks/devnet.nix
+++ b/networks/devnet.nix
@@ -61,6 +61,7 @@
           self'.packages.ethereum-light-client-minimal
           self'.packages.ethereum-light-client-mainnet
           self'.packages.scroll-light-client
+          self'.packages.arbitrum-light-client
         ];
         cosmwasmContracts = [
           {

--- a/tools/parse-wasm-client-type/src/main.rs
+++ b/tools/parse-wasm-client-type/src/main.rs
@@ -7,7 +7,8 @@ use unionlabs::{parse_wasm_client_type, WasmClientType};
 #[command(arg_required_else_help = true)]
 struct Args {
     file_path: OsString,
-    expected_client_type: WasmClientType,
+    /// Optionally provide a client type to expect, exiting with a non-zero status code if it's incorrect.
+    expected_client_type: Option<WasmClientType>,
 }
 
 fn main() {
@@ -15,9 +16,10 @@ fn main() {
 
     let bz = std::fs::read(args.file_path).unwrap();
 
-    match parse_wasm_client_type(bz) {
-        Ok(Some(ty)) => assert_eq!(ty, args.expected_client_type),
-        Ok(None) => panic!("file does not contain a wasm client type"),
-        Err(err) => panic!("{err}"),
+    match (parse_wasm_client_type(bz), args.expected_client_type) {
+        (Ok(Some(ty)), Some(expected)) => assert_eq!(ty, expected),
+        (Ok(Some(ty)), None) => println!("{ty}"),
+        (Ok(None), _) => panic!("file does not contain a wasm client type"),
+        (Err(err), _) => panic!("{err}"),
     }
 }


### PR DESCRIPTION
```sh
$ nix build .#tendermint-light-client

$ nix run .#parse-wasm-client-type -- result/lib/tendermint_light_client.wasm
Tendermint

$ nix run .#parse-wasm-client-type -- result/lib/tendermint_light_client.wasm Tendermint

$ echo $?
0

$ nix run .#parse-wasm-client-type -- result/lib/tendermint_light_client.wasm Cometbls
thread 'main' panicked at tools/parse-wasm-client-type/src/main.rs:20:43:
assertion `left == right` failed
  left: Tendermint
 right: Cometbls
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace

$ echo $?
101
```