### PR TITLE
chore(eth-lc): fix canonicalization

### DIFF
--- a/lib/unionlabs/src/cosmwasm/wasm/union/custom_query.rs
+++ b/lib/unionlabs/src/cosmwasm/wasm/union/custom_query.rs
@@ -2,7 +2,9 @@ use core::fmt::Debug;
 
 use cosmwasm_std::{Binary, Deps, QueryRequest};
 
-use crate::{bls::BlsPublicKey, ibc::core::client::height::Height, ics24::Path};
+#[cfg(feature = "stargate")]
+use crate::ibc::core::client::height::Height;
+use crate::{bls::BlsPublicKey, ics24::Path};
 
 #[derive(thiserror::Error, Debug, PartialEq, Clone)]
 pub enum Error {

--- a/lib/unionlabs/src/ibc/core/channel/counterparty.rs
+++ b/lib/unionlabs/src/ibc/core/channel/counterparty.rs
@@ -4,14 +4,7 @@ use macros::model;
 
 use crate::id::PortId;
 
-#[model(
-    proto(raw(protos::ibc::core::channel::v1::Counterparty), into, from),
-    ethabi(
-        raw(contracts::ibc_handler::IbcCoreChannelV1CounterpartyData),
-        into,
-        from
-    )
-)]
+#[model(proto(raw(protos::ibc::core::channel::v1::Counterparty), into, from))]
 pub struct Counterparty {
     pub port_id: PortId,
     // TODO: Option<ChannelId>, same as connection counterparty
@@ -43,40 +36,6 @@ impl TryFrom<protos::ibc::core::channel::v1::Counterparty> for Counterparty {
                 .parse()
                 .map_err(TryFromChannelCounterpartyError::PortId)?,
             channel_id: proto.channel_id,
-        })
-    }
-}
-
-#[cfg(feature = "ethabi")]
-impl From<Counterparty> for contracts::ibc_handler::IbcCoreChannelV1CounterpartyData {
-    fn from(value: Counterparty) -> Self {
-        Self {
-            port_id: value.port_id.to_string(),
-            channel_id: value.channel_id,
-        }
-    }
-}
-
-#[cfg(feature = "ethabi")]
-#[derive(Debug, thiserror::Error)]
-pub enum TryFromEthAbiChannelCounterpartyError {
-    #[error("error parsing port id")]
-    PortId(#[source] <PortId as FromStr>::Err),
-}
-
-#[cfg(feature = "ethabi")]
-impl TryFrom<contracts::ibc_handler::IbcCoreChannelV1CounterpartyData> for Counterparty {
-    type Error = TryFromEthAbiChannelCounterpartyError;
-
-    fn try_from(
-        value: contracts::ibc_handler::IbcCoreChannelV1CounterpartyData,
-    ) -> Result<Self, Self::Error> {
-        Ok(Self {
-            port_id: value
-                .port_id
-                .parse()
-                .map_err(TryFromEthAbiChannelCounterpartyError::PortId)?,
-            channel_id: value.channel_id,
         })
     }
 }

--- a/lib/unionlabs/src/ibc/core/connection/connection_end.rs
+++ b/lib/unionlabs/src/ibc/core/connection/connection_end.rs
@@ -1,10 +1,10 @@
 use core::str::FromStr;
 
+use alloy::sol_types::SolValue as _;
 use macros::model;
 
-#[cfg(feature = "ethabi")]
-use crate::ibc::core::connection::counterparty::TryFromEthAbiConnectionCounterpartyError;
 use crate::{
+    encoding::{Encode, EthAbi},
     errors::{required, MissingField, UnknownEnumVariant},
     ibc::core::connection::{
         counterparty::{Counterparty, TryFromConnectionCounterpartyError},
@@ -12,12 +12,10 @@ use crate::{
         version::Version,
     },
     id::ClientId,
+    validated::ValidateT as _,
 };
 
-#[model(
-    proto(raw(protos::ibc::core::connection::v1::ConnectionEnd), into, from),
-    ethabi(raw(contracts::glue::IbcCoreConnectionV1ConnectionEndData), into, from)
-)]
+#[model(proto(raw(protos::ibc::core::connection::v1::ConnectionEnd), into, from))]
 #[cfg_attr(feature = "schemars", derive(::schemars::JsonSchema))]
 pub struct ConnectionEnd {
     pub client_id: ClientId,
@@ -81,57 +79,59 @@ impl From<ConnectionEnd> for protos::ibc::core::connection::v1::ConnectionEnd {
     }
 }
 
-#[derive(Debug)]
-#[cfg(feature = "ethabi")]
-pub enum TryFromEthAbiConnectionEndError {
-    ClientId(<ClientId as FromStr>::Err),
-    Version(UnknownEnumVariant<String>),
-    State(UnknownEnumVariant<u8>),
-    Counterparty(TryFromEthAbiConnectionCounterpartyError),
-}
+alloy::sol! {
+    struct SolIBCConnection {
+        SolIBCConnectionState state;
+        uint32 clientId;
+        uint32 counterpartyClientId;
+        uint32 counterpartyConnectionId;
+    }
 
-#[cfg(feature = "ethabi")]
-impl TryFrom<contracts::glue::IbcCoreConnectionV1ConnectionEndData> for ConnectionEnd {
-    type Error = TryFromEthAbiConnectionEndError;
-
-    fn try_from(
-        val: contracts::glue::IbcCoreConnectionV1ConnectionEndData,
-    ) -> Result<Self, Self::Error> {
-        Ok(Self {
-            client_id: val
-                .client_id
-                .parse()
-                .map_err(TryFromEthAbiConnectionEndError::ClientId)?,
-            versions: val
-                .versions
-                .into_iter()
-                .map(|x| {
-                    x.try_into()
-                        .map_err(TryFromEthAbiConnectionEndError::Version)
-                })
-                .collect::<Result<_, _>>()?,
-            state: val
-                .state
-                .try_into()
-                .map_err(TryFromEthAbiConnectionEndError::State)?,
-            counterparty: val
-                .counterparty
-                .try_into()
-                .map_err(TryFromEthAbiConnectionEndError::Counterparty)?,
-            delay_period: val.delay_period,
-        })
+    enum SolIBCConnectionState {
+        Unspecified,
+        Init,
+        TryOpen,
+        Open
     }
 }
 
-#[cfg(feature = "ethabi")]
-impl From<ConnectionEnd> for contracts::glue::IbcCoreConnectionV1ConnectionEndData {
-    fn from(val: ConnectionEnd) -> Self {
-        Self {
-            client_id: val.client_id.to_string(),
-            versions: val.versions.into_iter().map(Into::into).collect(),
-            state: val.state.into(),
-            counterparty: val.counterparty.into(),
-            delay_period: val.delay_period,
+impl Encode<EthAbi> for ConnectionEnd {
+    fn encode(self) -> Vec<u8> {
+        SolIBCConnection {
+            state: self.state.into(),
+            clientId: self
+                .client_id
+                .strip_suffix(char::is_numeric)
+                .unwrap()
+                .parse()
+                .unwrap(),
+            counterpartyClientId: self
+                .counterparty
+                .client_id
+                .strip_suffix(char::is_numeric)
+                .unwrap()
+                .parse()
+                .unwrap(),
+            counterpartyConnectionId: self
+                .counterparty
+                .connection_id
+                .unwrap_or("connection-0".to_string().validate().unwrap())
+                .strip_suffix(char::is_numeric)
+                .unwrap()
+                .parse()
+                .unwrap(),
+        }
+        .abi_encode()
+    }
+}
+
+impl From<State> for SolIBCConnectionState {
+    fn from(value: State) -> SolIBCConnectionState {
+        match value {
+            State::UninitializedUnspecified => SolIBCConnectionState::Unspecified,
+            State::Init => SolIBCConnectionState::Init,
+            State::Tryopen => SolIBCConnectionState::TryOpen,
+            State::Open => SolIBCConnectionState::Open,
         }
     }
 }

--- a/light-clients/ethereum-light-client/src/errors.rs
+++ b/light-clients/ethereum-light-client/src/errors.rs
@@ -4,7 +4,10 @@ use unionlabs::{
     encoding::{DecodeErrorOf, Proto},
     hash::H256,
     ibc::{
-        core::client::height::Height,
+        core::{
+            channel::channel::Channel, client::height::Height,
+            connection::connection_end::ConnectionEnd,
+        },
         lightclients::ethereum::{self, storage_proof::StorageProof},
     },
     uint::U256,
@@ -98,20 +101,12 @@ pub enum Error {
 
 #[derive(thiserror::Error, Debug, Clone, PartialEq)]
 pub enum CanonicalizeStoredValueError {
-    // #[error("the proof path {0} is unknown")]
-    // UnknownIbcPath(String),
-    // #[error("unable to decode counterparty's stored cometbls client state")]
-    // CometblsClientStateDecode(
-    //     #[source] DecodeErrorOf<Proto, Any<cometbls::client_state::ClientState>>,
-    // ),
-    // #[error("unable to decode counterparty's stored cometbls consensus state")]
-    // CometblsConsensusStateDecode(
-    //     #[source]
-    //     DecodeErrorOf<
-    //         Proto,
-    //         Any<wasm::consensus_state::ConsensusState<cometbls::consensus_state::ConsensusState>>,
-    //     >,
-    // ),
+    #[error("the proof path {0} is unknown")]
+    UnknownIbcPath(String),
+    #[error("connection end")]
+    ConnectionEnd(#[source] DecodeErrorOf<Proto, ConnectionEnd>),
+    #[error("channel")]
+    Channel(#[source] DecodeErrorOf<Proto, Channel>),
 }
 
 #[derive(Debug, PartialEq, Clone, thiserror::Error)]


### PR DESCRIPTION
* Added `alloy::sol` implementations of the Solidity IBC types.
* Added canonicalization for `ConnectionEnd` and `Channel` in eth lc.