### PR TITLE
feat(hubble): faster inserts and add upsert mode

### DIFF
--- a/dictionary.txt
+++ b/dictionary.txt
@@ -718,6 +718,7 @@ msvc
 muldefs
 multisigs
 multistep
+multiunzip
 muno
 muslc
 nanos

--- a/hubble/.sqlx/query-342aeba317300419e54f78b96916accafc377d4fd4a98f9b87c091c8f18701e9.json
+++ b/hubble/.sqlx/query-342aeba317300419e54f78b96916accafc377d4fd4a98f9b87c091c8f18701e9.json
@@ -1,0 +1,19 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "\n            INSERT INTO v0.transactions (chain_id, block_hash, height, hash, data, index) \n            SELECT unnest($1::int[]), unnest($2::text[]), unnest($3::int[]), unnest($4::text[]), unnest($5::jsonb[]), unnest($6::int[])\n            ",
+  "describe": {
+    "columns": [],
+    "parameters": {
+      "Left": [
+        "Int4Array",
+        "TextArray",
+        "Int4Array",
+        "TextArray",
+        "JsonbArray",
+        "Int4Array"
+      ]
+    },
+    "nullable": []
+  },
+  "hash": "342aeba317300419e54f78b96916accafc377d4fd4a98f9b87c091c8f18701e9"
+}

--- a/hubble/.sqlx/query-9007db9f1e940092853db515a86b56184d0f017373c40fcc4970414dae9b523e.json
+++ b/hubble/.sqlx/query-9007db9f1e940092853db515a86b56184d0f017373c40fcc4970414dae9b523e.json
@@ -1,0 +1,18 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "\n            INSERT INTO v0.blocks (chain_id, hash, data, height, time)\n            SELECT unnest($1::int[]), unnest($2::text[]), unnest($3::jsonb[]), unnest($4::int[]), unnest($5::timestamptz[])\n            ",
+  "describe": {
+    "columns": [],
+    "parameters": {
+      "Left": [
+        "Int4Array",
+        "TextArray",
+        "JsonbArray",
+        "Int4Array",
+        "TimestamptzArray"
+      ]
+    },
+    "nullable": []
+  },
+  "hash": "9007db9f1e940092853db515a86b56184d0f017373c40fcc4970414dae9b523e"
+}

--- a/hubble/.sqlx/query-9b441330c7f7114464168f8be4958b5b68a0ffe685a2d7e55971e9c74cf9ccf4.json
+++ b/hubble/.sqlx/query-9b441330c7f7114464168f8be4958b5b68a0ffe685a2d7e55971e9c74cf9ccf4.json
@@ -1,0 +1,21 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "\n        INSERT INTO v0.events (chain_id, block_hash, height, transaction_hash, index, transaction_index, data, time)\n        SELECT unnest($1::int[]), unnest($2::text[]), unnest($3::int[]), unnest($4::text[]), unnest($5::int[]), unnest($6::int[]), unnest($7::jsonb[]), unnest($8::timestamptz[])\n        ON CONFLICT (transaction_hash, index) DO\n        UPDATE SET\n            chain_id = excluded.chain_id,\n            block_hash = excluded.block_hash,\n            height = excluded.height,\n            transaction_hash = excluded.transaction_hash,\n            index = excluded.index,\n            transaction_index = excluded.transaction_index,\n            data = excluded.data,\n            time = excluded.time\n    ",
+  "describe": {
+    "columns": [],
+    "parameters": {
+      "Left": [
+        "Int4Array",
+        "TextArray",
+        "Int4Array",
+        "TextArray",
+        "Int4Array",
+        "Int4Array",
+        "JsonbArray",
+        "TimestamptzArray"
+      ]
+    },
+    "nullable": []
+  },
+  "hash": "9b441330c7f7114464168f8be4958b5b68a0ffe685a2d7e55971e9c74cf9ccf4"
+}

--- a/hubble/.sqlx/query-9e4b7185e1b48daa94cd9b4c47db03c17ad3d64a0ee90ff5085c0f5825ff092e.json
+++ b/hubble/.sqlx/query-9e4b7185e1b48daa94cd9b4c47db03c17ad3d64a0ee90ff5085c0f5825ff092e.json
@@ -1,0 +1,19 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "\n            INSERT INTO v0.transactions (chain_id, block_hash, height, hash, data, index)\n            SELECT unnest($1::int[]), unnest($2::text[]), unnest($3::int[]), unnest($4::text[]), unnest($5::jsonb[]), unnest($6::int[])\n            ON CONFLICT (hash) DO\n            UPDATE SET\n                chain_id = excluded.chain_id,\n                block_hash = excluded.block_hash,\n                height = excluded.height,\n                hash = excluded.hash,\n                data = excluded.data,\n                index = excluded.index\n        ",
+  "describe": {
+    "columns": [],
+    "parameters": {
+      "Left": [
+        "Int4Array",
+        "TextArray",
+        "Int4Array",
+        "TextArray",
+        "JsonbArray",
+        "Int4Array"
+      ]
+    },
+    "nullable": []
+  },
+  "hash": "9e4b7185e1b48daa94cd9b4c47db03c17ad3d64a0ee90ff5085c0f5825ff092e"
+}

--- a/hubble/.sqlx/query-d3540e25fb86357e3900a35df6f9205cf13304e7f0d3d3cdb606c490ea82c1a4.json
+++ b/hubble/.sqlx/query-d3540e25fb86357e3900a35df6f9205cf13304e7f0d3d3cdb606c490ea82c1a4.json
@@ -1,0 +1,18 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "\n            INSERT INTO v0.blocks (chain_id, hash, data, height, time)\n            SELECT unnest($1::int[]), unnest($2::text[]), unnest($3::jsonb[]), unnest($4::int[]), unnest($5::timestamptz[])\n            ON CONFLICT (hash) DO \n            UPDATE SET\n                chain_id = excluded.chain_id,\n                hash = excluded.hash,\n                data = excluded.data,\n                height = excluded.height,\n                time = excluded.time\n        ",
+  "describe": {
+    "columns": [],
+    "parameters": {
+      "Left": [
+        "Int4Array",
+        "TextArray",
+        "JsonbArray",
+        "Int4Array",
+        "TimestamptzArray"
+      ]
+    },
+    "nullable": []
+  },
+  "hash": "d3540e25fb86357e3900a35df6f9205cf13304e7f0d3d3cdb606c490ea82c1a4"
+}

--- a/hubble/.sqlx/query-edfce3ae58f4872f01cd34e1162f5d66cf79cbb081dec0ac9dceb2213356ff56.json
+++ b/hubble/.sqlx/query-edfce3ae58f4872f01cd34e1162f5d66cf79cbb081dec0ac9dceb2213356ff56.json
@@ -1,0 +1,21 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "\n            INSERT INTO v0.events (chain_id, block_hash, height, transaction_hash, index, transaction_index, data, time)\n            SELECT unnest($1::int[]), unnest($2::text[]), unnest($3::int[]), unnest($4::text[]), unnest($5::int[]), unnest($6::int[]), unnest($7::jsonb[]), unnest($8::timestamptz[])\n            ",
+  "describe": {
+    "columns": [],
+    "parameters": {
+      "Left": [
+        "Int4Array",
+        "TextArray",
+        "Int4Array",
+        "TextArray",
+        "Int4Array",
+        "Int4Array",
+        "JsonbArray",
+        "TimestamptzArray"
+      ]
+    },
+    "nullable": []
+  },
+  "hash": "edfce3ae58f4872f01cd34e1162f5d66cf79cbb081dec0ac9dceb2213356ff56"
+}


### PR DESCRIPTION
1. Cleans up some batch inserting logic for tendermint chains
2. Adds insert-mode. Will enable it in the nixos config in a later PR. Will allow us to re-index data without needing to perform a delete.