### PR TITLE
refactor(hubble): remove sync_next and always use batch syncing

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3463,12 +3463,12 @@ dependencies = [
  "ethers",
  "futures",
  "hex",
+ "itertools 0.13.0",
  "lazy_static",
  "prometheus",
  "prost",
  "protos",
  "reqwest",
- "retry",
  "serde",
  "serde_json",
  "sqlx",
@@ -3768,6 +3768,15 @@ name = "itertools"
 version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ba291022dbbd398a455acf126c1e341954079855bc60dfdda641363bd6922569"
+dependencies = [
+ "either",
+]
+
+[[package]]
+name = "itertools"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "413ee7dfc52ee1a4949ceeb7dbc8a33f2d6c088194d9f922fb8318faf1f01186"
 dependencies = [
  "either",
 ]
@@ -5315,15 +5324,6 @@ dependencies = [
  "web-sys",
  "webpki-roots",
  "winreg",
-]
-
-[[package]]
-name = "retry"
-version = "2.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9166d72162de3575f950507683fac47e30f6f2c3836b71b7fbc61aa517c9c5f4"
-dependencies = [
- "rand 0.8.5",
 ]
 
 [[package]]

--- a/hubble/Cargo.toml
+++ b/hubble/Cargo.toml
@@ -27,12 +27,12 @@ contracts.workspace = true
 ethers              = { workspace = true, features = ["default", "std"] }
 futures             = { workspace = true, features = ["async-await"] }
 hex.workspace       = true
+itertools           = "0.13.0"
 lazy_static         = { workspace = true }
 prometheus          = { version = "0.13.3", features = ["process"] }
 prost.workspace     = true
 protos              = { workspace = true, features = ["client"] }
 reqwest             = { workspace = true, features = ["json", "blocking"] }
-retry               = "2.0.0"
 serde               = { workspace = true, features = ["derive"] }
 serde_json          = { workspace = true }
 sqlx                = { workspace = true, features = ["postgres", "runtime-tokio", "tls-rustls", "time", "macros", "json"] }


### PR DESCRIPTION
A simplification of the current tendermint indexer. It can be simplified more, but this already despaghettifies a lot.