### PR TITLE
fix(evm): ucs01: revert invalid change in denom prefixing

### DIFF
--- a/evm/contracts/apps/ucs/01-relay/Relay.sol
+++ b/evm/contracts/apps/ucs/01-relay/Relay.sol
@@ -445,7 +445,7 @@ contract UCS01Relay is
         }
         RelayPacket calldata packet = RelayPacketLib.decode(ibcPacket.data);
         string memory prefix = RelayLib.makeDenomPrefix(
-            ibcPacket.destination_port, ibcPacket.destination_channel
+            ibcPacket.source_port, ibcPacket.source_channel
         );
         uint256 packetTokensLength = packet.tokens.length;
         for (uint256 i; i < packetTokensLength; i++) {

--- a/evm/tests/src/apps/ucs/01-relay/Relay.t.sol
+++ b/evm/tests/src/apps/ucs/01-relay/Relay.t.sol
@@ -613,7 +613,7 @@ contract RelayTests is Test {
         // Receive a token that hasn't been escrowed
         Token[] memory tokens = new Token[](1);
         tokens[0].denom = RelayLib.makeForeignDenom(
-            destinationPort, destinationChannel, denom.toHexString()
+            sourcePort, sourceChannel, denom.toHexString()
         );
         tokens[0].amount = amount;
 
@@ -709,9 +709,7 @@ contract RelayTests is Test {
 
         Token[] memory tokens = new Token[](1);
         tokens[0].denom = RelayLib.makeForeignDenom(
-            args.destinationPort,
-            args.destinationChannel,
-            denomAddress.toHexString()
+            args.sourcePort, args.sourceChannel, denomAddress.toHexString()
         );
         tokens[0].amount = args.amount;
 
@@ -1111,7 +1109,7 @@ contract RelayTests is Test {
             args.receiver,
             args.relayer,
             RelayLib.makeForeignDenom(
-                args.sourcePort, args.sourceChannel, args.denomName
+                args.destinationPort, "channel-1", args.denomName
             ),
             args.amount,
             args.extension
@@ -1130,7 +1128,7 @@ contract RelayTests is Test {
             args.receiver,
             args.relayer,
             RelayLib.makeForeignDenom(
-                args.sourcePort, args.sourceChannel, args.denomName
+                args.destinationPort, "channel-2", args.denomName
             ),
             args.amount,
             args.extension


### PR DESCRIPTION
Revert changes made in https://github.com/unionlabs/union/pull/2672 where we wrongly switched the prefixing. See `onRecvPacket` function in https://github.com/cosmos/ibc/tree/main/spec/app/ics-020-fungible-token-transfer:
```js
    // we are the source if the packets were prefixed by the sending chain
    // if the sender sends the tokens prefixed with their channel end's
    // port and channel identifiers then we are receiving tokens we 
    // previously had sent to the sender, thus we are receiving the tokens
    // as a source zone
    if isTracePrefixed(packet.sourcePort, packet.sourceChannel, token) {
```