### PR TITLE
feat(unionvisor): add set-binary command

### DIFF
--- a/docs/src/content/docs/joining-testnet/unionvisor.mdx
+++ b/docs/src/content/docs/joining-testnet/unionvisor.mdx
@@ -109,6 +109,24 @@ We use `sudo` here because Docker created the files we are copying with elevated
 
 :::
 
+### Using Snapshots or State Sync
+
+For networks that have been producing blocks for more than a few weeks, syncing from genesis is often not recommended. Most validators and node operators prefer to use node snapshots or state sync to jump start their nodes.
+
+To use state sync or node snapshots with Unionvisor, you will need to use the `set-binary` sub-command of Unionvisor. You should set Unionvisor to use the version of `uniond` that was used to generate the node snapshot or state sync snapshot.
+
+You can use the `set-binary` command as follows:
+
+```sh frame="none"
+docker run \
+  --volume ~/.unionvisor:/.unionvisor \
+  --volume /tmp:/tmp \
+  -it ghcr.io/unionlabs/bundle-testnet-8:$UNIONVISOR_VERSION \
+  set-binary $UNIOND_VERSION
+```
+*Where `UNIOND_VERSION` is the version of `uniond` used when the snapshot was generated*
+
+
 ### Issuing Sub-Commands to uniond via Unionvisor
 
 To run `uniond` sub-commands, it will be useful to alias the Docker command in your shell `.*rc` file.

--- a/docs/src/content/docs/joining-testnet/unionvisor.mdx
+++ b/docs/src/content/docs/joining-testnet/unionvisor.mdx
@@ -113,16 +113,16 @@ We use `sudo` here because Docker created the files we are copying with elevated
 
 For networks that have been producing blocks for more than a few weeks, syncing from genesis is often not recommended. Most validators and node operators prefer to use node snapshots or state sync to jump start their nodes.
 
-To use state sync or node snapshots with Unionvisor, you will need to use the `set-binary` sub-command of Unionvisor. You should set Unionvisor to use the version of `uniond` that was used to generate the node snapshot or state sync snapshot.
+To use state sync or node snapshots with Unionvisor, you will need to use the `set-uniond-version` sub-command of Unionvisor. You should set Unionvisor to use the version of `uniond` that was used to generate the node snapshot or state sync snapshot.
 
-You can use the `set-binary` command as follows:
+You can use the `set-uniond-version` command as follows:
 
 ```sh frame="none"
 docker run \
   --volume ~/.unionvisor:/.unionvisor \
   --volume /tmp:/tmp \
   -it ghcr.io/unionlabs/bundle-testnet-8:$UNIONVISOR_VERSION \
-  set-binary $UNIOND_VERSION
+  set-uniond-version $UNIOND_VERSION
 ```
 *Where `UNIOND_VERSION` is the version of `uniond` used when the snapshot was generated*
 

--- a/flake.nix
+++ b/flake.nix
@@ -596,6 +596,7 @@
 
             SQLX_OFFLINE = true;
             LIBCLANG_PATH = "${pkgs.llvmPackages_14.libclang.lib}/lib";
+            PROTOC = "${pkgs.protobuf}/bin/protoc";
           };
 
           treefmt = {

--- a/unionvisor/src/cli.rs
+++ b/unionvisor/src/cli.rs
@@ -57,7 +57,7 @@ pub struct Cli {
 pub enum Command {
     /// Set the current binary to a specific version in the bundle.
     /// Use this when using unionvisor in combination with a node snapshot or state sync.
-    SetBinary(SetBinaryCmd),
+    SetUniondVersion(SetUniondVersionCmd),
 
     /// Call the current binary, forwarding all arguments passed.
     /// `unionvisor call ..arg` is equivalent to `uniond ..args`.
@@ -71,7 +71,7 @@ pub enum Command {
 }
 
 #[derive(Clone, Parser)]
-pub struct SetBinaryCmd {
+pub struct SetUniondVersionCmd {
     /// Path to where the binary bundle is stored.
     #[arg(short, long, env = "UNIONVISOR_BUNDLE")]
     bundle: PathBuf,
@@ -129,8 +129,8 @@ pub struct RunCmd {
 impl Cli {
     pub fn run(self) -> Result<(), RunCliError> {
         match &self.command {
-            Command::SetBinary(cmd) => {
-                cmd.set_binary(self.root)?;
+            Command::SetUniondVersion(cmd) => {
+                cmd.set_uniond_version(self.root)?;
                 Ok(())
             }
             Command::Call(cmd) => {
@@ -152,7 +152,7 @@ impl Cli {
 #[derive(Debug, Error)]
 pub enum RunCliError {
     #[error("set binary error")]
-    SetBinary(#[from] SetBinaryError),
+    SetUniondVersion(#[from] SetUniondVersionError),
     #[error("call command error")]
     Call(#[from] CallError),
     #[error("run command error")]
@@ -249,7 +249,7 @@ pub enum RunError {
 }
 
 #[derive(Debug, Error)]
-pub enum SetBinaryError {
+pub enum SetUniondVersionError {
     #[error("runtime error")]
     Runtime(#[from] RuntimeError),
     #[error("new bundle error")]
@@ -258,8 +258,8 @@ pub enum SetBinaryError {
     Symlink(#[from] SymlinkerError),
 }
 
-impl SetBinaryCmd {
-    fn set_binary(&self, root: impl Into<PathBuf>) -> Result<(), SetBinaryError> {
+impl SetUniondVersionCmd {
+    fn set_uniond_version(&self, root: impl Into<PathBuf>) -> Result<(), SetUniondVersionError> {
         let root = root.into();
         let bundle = Bundle::new(self.bundle.clone())?;
         log_bundle(&bundle);

--- a/versions/versions.json
+++ b/versions/versions.json
@@ -21,7 +21,7 @@
   },
   "union-testnet-8": {
     "versions": ["v0.21.0", "v0.22.0", "v0.23.0", "v0.24.0"],
-    "current": "v0.22.0",
+    "current": "v0.24.0",
     "seeds": "c2bf0d5b2ad3a1df0f4e9cc32debffa239c0af90@testnet.seed.poisonphang.com:26656"
   }
 }


### PR DESCRIPTION
Adds the `set-binary` command to unionvisor enabling users to easily set the version of `uniond` being used by unionvisor. This allows users to more easily use tools like state sync and node snapshots.

Usage:
```shell
unionvisor --root $ROOT set-binary --bundle $BUNDLE $UNIOND_VERSION
```