### PR TITLE
fix(ci): provide backup sha when using garnix deploy

### DIFF
--- a/.github/workflows/deploy-app.yml
+++ b/.github/workflows/deploy-app.yml
@@ -30,7 +30,7 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           REPO: ${{ github.repository }}
-          REF: ${{ github.head_ref }}
+          REF: ${{ github.head_ref || github.sha }}
         run: |
           sleep 15
 

--- a/.github/workflows/deploy-app.yml
+++ b/.github/workflows/deploy-app.yml
@@ -2,11 +2,11 @@ name: Deploy App
 
 on:
   push:
-    # branches:
-    #   - main
-    #   - release/app
-    # paths:
-    #   - 'app/**'
+  # branches:
+  #   - main
+  #   - release/app
+  # paths:
+  #   - 'app/**'
   # pull_request:
   #   paths:
   #     - 'app/**'

--- a/.github/workflows/deploy-app.yml
+++ b/.github/workflows/deploy-app.yml
@@ -2,14 +2,14 @@ name: Deploy App
 
 on:
   push:
-  # branches:
-  #   - main
-  #   - release/app
-  # paths:
-  #   - 'app/**'
-  # pull_request:
-  #   paths:
-  #     - 'app/**'
+    branches:
+      - main
+      - release/app
+    paths:
+      - 'app/**'
+  pull_request:
+    paths:
+      - 'app/**'
   workflow_dispatch:
 
 concurrency:

--- a/.github/workflows/deploy-app.yml
+++ b/.github/workflows/deploy-app.yml
@@ -17,44 +17,48 @@ concurrency:
   cancel-in-progress: true
 
 env:
-  NIX_VERSION: nix-2.13.2
-  NIXPKGS_CHANNEL: nixos-22.11
   NODE_OPTIONS: '--no-warnings'
   ACTIONS_RUNNER_DEBUG: true
   ASTRO_TELEMETRY_DISABLED: true
 
 jobs:
-  build:
-    runs-on: ['ubuntu-latest']
-    permissions:
-      contents: read
+  garnix:
+    name: Wait on Garnix CI
+    runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-        with:
-          lfs: true
-      - uses: nixbuild/nix-quick-install-action@v26
-        with:
-          nix_on_tmpfs: false
-          nix_conf: |
-            experimental-features = nix-command flakes
-            access-tokens = ${{ secrets.GITHUB_TOKEN }}
-      - uses: nixbuild/nixbuild-action@812f1ab2b51842b0d44b9b79574611502d6940a0
-        with:
-          nixbuild_token: ${{secrets.nixbuild_token}}
-      - name: Build app
+      - name: Wait on Garnix CI Check Suite
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REPO: ${{ github.repository }}
+          REF: ${{ github.head_ref }}
         run: |
-          touch build.json
-          nix build .#packages.x86_64-linux.app \
-            --print-build-logs \
-            --eval-store auto \
-            --store ssh-ng://eu.nixbuild.net \
-            --builders "" --max-jobs 2 \
-            --show-trace \
-            --json
+          sleep 15
+
+          status=''
+
+          while [[ $status != 'completed' ]]; do
+            check_suites=$(gh api \
+              -H "Accept: application/vnd.github+json" \
+              -H "X-GitHub-Api-Version: 2022-11-28" \
+              "/repos/$REPO/commits/$REF/check-suites")
+
+            status=$(echo "$check_suites" | jq -r '.check_suites | .[] | select(.app.name == "Garnix CI") | .status')
+            sleep 15
+          done
+          conclusion=$(echo "$check_suites" | jq -r '.check_suites | .[] | select(.app.name == "Garnix CI") | .conclusion')
+          case "$conclusion" in
+            failure | timed_out | action_required | stale | startup_failure)
+              echo "ERROR: Garnix CI concluded with $conclusion"
+              exit 1
+              ;;
+            *)
+              echo "INFO: Garnix CI concluded with $conclusion"
+              ;;
+          esac
 
   deploy-preview:
     runs-on: ['ubuntu-latest']
-    needs: [build]
+    needs: [garnix]
     permissions:
       contents: read
       pull-requests: write
@@ -66,15 +70,11 @@ jobs:
       - uses: actions/checkout@v4
         with:
           lfs: true
-      - uses: nixbuild/nix-quick-install-action@v26
-      - uses: nixbuild/nixbuild-action@812f1ab2b51842b0d44b9b79574611502d6940a0
-        with:
-          nixbuild_token: ${{ secrets.nixbuild_token }}
-      - run: mkdir dump
-      - run: nix copy --to file://`pwd`/dump --from ssh-ng://eu.nixbuild.net `nix eval --raw .#packages.x86_64-linux.app` --extra-experimental-features nix-command
-      - run: cat dump/nar/*.nar.xz | xz -dc | nix-store --restore result
-
-        # create preview deployment when trigger is pull_request, then post preview deployment url as a pr comment
+      - uses: nixbuild/nix-quick-install-action@v28
+      - name: Fetch from Cache
+        run: |
+          nix develop
+          nix build .#app
       - name: '[preview] 🔶 Publish to Cloudflare Pages'
         env:
           CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
@@ -101,7 +101,7 @@ jobs:
 
   deploy-manual:
     runs-on: ['ubuntu-latest']
-    needs: [build]
+    needs: [garnix]
     env:
       npm_config_yes: true
     if: github.event_name == 'workflow_dispatch'
@@ -109,15 +109,11 @@ jobs:
       - uses: actions/checkout@v4
         with:
           lfs: true
-      - uses: nixbuild/nix-quick-install-action@v26
-      - uses: nixbuild/nixbuild-action@812f1ab2b51842b0d44b9b79574611502d6940a0
-        with:
-          nixbuild_token: ${{ secrets.nixbuild_token }}
-      - run: mkdir dump
-      - run: nix copy --to file://`pwd`/dump --from ssh-ng://eu.nixbuild.net `nix eval --raw .#packages.x86_64-linux.app` --extra-experimental-features nix-command
-      - run: cat dump/nar/*.nar.xz | xz -dc | nix-store --restore result
-
-        # create preview deployment when trigger is workflow_dispatch && branch is not main
+      - uses: nixbuild/nix-quick-install-action@v28
+      - name: Fetch from Cache
+        run: |
+          nix develop
+          nix build .#app
       - name: '[workflow-dispatch] 🔶 Publish to Cloudflare Pages'
         env:
           CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
@@ -126,7 +122,7 @@ jobs:
 
   deploy-staging:
     runs-on: ['ubuntu-latest']
-    needs: [build]
+    needs: [garnix]
     env:
       npm_config_yes: true
     environment: 'app-staging'
@@ -135,14 +131,11 @@ jobs:
       - uses: actions/checkout@v4
         with:
           lfs: true
-      - uses: nixbuild/nix-quick-install-action@v26
-      - uses: nixbuild/nixbuild-action@812f1ab2b51842b0d44b9b79574611502d6940a0
-        with:
-          nixbuild_token: ${{ secrets.nixbuild_token }}
-      - run: mkdir dump
-      - run: nix copy --to file://`pwd`/dump --from ssh-ng://eu.nixbuild.net `nix eval --raw .#packages.x86_64-linux.app` --extra-experimental-features nix-command
-      - run: cat dump/nar/*.nar.xz | xz -dc | nix-store --restore result
-
+      - uses: nixbuild/nix-quick-install-action@v28
+      - name: Fetch from Cache
+        run: |
+          nix develop
+          nix build .#app
       - name: '[staging] 🔶 Publish to Cloudflare Pages'
         env:
           CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
@@ -151,7 +144,7 @@ jobs:
 
   deploy-production:
     runs-on: ['ubuntu-latest']
-    needs: [build]
+    needs: [garnix]
     env:
       npm_config_yes: true
     environment: 'app-production'
@@ -160,14 +153,11 @@ jobs:
       - uses: actions/checkout@v4
         with:
           lfs: true
-      - uses: nixbuild/nix-quick-install-action@v26
-      - uses: nixbuild/nixbuild-action@812f1ab2b51842b0d44b9b79574611502d6940a0
-        with:
-          nixbuild_token: ${{ secrets.nixbuild_token }}
-      - run: mkdir dump
-      - run: nix copy --to file://`pwd`/dump --from ssh-ng://eu.nixbuild.net `nix eval --raw .#packages.x86_64-linux.app` --extra-experimental-features nix-command
-      - run: cat dump/nar/*.nar.xz | xz -dc | nix-store --restore result
-
+      - uses: nixbuild/nix-quick-install-action@v28
+      - name: Fetch from Cache
+        run: |
+          nix develop
+          nix build .#app
       - name: '[production] 🔶 Publish to Cloudflare Pages'
         env:
           CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}

--- a/.github/workflows/deploy-app.yml
+++ b/.github/workflows/deploy-app.yml
@@ -2,14 +2,14 @@ name: Deploy App
 
 on:
   push:
-    branches:
-      - main
-      - release/app
-    paths:
-      - 'app/**'
-  pull_request:
-    paths:
-      - 'app/**'
+    # branches:
+    #   - main
+    #   - release/app
+    # paths:
+    #   - 'app/**'
+  # pull_request:
+  #   paths:
+  #     - 'app/**'
   workflow_dispatch:
 
 concurrency:

--- a/app/app.nix
+++ b/app/app.nix
@@ -19,6 +19,7 @@
           buildInputs = combinedDeps;
           installPhase = ''
             mkdir -p $out
+            echo "force rebuild"
             cp -r ./build/* $out
           '';
           doDist = false;


### PR DESCRIPTION
- uses correct ref on `push` trigger: https://github.com/unionlabs/union/actions/runs/10616457172/job/29426901095