### PR TITLE
fix(crane): actually run tests in test derivations

### DIFF
--- a/unionvisor/unionvisor.nix
+++ b/unionvisor/unionvisor.nix
@@ -6,8 +6,7 @@
       unionvisorAll = crane.buildWorkspaceMember {
         crateDirFromRoot = "unionvisor";
         cargoTestExtraAttrs = {
-          partitions = 1;
-          partitionType = "count";
+          cargoTestExtraArgs = "-- --test-threads 1";
           preConfigureHooks = [
             ''
               cp -r ${self'.packages.uniond-release}/bin/uniond $PWD/unionvisor/src/testdata/test_init_cmd/bundle/bins/genesis


### PR DESCRIPTION
i think something changed within crane the last time we update the flake input, we haven't been running tests in ci for a bit. whoops

also removed the individual clippy derivations since we run clippy on the whole repo