### PR TITLE
chore: fix edit link in docs

### DIFF
--- a/dictionary.txt
+++ b/dictionary.txt
@@ -501,6 +501,7 @@ evmincosmos
 evmos
 extldflags
 extralight
+fastfetch
 fastnode
 feegrant
 feegrantkeeper

--- a/docs/astro.config.ts
+++ b/docs/astro.config.ts
@@ -44,7 +44,7 @@ export default defineConfig({
       favicon: "/favicon.svg",
       lastUpdated: true,
       editLink: {
-        baseUrl: "https://github.com/unionlabs/union/tree/main/docs"
+        baseUrl: "https://github.com/unionlabs/union/edit/main/docs/"
       },
       social: {
         github: "https://github.com/unionlabs",

--- a/docs/src/content/docs/infrastructure/node-operators/nixos.mdx
+++ b/docs/src/content/docs/infrastructure/node-operators/nixos.mdx
@@ -59,7 +59,7 @@ The example currently uses `git+ssh://` syntax rather than `github:` syntax beca
                 bottom
                 helix
                 jq
-                neofetch
+                fastfetch
                 tree
               ];
             }


### PR DESCRIPTION
missed the edit part in the url

`neofetch` is deprecated
