### PR TITLE
fix(hubble): ignore clients without client_id

### DIFF
--- a/hubble/src/chain_id_query.rs
+++ b/hubble/src/chain_id_query.rs
@@ -54,6 +54,8 @@ pub async fn tx(db: PgPool, indexers: Indexers) {
                         cl.chain_id = ch.id
                     WHERE
                         ch.chain_id = $1
+                    AND
+                        cl.client_id is not NULL
                     "#,
                     chain_id
                 )


### PR DESCRIPTION
Hubble can't handle non-existent `client_id`s

```
Jun 05 05:52:30 hubble hubble-systemd[2198811]: The application panicked (crashed).
Jun 05 05:52:30 hubble hubble-systemd[2198811]: Message:  called `Option::unwrap()` on a `None` value
Jun 05 05:52:30 hubble hubble-systemd[2198811]: Location: hubble/src/chain_id_query.rs:67
Jun 05 05:52:30 hubble hubble-systemd[2198811]: Backtrace omitted. Run with RUST_BACKTRACE=1 environment variable to display it.
Jun 05 05:52:30 hubble hubble-systemd[2198811]: Run with RUST_BACKTRACE=full to include source snippets.
Jun 05 05:52:30 hubble hubble-systemd[2198811]: Error:
Jun 05 05:52:30 hubble hubble-systemd[2198811]:    0: task 58 panicked
Jun 05 05:52:30 hubble hubble-systemd[2198811]: Location:
Jun 05 05:52:30 hubble hubble-systemd[2198811]:    hubble/src/main.rs:98
```

this query lists them:

```sql
SELECT
	*
FROM
	V0_COSMOS.CREATE_CLIENT
WHERE
	CLIENT_ID IS NULL
```