### PR TITLE
fix: pagination button visibility when there's alert

### DIFF
--- a/app/src/routes/explorer/+layout.svelte
+++ b/app/src/routes/explorer/+layout.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+import { onMount } from "svelte"
 import { page } from "$app/stores"
 import { onNavigate } from "$app/navigation"
 import { cn } from "$lib/utilities/shadcn.ts"
@@ -16,6 +17,16 @@ $: explorerPageDescription =
 onNavigate(navigation => {
   if (navigation.to?.route.id?.split("/").at(1) === "explorer") {
     explorerRoute = navigation.to?.route.id?.split("/").at(2) ?? null
+  }
+})
+
+onMount(() => {
+  const announcementElement = document.querySelector("div.betteruptime-announcement")
+  if (!announcementElement) return
+  const elementHeight = announcementElement.getBoundingClientRect().height
+  const explorerLayoutElement = document.querySelector("div[data-explorer-layout]")
+  if (explorerLayoutElement) {
+    explorerLayoutElement.style.paddingBottom = `${elementHeight + 10}px`
   }
 })
 </script>
@@ -53,7 +64,7 @@ onNavigate(navigation => {
     {/if}
 
     <div class="flex flex-col flex-1 size-full">
-      <div class="p-2 sm:p-4 md:p-6">
+      <div class="p-2 sm:p-4 md:p-6" data-explorer-layout>
         <div
           class={cn($page.route.id?.split("/").length === 3 ? "" : "hidden")}
         >

--- a/dictionary.txt
+++ b/dictionary.txt
@@ -332,6 +332,7 @@ behaviours
 benluelo
 berachain
 berachain's
+betteruptime
 bhapi
 bigdecimal
 bigtestnet


### PR DESCRIPTION
fixes #3084 

this solution is not perfect since it doesn't remove the applied style once the announcement is manually closed. The penalty is a little extra padding on bottom. But at least it makes nav buttons usable when there's an announcement