### PR TITLE
chore: remove site codeowners

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -2,4 +2,3 @@
 /.github/ @PoisonPhang
 /voyager/ @benluelo
 /galoisd/ @hussein-aitlahcen
-/site/ @cor @PoisonPhang


### PR DESCRIPTION
Site is one of the few directories with 2 codeowners, while most have 0/1.