### PR TITLE
Small fix in Cometbls solidity light client and add misbehaviours to `ics08-cometbls`

### DIFF
--- a/evm/contracts/clients/CometblsClient.sol
+++ b/evm/contracts/clients/CometblsClient.sol
@@ -232,7 +232,7 @@ contract CometblsClient is
         Header calldata headerB
     ) internal returns (bool) {
         // Ensures that A > B to simplify the misbehavior of time violation check
-        if (headerA.trustedHeight < headerB.trustedHeight) {
+        if (headerA.signedHeader.height < headerB.signedHeader.height) {
             revert CometblsClientLib.ErrInvalidMisbehaviorHeadersSequence();
         }
 
@@ -247,7 +247,7 @@ contract CometblsClient is
         (, uint64 untrustedTimestampB,) =
             verifyHeader(headerB, consensusStateB, clientState);
 
-        if (headerA.trustedHeight == headerB.trustedHeight) {
+        if (headerA.signedHeader.height == headerB.signedHeader.height) {
             bytes32 hashA = keccak256(abi.encode(headerA.signedHeader));
             bytes32 hashB = keccak256(abi.encode(headerB.signedHeader));
             if (hashA != hashB) {

--- a/generated/rust/protos/src/union.ibc.lightclients.cometbls.v1.rs
+++ b/generated/rust/protos/src/union.ibc.lightclients.cometbls.v1.rs
@@ -56,13 +56,9 @@ impl ::prost::Name for ConsensusState {
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct Misbehaviour {
     #[prost(message, optional, tag = "1")]
-    pub header_1: ::core::option::Option<LightHeader>,
+    pub header_a: ::core::option::Option<Header>,
     #[prost(message, optional, tag = "2")]
-    pub header_2: ::core::option::Option<LightHeader>,
-    #[prost(bytes = "vec", tag = "3")]
-    pub header_1_zkp: ::prost::alloc::vec::Vec<u8>,
-    #[prost(bytes = "vec", tag = "4")]
-    pub header_2_zkp: ::prost::alloc::vec::Vec<u8>,
+    pub header_b: ::core::option::Option<Header>,
 }
 impl ::prost::Name for Misbehaviour {
     const NAME: &'static str = "Misbehaviour";

--- a/lib/unionlabs/src/ibc/lightclients/cometbls.rs
+++ b/lib/unionlabs/src/ibc/lightclients/cometbls.rs
@@ -2,3 +2,4 @@ pub mod client_state;
 pub mod consensus_state;
 pub mod header;
 pub mod light_header;
+pub mod misbehaviour;

--- a/lib/unionlabs/src/ibc/lightclients/cometbls/misbehaviour.rs
+++ b/lib/unionlabs/src/ibc/lightclients/cometbls/misbehaviour.rs
@@ -1,0 +1,46 @@
+use macros::model;
+
+use crate::{
+    errors::{required, MissingField},
+    ibc::lightclients::cometbls::header::{Header, TryFromHeaderError},
+};
+
+#[model(proto(
+    raw(protos::union::ibc::lightclients::cometbls::v1::Misbehaviour),
+    into,
+    from
+))]
+pub struct Misbehaviour {
+    pub header_a: Header,
+    pub header_b: Header,
+}
+
+impl From<Misbehaviour> for protos::union::ibc::lightclients::cometbls::v1::Misbehaviour {
+    fn from(value: Misbehaviour) -> Self {
+        Self {
+            header_a: Some(value.header_a.into()),
+            header_b: Some(value.header_b.into()),
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, thiserror::Error)]
+pub enum TryFromMisbehaviourError {
+    #[error(transparent)]
+    MissingField(MissingField),
+    #[error("invalid signed header")]
+    Header(#[from] TryFromHeaderError),
+}
+
+impl TryFrom<protos::union::ibc::lightclients::cometbls::v1::Misbehaviour> for Misbehaviour {
+    type Error = TryFromMisbehaviourError;
+
+    fn try_from(
+        value: protos::union::ibc::lightclients::cometbls::v1::Misbehaviour,
+    ) -> Result<Self, Self::Error> {
+        Ok(Self {
+            header_a: required!(value.header_a)?.try_into()?,
+            header_b: required!(value.header_b)?.try_into()?,
+        })
+    }
+}

--- a/light-clients/cometbls-light-client/src/errors.rs
+++ b/light-clients/cometbls-light-client/src/errors.rs
@@ -70,6 +70,12 @@ pub enum Error {
 
     #[error("the chain id cannot be more than 31 bytes long to fit in the bn254 scalar field")]
     InvalidChainId,
+
+    #[error("header_b.height should be greater than or equal to header_a.height")]
+    InvalidMisbehaviourHeaderSequence,
+
+    #[error("given headers don't prove a misbehaviour")]
+    MisbehaviourNotFound,
 }
 
 // required for IbcClient trait

--- a/uniond/proto/union/ibc/lightclients/cometbls/v1/cometbls.proto
+++ b/uniond/proto/union/ibc/lightclients/cometbls/v1/cometbls.proto
@@ -35,8 +35,8 @@ message ConsensusState {
 }
 
 message Misbehaviour {
-  Header header_1  = 1;
-  Header header_2  = 2;
+  Header header_a  = 1;
+  Header header_b  = 2;
 }
 
 message LightHeader {


### PR DESCRIPTION
- Use the correct height in `CometBLS` `Solidity` light client.
- Add misbehaviours to `ics08-movement`.