### PR TITLE
chore: remove garnix preview deployment requirement

### DIFF
--- a/.github/workflows/deploy-app.yml
+++ b/.github/workflows/deploy-app.yml
@@ -57,7 +57,6 @@ jobs:
 
   deploy-preview:
     runs-on: ['ubuntu-latest']
-    needs: [garnix]
     permissions:
       contents: read
       pull-requests: write
@@ -107,7 +106,6 @@ jobs:
 
   deploy-manual:
     runs-on: ['ubuntu-latest']
-    needs: [garnix]
     env:
       npm_config_yes: true
       ENVIRONMENT: 'preview'

--- a/.github/workflows/deploy-ceremony.yml
+++ b/.github/workflows/deploy-ceremony.yml
@@ -58,7 +58,6 @@ jobs:
 
   deploy-preview:
     runs-on: ['ubuntu-latest']
-    needs: [garnix]
     permissions:
       contents: read
       pull-requests: write
@@ -104,7 +103,6 @@ jobs:
 
   deploy-manual:
     runs-on: ['ubuntu-latest']
-    needs: [garnix]
     env:
       npm_config_yes: true
     if: github.event_name == 'workflow_dispatch'

--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -63,7 +63,6 @@ jobs:
 
   deploy-preview:
     runs-on: ['ubuntu-latest']
-    needs: [garnix]
     permissions:
       contents: read
       pull-requests: write
@@ -109,7 +108,6 @@ jobs:
 
   deploy-manual:
     runs-on: ['ubuntu-latest']
-    needs: [garnix]
     env:
       npm_config_yes: true
     if: github.event_name == 'workflow_dispatch'


### PR DESCRIPTION
we want preview deployments to go through even if spellcheck, fmt, etc fails