### PR TITLE
chore(hubble): tweak expo backoff

### DIFF
--- a/hubble/src/main.rs
+++ b/hubble/src/main.rs
@@ -5,7 +5,7 @@
 use std::time::Duration;
 
 use axum::{routing::get, Router};
-use backon::ExponentialBuilder;
+use backon::{ConstantBuilder, ExponentialBuilder};
 use clap::Parser;
 use sqlx::postgres::PgPoolOptions;
 use tokio::task::JoinSet;
@@ -109,5 +109,13 @@ pub fn expo_backoff() -> ExponentialBuilder {
     ExponentialBuilder::default()
         .with_min_delay(Duration::from_secs(2))
         .with_max_delay(Duration::from_secs(60))
+        .with_max_times(60)
+        .with_factor(1.25)
+}
+
+/// Our 'new block' backoff we use to check if a new block arrived.
+pub fn new_block_backoff() -> ConstantBuilder {
+    ConstantBuilder::default()
+        .with_delay(Duration::from_millis(500))
         .with_max_times(60)
 }

--- a/hubble/src/tm.rs
+++ b/hubble/src/tm.rs
@@ -279,7 +279,7 @@ async fn fetch_and_insert_blocks(
                     .block_results(header.height)
                     .inspect_err(|e| debug!(?e, ?header.height, "error fetching block results"))
             })
-            .retry(&crate::expo_backoff())
+            .retry(&crate::new_block_backoff())
             .await?;
             let txs = (|| {
                 debug!(


### PR DESCRIPTION
Tweak Hubble backoff to be a bit more aggressive when fetching new blocks