### PR TITLE
feat(ci): accept 429 status code in link checker

### DIFF
--- a/lychee.toml
+++ b/lychee.toml
@@ -15,6 +15,6 @@ exclude = [
   '^https://union-testnet-grpc.polkachu.com',
 ]
 
+accept              = ["200", "429"]
 exclude_all_private = true
 exclude_link_local  = true
-accept = ["200", "429"]


### PR DESCRIPTION
We keep seeing LinkedIn report 429 while running link checker. In *most* cases of 429, there will not be much we can do in CI to get around this.

This PR configures Lychee to accept the status code 429.