### PR TITLE
fix(app): fix scroll

### DIFF
--- a/app/src/lib/components/stepper.svelte
+++ b/app/src/lib/components/stepper.svelte
@@ -66,7 +66,7 @@ const cancel = () => {
           <p class="text-xs text-muted-foreground"><Truncate value={trace.tx} type="hash"/></p>
         {/if}
       {:else if step.description}
-          <div class="font-normal break-words">{step.description}</div>      
+          <div class="font-normal break-words">{step.description}</div>
       {/if}
     </div>
   </li>

--- a/app/src/routes/transfer/(components)/transfer-form.svelte
+++ b/app/src/routes/transfer/(components)/transfer-form.svelte
@@ -853,7 +853,7 @@ const resetInput = () => {
         {#if $fromChain}
           <Stepper steps={stepperSteps}
                    on:cancel={() => transferState.set({kind: "PRE_TRANSFER"})}
-                   nRetry={() => {
+                   onRetry={() => {
         transferState.update(ts => {
           // @ts-ignore
           ts.error = undefined;


### PR DESCRIPTION
Spent some time trying to fix the flip animation but without success, seems like it's a combination of transform and absolute.

This PR basically comments out and removes the classes from elements and adds a simpler svelte animation `in:slide`. I also kept the same padding as we do on /faucet, so the cards keep the same size etc.