### PR TITLE
chore(ci): disable nightly workflow

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -3,8 +3,6 @@ name: Nightly
 on:
   workflow_dispatch:
   workflow_call:
-  schedule:
-    - cron: '0 4 * * *'
 
 jobs:
   build:


### PR DESCRIPTION
Until we're able to stabilize the e2e test suite, we'll disable the nightly workflow