### PR TITLE
feat(hubble): use unnest for eth inserts

### DIFF
--- a/hubble/.sqlx/query-543456abc777bff72096fd722beef0095d545f515d33e6058b6855120ce22988.json
+++ b/hubble/.sqlx/query-543456abc777bff72096fd722beef0095d545f515d33e6058b6855120ce22988.json
@@ -1,0 +1,18 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "\n            INSERT INTO v0.logs (chain_id, block_hash, data, height, time)\n            SELECT unnest($1::int[]), unnest($2::text[]), unnest($3::jsonb[]), unnest($4::int[]), unnest($5::timestamptz[])\n            ",
+  "describe": {
+    "columns": [],
+    "parameters": {
+      "Left": [
+        "Int4Array",
+        "TextArray",
+        "JsonbArray",
+        "Int4Array",
+        "TimestamptzArray"
+      ]
+    },
+    "nullable": []
+  },
+  "hash": "543456abc777bff72096fd722beef0095d545f515d33e6058b6855120ce22988"
+}

--- a/hubble/.sqlx/query-a271da9326aaec5f1a2055ae16c89673782fbed529683bb3a475e4a2c7a7ac6f.json
+++ b/hubble/.sqlx/query-a271da9326aaec5f1a2055ae16c89673782fbed529683bb3a475e4a2c7a7ac6f.json
@@ -1,0 +1,18 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "\n            INSERT INTO v0.logs (chain_id, block_hash, data, height, time)\n            SELECT unnest($1::int[]), unnest($2::text[]), unnest($3::jsonb[]), unnest($4::int[]), unnest($5::timestamptz[])\n            ON CONFLICT (block_hash) DO \n            UPDATE SET\n                chain_id = excluded.chain_id,\n                block_hash = excluded.block_hash,\n                data = excluded.data,\n                height = excluded.height,\n                time = excluded.time\n            ",
+  "describe": {
+    "columns": [],
+    "parameters": {
+      "Left": [
+        "Int4Array",
+        "TextArray",
+        "JsonbArray",
+        "Int4Array",
+        "TimestamptzArray"
+      ]
+    },
+    "nullable": []
+  },
+  "hash": "a271da9326aaec5f1a2055ae16c89673782fbed529683bb3a475e4a2c7a7ac6f"
+}


### PR DESCRIPTION
Adds InsertMode and better batch inserts for evm indexer.