### PR TITLE
feat: refactor id types

### DIFF
--- a/cosmwasm/ucs01-relay/src/ibc/tests.rs
+++ b/cosmwasm/ucs01-relay/src/ibc/tests.rs
@@ -22,7 +22,10 @@ use ucs01_relay_api::{
     protocol::TransferProtocol,
     types::make_foreign_denom,
 };
-use unionlabs::validated::Validated;
+use unionlabs::{
+    id::{ChannelId, PortId},
+    validated::Validated,
+};
 
 use crate::{
     contract::{execute, instantiate, query},
@@ -617,8 +620,8 @@ fn test_pfm_valid_memo() {
         &(Memo::Forward {
             forward: PacketForward {
                 receiver: Validated::new(fwd_contract_addr.to_string()).unwrap(),
-                port: Validated::new(fwd_dst_port.clone()).unwrap(),
-                channel: Validated::new(fwd_dst_channel.clone()).unwrap(),
+                port: PortId::new(fwd_dst_port.clone()).unwrap(),
+                channel: ChannelId::from_str_prefixed(&fwd_dst_channel).unwrap(),
                 next: None,
                 retries: 1,
                 return_info: None,

--- a/cosmwasm/ucs01-relay/src/protocol.rs
+++ b/cosmwasm/ucs01-relay/src/protocol.rs
@@ -125,7 +125,7 @@ pub trait TransferProtocolExt<'a>:
         };
 
         let transfer_msg = TransferMsg {
-            channel: forward.channel.clone().value(),
+            channel: forward.channel.clone().to_string_prefixed(),
             receiver: forward.receiver.value(),
             timeout: Some(timeout),
             memo,
@@ -145,8 +145,8 @@ pub trait TransferProtocolExt<'a>:
             origin_sender_addr: self.common().info.sender.clone(),
             origin_packet: original_packet,
             forward_timeout: timeout,
-            forward_src_channel_id: forward.channel.value(),
-            forward_src_port_id: forward.port.value(),
+            forward_src_channel_id: forward.channel.to_string_prefixed(),
+            forward_src_port_id: forward.port.to_string(),
             origin_protocol_version: Self::VERSION.to_string(),
         };
 

--- a/lib/ibc-events/src/lib.rs
+++ b/lib/ibc-events/src/lib.rs
@@ -197,7 +197,7 @@ event! {
 
         #[event(tag = "connection_open_init", deprecated("counterparty_connection_id"))]
         ConnectionOpenInit {
-            #[parse(ConnectionId::from_str)]
+            #[parse(ConnectionId::from_str_prefixed)]
             connection_id: ConnectionId,
             #[parse(ClientId::from_str)]
             client_id: ClientId,
@@ -207,37 +207,37 @@ event! {
 
         #[event(tag = "connection_open_try")]
         ConnectionOpenTry {
-            #[parse(ConnectionId::from_str)]
+            #[parse(ConnectionId::from_str_prefixed)]
             connection_id: ConnectionId,
             #[parse(ClientId::from_str)]
             client_id: ClientId,
             #[parse(ClientId::from_str)]
             counterparty_client_id: ClientId,
-            #[parse(ConnectionId::from_str)]
+            #[parse(ConnectionId::from_str_prefixed)]
             counterparty_connection_id: ConnectionId,
         },
 
         #[event(tag = "connection_open_ack")]
         ConnectionOpenAck {
-            #[parse(ConnectionId::from_str)]
+            #[parse(ConnectionId::from_str_prefixed)]
             connection_id: ConnectionId,
             #[parse(ClientId::from_str)]
             client_id: ClientId,
             #[parse(ClientId::from_str)]
             counterparty_client_id: ClientId,
-            #[parse(ConnectionId::from_str)]
+            #[parse(ConnectionId::from_str_prefixed)]
             counterparty_connection_id: ConnectionId,
         },
 
         #[event(tag = "connection_open_confirm")]
         ConnectionOpenConfirm {
-            #[parse(ConnectionId::from_str)]
+            #[parse(ConnectionId::from_str_prefixed)]
             connection_id: ConnectionId,
             #[parse(ClientId::from_str)]
             client_id: ClientId,
             #[parse(ClientId::from_str)]
             counterparty_client_id: ClientId,
-            #[parse(ConnectionId::from_str)]
+            #[parse(ConnectionId::from_str_prefixed)]
             counterparty_connection_id: ConnectionId,
         },
 
@@ -245,11 +245,11 @@ event! {
         ChannelOpenInit {
             #[parse(PortId::from_str)]
             port_id: PortId,
-            #[parse(ChannelId::from_str)]
+            #[parse(ChannelId::from_str_prefixed)]
             channel_id: ChannelId,
             #[parse(PortId::from_str)]
             counterparty_port_id: PortId,
-            #[parse(ConnectionId::from_str)]
+            #[parse(ConnectionId::from_str_prefixed)]
             connection_id: ConnectionId,
             version: String,
         },
@@ -258,13 +258,13 @@ event! {
         ChannelOpenTry {
             #[parse(PortId::from_str)]
             port_id: PortId,
-            #[parse(ChannelId::from_str)]
+            #[parse(ChannelId::from_str_prefixed)]
             channel_id: ChannelId,
             #[parse(PortId::from_str)]
             counterparty_port_id: PortId,
-            #[parse(ChannelId::from_str)]
+            #[parse(ChannelId::from_str_prefixed)]
             counterparty_channel_id: ChannelId,
-            #[parse(ConnectionId::from_str)]
+            #[parse(ConnectionId::from_str_prefixed)]
             connection_id: ConnectionId,
             version: String,
         },
@@ -273,13 +273,13 @@ event! {
         ChannelOpenAck {
             #[parse(PortId::from_str)]
             port_id: PortId,
-            #[parse(ChannelId::from_str)]
+            #[parse(ChannelId::from_str_prefixed)]
             channel_id: ChannelId,
             #[parse(PortId::from_str)]
             counterparty_port_id: PortId,
-            #[parse(ChannelId::from_str)]
+            #[parse(ChannelId::from_str_prefixed)]
             counterparty_channel_id: ChannelId,
-            #[parse(ConnectionId::from_str)]
+            #[parse(ConnectionId::from_str_prefixed)]
             connection_id: ConnectionId,
         },
 
@@ -287,13 +287,13 @@ event! {
         ChannelOpenConfirm {
             #[parse(PortId::from_str)]
             port_id: PortId,
-            #[parse(ChannelId::from_str)]
+            #[parse(ChannelId::from_str_prefixed)]
             channel_id: ChannelId,
             #[parse(PortId::from_str)]
             counterparty_port_id: PortId,
-            #[parse(ChannelId::from_str)]
+            #[parse(ChannelId::from_str_prefixed)]
             counterparty_channel_id: ChannelId,
-            #[parse(ConnectionId::from_str)]
+            #[parse(ConnectionId::from_str_prefixed)]
             connection_id: ConnectionId,
         },
 
@@ -313,16 +313,16 @@ event! {
             packet_sequence: NonZeroU64,
             #[parse(PortId::from_str)]
             packet_src_port: PortId,
-            #[parse(ChannelId::from_str)]
+            #[parse(ChannelId::from_str_prefixed)]
             packet_src_channel: ChannelId,
             #[parse(PortId::from_str)]
             packet_dst_port: PortId,
-            #[parse(ChannelId::from_str)]
+            #[parse(ChannelId::from_str_prefixed)]
             packet_dst_channel: ChannelId,
             #[parse(hex::decode)]
             #[serde(with = "::serde_utils::hex_string")]
             packet_ack_hex: Vec<u8>,
-            #[parse(ConnectionId::from_str)]
+            #[parse(ConnectionId::from_str_prefixed)]
             connection_id: ConnectionId,
         },
 
@@ -339,15 +339,15 @@ event! {
             packet_sequence: NonZeroU64,
             #[parse(PortId::from_str)]
             packet_src_port: PortId,
-            #[parse(ChannelId::from_str)]
+            #[parse(ChannelId::from_str_prefixed)]
             packet_src_channel: ChannelId,
             #[parse(PortId::from_str)]
             packet_dst_port: PortId,
-            #[parse(ChannelId::from_str)]
+            #[parse(ChannelId::from_str_prefixed)]
             packet_dst_channel: ChannelId,
             #[parse(Order::from_str)]
             packet_channel_ordering: Order,
-            #[parse(ConnectionId::from_str)]
+            #[parse(ConnectionId::from_str_prefixed)]
             connection_id: ConnectionId,
         },
 
@@ -365,15 +365,15 @@ event! {
             packet_sequence: NonZeroU64,
             #[parse(PortId::from_str)]
             packet_src_port: PortId,
-            #[parse(ChannelId::from_str)]
+            #[parse(ChannelId::from_str_prefixed)]
             packet_src_channel: ChannelId,
             #[parse(PortId::from_str)]
             packet_dst_port: PortId,
-            #[parse(ChannelId::from_str)]
+            #[parse(ChannelId::from_str_prefixed)]
             packet_dst_channel: ChannelId,
             #[parse(Order::from_str)]
             packet_channel_ordering: Order,
-            #[parse(ConnectionId::from_str)]
+            #[parse(ConnectionId::from_str_prefixed)]
             connection_id: ConnectionId,
         },
 
@@ -387,15 +387,15 @@ event! {
             packet_sequence: NonZeroU64,
             #[parse(PortId::from_str)]
             packet_src_port: PortId,
-            #[parse(ChannelId::from_str)]
+            #[parse(ChannelId::from_str_prefixed)]
             packet_src_channel: ChannelId,
             #[parse(PortId::from_str)]
             packet_dst_port: PortId,
-            #[parse(ChannelId::from_str)]
+            #[parse(ChannelId::from_str_prefixed)]
             packet_dst_channel: ChannelId,
             #[parse(Order::from_str)]
             packet_channel_ordering: Order,
-            #[parse(ConnectionId::from_str)]
+            #[parse(ConnectionId::from_str_prefixed)]
             connection_id: ConnectionId,
         },
 
@@ -409,15 +409,15 @@ event! {
             packet_sequence: NonZeroU64,
             #[parse(PortId::from_str)]
             packet_src_port: PortId,
-            #[parse(ChannelId::from_str)]
+            #[parse(ChannelId::from_str_prefixed)]
             packet_src_channel: ChannelId,
             #[parse(PortId::from_str)]
             packet_dst_port: PortId,
-            #[parse(ChannelId::from_str)]
+            #[parse(ChannelId::from_str_prefixed)]
             packet_dst_channel: ChannelId,
             #[parse(Order::from_str)]
             packet_channel_ordering: Order,
-            #[parse(ConnectionId::from_str)]
+            #[parse(ConnectionId::from_str_prefixed)]
             connection_id: ConnectionId,
         },
     }
@@ -452,7 +452,7 @@ impl IbcEvent {
 mod tests {
     mod event_conversion {
         use cometbft_types::abci::{event::Event, event_attribute::EventAttribute};
-        use unionlabs::ibc::core::client::height::{Height, HeightFromStrError};
+        use unionlabs::{ibc::core::client::height::Height, id::ConnectionId};
 
         use crate::{
             ConnectionOpenConfirm, CreateClient, TryFromTendermintEventError, UpdateClient,
@@ -487,10 +487,10 @@ mod tests {
                     ],
                 }),
                 Ok(ConnectionOpenConfirm {
-                    connection_id: "connection-11".parse().unwrap(),
+                    connection_id: ConnectionId::new(11),
                     client_id: "08-wasm-1".parse().unwrap(),
                     counterparty_client_id: "cometbls-new-0".parse().unwrap(),
-                    counterparty_connection_id: "connection-6".parse().unwrap(),
+                    counterparty_connection_id: ConnectionId::new(6),
                 })
             );
         }
@@ -500,7 +500,7 @@ mod tests {
             let attributes = vec![
                 EventAttribute {
                     key: "client_id".to_string(),
-                    value: "client_id".to_string(),
+                    value: "client_id-1".to_string(),
                     index: true,
                 },
                 EventAttribute {
@@ -527,7 +527,7 @@ mod tests {
             };
 
             let expected_event = UpdateClient {
-                client_id: "client_id".parse().unwrap(),
+                client_id: "client_id-1".parse().unwrap(),
                 client_type: "client_type".to_string(),
                 consensus_heights: vec![Height::new_with_revision(1, 1)],
             };
@@ -557,7 +557,7 @@ mod tests {
                     attributes: vec![
                         EventAttribute {
                             key: "client_id".to_string(),
-                            value: "client_id".to_string(),
+                            value: "client_id-1".to_string(),
                             index: true,
                         },
                         EventAttribute {

--- a/lib/ibc-vm-rs/src/lib.rs
+++ b/lib/ibc-vm-rs/src/lib.rs
@@ -120,7 +120,7 @@ pub trait IbcHost: Sized {
 
     fn next_channel_identifier(&mut self) -> Result<ChannelId, Self::Error>;
 
-    fn client_state(&self, client_id: &str) -> Option<Vec<u8>>;
+    fn client_state(&self, client_id: &ClientId) -> Option<Vec<u8>>;
 
     fn read<T: Decode<Proto>>(&self, path: &Path) -> Option<T>;
 

--- a/lib/ibc-vm-rs/src/states/connection_handshake.rs
+++ b/lib/ibc-vm-rs/src/states/connection_handshake.rs
@@ -9,8 +9,7 @@ use unionlabs::{
         },
     },
     ics24::ConnectionPath,
-    id::ClientId,
-    validated::ValidateT,
+    id::{ClientId, ConnectionId},
 };
 
 use crate::{
@@ -331,7 +330,7 @@ impl<T: IbcHost> Runnable<T> for ConnectionOpenAck {
                 let connection: ConnectionEnd = host
                     .read(
                         &ConnectionPath {
-                            connection_id: connection_id.clone().validate().unwrap(),
+                            connection_id: ConnectionId::from_str_prefixed(&connection_id).unwrap(),
                         }
                         .into(),
                     )
@@ -355,7 +354,9 @@ impl<T: IbcHost> Runnable<T> for ConnectionOpenAck {
                     state: connection::state::State::Tryopen,
                     counterparty: Counterparty {
                         client_id: client_id.clone(),
-                        connection_id: Some(connection_id.clone().validate().unwrap()),
+                        connection_id: Some(
+                            ConnectionId::from_str_prefixed(&connection_id).unwrap(),
+                        ),
                         prefix: DEFAULT_MERKLE_PREFIX.clone(),
                     },
                     delay_period: connection.delay_period,
@@ -402,13 +403,13 @@ impl<T: IbcHost> Runnable<T> for ConnectionOpenAck {
                 }
                 connection.state = connection::state::State::Open;
                 connection.counterparty.connection_id =
-                    Some(counterparty_connection_id.clone().validate().unwrap());
+                    Some(ConnectionId::from_str_prefixed(&counterparty_connection_id).unwrap());
 
                 let counterparty_client_id = connection.counterparty.client_id.clone();
 
                 host.commit(
                     ConnectionPath {
-                        connection_id: connection_id.clone().validate().unwrap(),
+                        connection_id: ConnectionId::from_str_prefixed(&connection_id).unwrap(),
                     }
                     .into(),
                     connection,
@@ -416,10 +417,13 @@ impl<T: IbcHost> Runnable<T> for ConnectionOpenAck {
 
                 Either::Right((
                     vec![IbcEvent::ConnectionOpenAck(ibc_events::ConnectionOpenAck {
-                        connection_id: connection_id.validate().unwrap(),
+                        connection_id: ConnectionId::from_str_prefixed(&connection_id).unwrap(),
                         client_id,
                         counterparty_client_id,
-                        counterparty_connection_id: counterparty_connection_id.validate().unwrap(),
+                        counterparty_connection_id: ConnectionId::from_str_prefixed(
+                            &counterparty_connection_id,
+                        )
+                        .unwrap(),
                     })],
                     IbcVmResponse::Empty,
                 ))
@@ -466,7 +470,7 @@ impl<T: IbcHost> Runnable<T> for ConnectionOpenConfirm {
                 let connection: ConnectionEnd = host
                     .read(
                         &ConnectionPath {
-                            connection_id: connection_id.clone().validate().unwrap(),
+                            connection_id: ConnectionId::from_str_prefixed(&connection_id).unwrap(),
                         }
                         .into(),
                     )
@@ -488,7 +492,9 @@ impl<T: IbcHost> Runnable<T> for ConnectionOpenConfirm {
                     state: connection::state::State::Open,
                     counterparty: Counterparty {
                         client_id: client_id.clone(),
-                        connection_id: Some(connection_id.clone().validate().unwrap()),
+                        connection_id: Some(
+                            ConnectionId::from_str_prefixed(&connection_id).unwrap(),
+                        ),
                         prefix: DEFAULT_MERKLE_PREFIX.clone(),
                     },
                     delay_period: connection.delay_period,
@@ -542,7 +548,7 @@ impl<T: IbcHost> Runnable<T> for ConnectionOpenConfirm {
                 connection.state = connection::state::State::Open;
                 host.commit(
                     ConnectionPath {
-                        connection_id: connection_id.clone().validate().unwrap(),
+                        connection_id: ConnectionId::from_str_prefixed(&connection_id).unwrap(),
                     }
                     .into(),
                     connection,
@@ -551,7 +557,7 @@ impl<T: IbcHost> Runnable<T> for ConnectionOpenConfirm {
                 Either::Right((
                     vec![IbcEvent::ConnectionOpenConfirm(
                         ibc_events::ConnectionOpenConfirm {
-                            connection_id: connection_id.validate().unwrap(),
+                            connection_id: ConnectionId::from_str_prefixed(&connection_id).unwrap(),
                             client_id,
                             counterparty_client_id,
                             counterparty_connection_id,

--- a/lib/ibc-vm-rs/src/states/packet.rs
+++ b/lib/ibc-vm-rs/src/states/packet.rs
@@ -11,7 +11,6 @@ use unionlabs::{
         ReceiptPath,
     },
     id::{ChannelId, ClientId, ConnectionId, PortId},
-    validated::ValidateT,
 };
 
 use crate::{
@@ -83,10 +82,10 @@ impl<T: IbcHost> Runnable<T> for RecvPacket {
                     .into());
                 }
 
-                if packet.source_channel.to_string() != channel.counterparty.channel_id {
+                if Some(&packet.source_channel) != channel.counterparty.channel_id.as_ref() {
                     return Err(IbcError::SourceChannelMismatch(
                         packet.source_channel,
-                        channel.counterparty.channel_id.validate().unwrap(),
+                        channel.counterparty.channel_id.unwrap(),
                     )
                     .into());
                 }
@@ -392,7 +391,7 @@ impl<T: IbcHost> Runnable<T> for SendPacket {
                         timeout_height,
                         timeout_timestamp,
                         destination_port: channel.counterparty.port_id,
-                        destination_channel: channel.counterparty.channel_id.validate().unwrap(),
+                        destination_channel: channel.counterparty.channel_id.unwrap(),
                         data,
                         connection_id: channel.connection_hops[0].clone(),
                     },
@@ -594,11 +593,10 @@ impl<T: IbcHost> Runnable<T> for Acknowledgement {
                     .into());
                 }
 
-                if packet.destination_channel.to_string() != channel.counterparty.channel_id {
+                if Some(&packet.destination_channel) != channel.counterparty.channel_id.as_ref() {
                     return Err(IbcError::DestinationChannelMismatch(
                         packet.destination_channel,
-                        // TODO(aeryz): make the error String so that we don't need to validate
-                        channel.counterparty.channel_id.validate().unwrap(),
+                        channel.counterparty.channel_id.unwrap(),
                     )
                     .into());
                 }

--- a/lib/ics23/src/ibc_api.rs
+++ b/lib/ics23/src/ibc_api.rs
@@ -169,6 +169,7 @@ mod tests {
             merkle_path::MerklePath, merkle_proof::MerkleProof, merkle_root::MerkleRoot,
         },
         ics24::ConnectionPath,
+        id::ConnectionId,
     };
 
     use super::{verify_membership, verify_non_membership, VerifyMembershipError, SDK_SPECS};
@@ -345,7 +346,7 @@ mod tests {
             &proof,
             &SDK_SPECS,
             &MerkleRoot { hash: hex!("F7ED1D182E325EA21817DC6048C7043056F76AB044642504CE57DDC5C1B47CD3").into() },
-            &[b"ibc".to_vec(), ConnectionPath { connection_id: "connection-2".parse().unwrap() }.to_string().into_bytes()],
+            &[b"ibc".to_vec(), ConnectionPath { connection_id: ConnectionId::new(2) }.to_string().into_bytes()],
             hex!("0a0930382d7761736d2d3112140a0131120f4f524445525f554e4f524445524544180122130a0a636f6d6574626c732d301a050a03696263").into()
         ).unwrap();
     }

--- a/lib/ics23/src/verify.rs
+++ b/lib/ics23/src/verify.rs
@@ -414,7 +414,7 @@ mod tests {
             commitment::{merkle_proof::MerkleProof, merkle_root::MerkleRoot},
             connection::{connection_end::ConnectionEnd, version::Version},
         },
-        validated::ValidateT,
+        id::{ClientId, ConnectionId},
     };
 
     use super::*;
@@ -523,15 +523,15 @@ mod tests {
             },
             &[b"ibc".to_vec(), key.to_vec()],
             ConnectionEnd {
-                client_id: String::from("08-wasm-0").validate().unwrap(),
+                client_id: ClientId::new("08-wasm", 0),
                 versions: vec![Version {
                     identifier: "1".to_string(),
                     features: vec![Order::Unordered],
                 }],
                 state: unionlabs::ibc::core::connection::state::State::Tryopen,
                 counterparty: unionlabs::ibc::core::connection::counterparty::Counterparty {
-                    client_id: "cometbls-0".to_string().validate().unwrap(),
-                    connection_id: Some("connection-0".to_string().validate().unwrap()),
+                    client_id: ClientId::new("cometbls", 0),
+                    connection_id: Some(ConnectionId::new(0)),
                     prefix: unionlabs::ibc::core::commitment::merkle_prefix::MerklePrefix {
                         key_prefix: b"ibc".to_vec(),
                     },

--- a/lib/near/dummy-ibc-app/src/contract.rs
+++ b/lib/near/dummy-ibc-app/src/contract.rs
@@ -13,7 +13,6 @@ use unionlabs::{
         client::height::Height,
     },
     id::{ChannelId, ConnectionId, PortId},
-    validated::ValidateT,
 };
 
 #[near_bindgen]
@@ -75,7 +74,7 @@ impl Contract {
     pub fn ping(ibc_addr: AccountId, source_channel: ChannelId) -> Promise {
         ext_ibc::ext(ibc_addr)
             .send_packet(
-                env::current_account_id().to_string().validate().unwrap(),
+                PortId::new(env::current_account_id().to_string()).unwrap(),
                 source_channel,
                 Height::new(1_000_000_000),
                 0,

--- a/lib/unionlabs/src/cosmwasm/wasm/union/custom_query.rs
+++ b/lib/unionlabs/src/cosmwasm/wasm/union/custom_query.rs
@@ -135,22 +135,16 @@ where
 pub fn query_consensus_state<T>(
     deps: Deps<UnionCustomQuery>,
     env: &Env,
-    // TODO: Use ClientId here
-    client_id: String,
+    client_id: crate::id::ClientId,
     height: Height,
 ) -> Result<T, Error>
 where
     Any<T>: Decode<Proto>,
 {
-    use crate::validated::ValidateT;
-
     query_ibc_abci::<T>(
         deps,
         env,
-        Path::ClientConsensusState(ClientConsensusStatePath {
-            client_id: client_id.validate().expect("invalid client id"),
-            height,
-        }),
+        Path::ClientConsensusState(ClientConsensusStatePath { client_id, height }),
     )
 }
 
@@ -159,19 +153,10 @@ where
 pub fn query_client_state<T>(
     deps: Deps<UnionCustomQuery>,
     env: &Env,
-    // TODO: Use ClientId here
-    client_id: String,
+    client_id: crate::id::ClientId,
 ) -> Result<T, Error>
 where
     Any<T>: Decode<Proto>,
 {
-    use crate::validated::ValidateT;
-
-    query_ibc_abci::<T>(
-        deps,
-        env,
-        Path::ClientState(ClientStatePath {
-            client_id: client_id.validate().expect("invalid client id"),
-        }),
-    )
+    query_ibc_abci::<T>(deps, env, Path::ClientState(ClientStatePath { client_id }))
 }

--- a/lib/unionlabs/src/ethereum.rs
+++ b/lib/unionlabs/src/ethereum.rs
@@ -31,7 +31,7 @@ mod tests {
     use hex_literal::hex;
 
     use super::*;
-    use crate::{ics24::ConnectionPath, validated::ValidateT};
+    use crate::{ics24::ConnectionPath, id::ConnectionId};
 
     #[test]
     fn commitment_key() {
@@ -40,14 +40,14 @@ mod tests {
                 U256::from_be_bytes(hex!(
                     "55c4893838cf8a468bfdb0c63e25a4c924d9b7ad283fc335d5f527d29b2fcfc7"
                 )),
-                "connection-100",
+                ConnectionId::new(100),
                 0,
             ),
             (
                 U256::from_be_bytes(hex!(
                     "f39538e1f0ca1c5f5ecdf1bb05f67c173f2d0f75b41fbb5be884f6aab2ebae91"
                 )),
-                "connection-1",
+                ConnectionId::new(1),
                 5,
             ),
         ];
@@ -55,10 +55,7 @@ mod tests {
         for (expected, connection_id, slot) in commitments {
             assert_eq!(
                 ibc_commitment_key(
-                    &ConnectionPath {
-                        connection_id: connection_id.to_owned().validate().unwrap()
-                    }
-                    .to_string(),
+                    &ConnectionPath { connection_id }.to_string(),
                     U256::from(slot),
                 ),
                 expected

--- a/lib/unionlabs/src/ibc/core/client/height.rs
+++ b/lib/unionlabs/src/ibc/core/client/height.rs
@@ -125,12 +125,16 @@ impl Ord for Height {
 
 impl fmt::Display for Height {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        match self.revision {
-            Some(revision_number) => {
-                write!(f, "{}-{}", revision_number, self.height)
-            }
-            None => {
-                write!(f, "{}", self.height)
+        if f.alternate() {
+            write!(f, "{}-{}", self.revision(), self.height)
+        } else {
+            match self.revision {
+                Some(revision_number) => {
+                    write!(f, "{}-{}", revision_number, self.height)
+                }
+                None => {
+                    write!(f, "{}", self.height)
+                }
             }
         }
     }
@@ -311,6 +315,28 @@ mod tests {
                 }
             ),
             "1"
+        );
+
+        assert_eq!(
+            format!(
+                "{:#}",
+                Height {
+                    revision: None,
+                    height: 1,
+                }
+            ),
+            "0-1"
+        );
+
+        assert_eq!(
+            format!(
+                "{:#}",
+                Height {
+                    revision: Some(nz!(1)),
+                    height: 1,
+                }
+            ),
+            "1-1"
         );
     }
 

--- a/lib/unionlabs/src/id.rs
+++ b/lib/unionlabs/src/id.rs
@@ -1,125 +1,410 @@
-use core::fmt::Debug;
-
-use crate::{
-    errors::{ExpectedLength, InvalidLength},
-    validated::{Validate, Validated},
+use alloc::borrow::Cow;
+use core::{
+    fmt::{self, Debug, Display},
+    num::ParseIntError,
+    str::FromStr,
 };
 
-pub type PortIdValidator = (Bounded<2, 128>, Ics024IdentifierCharacters);
-pub type PortId = Validated<String, PortIdValidator>;
+use serde::{Deserialize, Serialize};
 
-pub type ClientIdValidator = (Bounded<9, 64>, Ics024IdentifierCharacters);
-pub type ClientId = Validated<String, ClientIdValidator>;
+use crate::errors::{ExpectedLength, InvalidLength};
 
-pub type ConnectionIdValidator = (Bounded<10, 64>, Ics024IdentifierCharacters);
-pub type ConnectionId = Validated<String, ConnectionIdValidator>;
+const DELIMITER: char = '-';
 
-pub type ChannelIdValidator = (Bounded<8, 64>, Ics024IdentifierCharacters);
-pub type ChannelId = Validated<String, ChannelIdValidator>;
+pub const CONNECTION_ID_PREFIX: &str = "connection";
+pub const CHANNEL_ID_PREFIX: &str = "channel";
 
-#[cfg(feature = "schemars")]
-static_assertions::assert_impl_all!(ClientId: schemars::JsonSchema);
+#[derive(macros::Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize)]
+#[serde(try_from = "String", into = "String")]
+// #[cfg_attr(feature = "serde", serde(try_from = "String", into = "String"))]
+#[debug("ClientId({}-{})", self.prefix, self.id)]
+#[cfg_attr(feature = "schemars", derive(::schemars::JsonSchema))]
+// #[cfg_attr(
+//     feature = "valuable",
+//     derive(valuable::Valuable),
+//     valuable(transparent)
+// )]
+pub struct ClientId {
+    prefix: Cow<'static, str>,
+    id: u32,
+}
 
-// https://github.com/cosmos/ibc/tree/main/spec/core/ics-024-host-requirements#paths-identifiers-separators
-pub struct Ics024IdentifierCharacters;
+impl ClientId {
+    #[must_use]
+    pub fn new(prefix: impl Into<Cow<'static, str>>, id: u32) -> Self {
+        Self {
+            prefix: prefix.into(),
+            id,
+        }
+    }
+
+    #[must_use]
+    pub fn new_static(prefix: &'static str, id: u32) -> Self {
+        Self {
+            prefix: Cow::Borrowed(prefix),
+            id,
+        }
+    }
+
+    #[must_use]
+    pub const fn id(&self) -> u32 {
+        self.id
+    }
+}
+
+impl From<ClientId> for String {
+    fn from(value: ClientId) -> Self {
+        value.to_string()
+    }
+}
+
+impl TryFrom<String> for ClientId {
+    type Error = ParsePrefixedIdError;
+
+    fn try_from(value: String) -> Result<Self, Self::Error> {
+        value.parse()
+    }
+}
+
+impl FromStr for ClientId {
+    type Err = ParsePrefixedIdError;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        // NOTE: rsplit bc prefixes can contain `-`
+        let Some((prefix, id)) = s.rsplit_once(DELIMITER) else {
+            return Err(ParsePrefixedIdError::MissingPrefix);
+        };
+
+        id.parse()
+            .map(|id| Self {
+                prefix: prefix.to_owned().into(),
+                id,
+            })
+            .map_err(ParsePrefixedIdError::ParseIntError)
+    }
+}
+
+impl fmt::Display for ClientId {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{}-{}", self.prefix, self.id)
+    }
+}
+
+#[derive(macros::Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize)]
+#[serde(transparent)]
+// #[cfg_attr(feature = "serde", serde(transparent))]
+#[debug("ConnectionId({})", self.0)]
+#[cfg_attr(feature = "schemars", derive(::schemars::JsonSchema))]
+// #[cfg_attr(
+//     feature = "valuable",
+//     derive(valuable::Valuable),
+//     valuable(transparent)
+// )]
+pub struct ConnectionId(#[doc(hidden)] u32);
+
+impl ConnectionId {
+    #[must_use]
+    pub const fn new(id: u32) -> Self {
+        Self(id)
+    }
+
+    pub fn from_str_prefixed(s: &str) -> Result<Self, ParsePrefixedIdError> {
+        let Some((prefix, id)) = s.split_once(DELIMITER) else {
+            return Err(ParsePrefixedIdError::MissingPrefix);
+        };
+
+        if prefix != CONNECTION_ID_PREFIX {
+            return Err(ParsePrefixedIdError::UnexpectedPrefix {
+                expected: CONNECTION_ID_PREFIX,
+                found: s.to_owned(),
+            });
+        }
+
+        id.parse()
+            .map(Self)
+            .map_err(ParsePrefixedIdError::ParseIntError)
+    }
+
+    /// Formats this [`ConnectionId`] with it's alternate [`Display`] formatting, prefixing the ID with [`CONNECTION_ID_PREFIX`].
+    ///
+    /// ```rust
+    /// # use unionlabs::id::ConnectionId;
+    /// assert_eq!(
+    ///     ConnectionId::new(123).to_string_prefixed(),
+    ///     "connection-123"
+    /// );
+    /// ```
+    #[must_use]
+    pub fn to_string_prefixed(&self) -> String {
+        format!("{self:#}")
+    }
+
+    #[must_use]
+    pub const fn id(&self) -> u32 {
+        self.0
+    }
+}
+
+impl Display for ConnectionId {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        if f.alternate() {
+            write!(f, "{CONNECTION_ID_PREFIX}{DELIMITER}{}", self.id())
+        } else {
+            write!(f, "{}", self.id())
+        }
+    }
+}
+
+#[derive(macros::Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize)]
+#[serde(transparent)]
+// #[cfg_attr(feature = "serde", serde(transparent))]
+#[debug("ChannelId({})", self.0)]
+#[cfg_attr(feature = "schemars", derive(::schemars::JsonSchema))]
+// #[cfg_attr(
+//     feature = "valuable",
+//     derive(valuable::Valuable),
+//     valuable(transparent)
+// )]
+pub struct ChannelId(#[doc(hidden)] u32);
+
+impl ChannelId {
+    #[must_use]
+    pub const fn new(id: u32) -> Self {
+        Self(id)
+    }
+
+    #[must_use]
+    pub const fn id(&self) -> u32 {
+        self.0
+    }
+
+    pub fn from_str_prefixed(s: &str) -> Result<Self, ParsePrefixedIdError> {
+        let Some((prefix, id)) = s.split_once(DELIMITER) else {
+            return Err(ParsePrefixedIdError::MissingPrefix);
+        };
+
+        if prefix != CHANNEL_ID_PREFIX {
+            return Err(ParsePrefixedIdError::UnexpectedPrefix {
+                expected: CHANNEL_ID_PREFIX,
+                found: s.to_owned(),
+            });
+        }
+
+        id.parse()
+            .map(Self)
+            .map_err(ParsePrefixedIdError::ParseIntError)
+    }
+
+    /// Formats this [`ChannelId`] with it's alternate [`Display`] formatting, prefixing the ID with [`CHANNEL_ID_PREFIX`].
+    ///
+    /// ```rust
+    /// # use unionlabs::id::ChannelId;
+    /// assert_eq!(
+    ///     ChannelId::new(123).to_string_prefixed(),
+    ///     "channel-123"
+    /// );
+    /// ```
+    #[must_use]
+    pub fn to_string_prefixed(&self) -> String {
+        format!("{self:#}")
+    }
+}
+
+impl Display for ChannelId {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        if f.alternate() {
+            write!(f, "{CHANNEL_ID_PREFIX}{DELIMITER}{}", self.id())
+        } else {
+            write!(f, "{}", self.id())
+        }
+    }
+}
+
+#[derive(macros::Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize)]
+// #[cfg_attr(feature = "serde", serde(try_from = "String", into = "String"))]
+#[serde(try_from = "String", into = "String")]
+#[debug("PortId({})", self.0)]
+#[cfg_attr(feature = "schemars", derive(::schemars::JsonSchema))]
+pub struct PortId(#[doc(hidden)] Cow<'static, str>);
+
+// #[cfg(feature = "valuable")]
+// impl valuable::Valuable for PortId {
+//     fn as_value(&self) -> valuable::Value<'_> {
+//         valuable::Value::String(&self.0)
+//     }
+
+//     fn visit(&self, visit: &mut dyn valuable::Visit) {
+//         visit.visit_value(self.as_value());
+//     }
+// }
 
 #[derive(Debug, Clone, PartialEq, thiserror::Error)]
-#[error("invalid ics-024 identifier character: `{0}`")]
-pub struct InvalidIcs024IdentifierCharacter(char);
+pub enum ParsePrefixedIdError {
+    #[error("missing prefix")]
+    MissingPrefix,
+    #[error("expected prefix `{expected}` but found `{found}`")]
+    UnexpectedPrefix {
+        expected: &'static str,
+        found: String,
+    },
+    #[error("error parsing integer portion of id")]
+    ParseIntError(#[from] ParseIntError),
+}
 
-impl<T: AsRef<str>> Validate<T> for Ics024IdentifierCharacters {
-    type Error = InvalidIcs024IdentifierCharacter;
+impl PortId {
+    pub const MIN_LEN: usize = 2;
+    pub const MAX_LEN: usize = 128;
 
-    fn validate(s: T) -> Result<T, Self::Error> {
-        for c in s.as_ref().chars() {
-            match c {
-                'a'..='z'
-                | 'A'..='Z'
-                | '0'..='9'
-                | '.'
-                | '_'
-                | '+'
-                | '-'
-                | '#'
-                | '['
-                | ']'
-                | '<'
-                | '>' => {}
-                _ => return Err(InvalidIcs024IdentifierCharacter(c)),
+    pub fn new(s: impl Into<Cow<'static, str>>) -> Result<Self, Ics24IdParseError> {
+        let s: Cow<'_, str> = s.into();
+
+        validate_id(&s, Self::MIN_LEN, Self::MAX_LEN)?;
+
+        Ok(Self(s))
+    }
+
+    pub const fn new_static(s: &'static str) -> Result<Self, Ics24IdParseError> {
+        if let Err(e) = validate_id(s, Self::MIN_LEN, Self::MAX_LEN) {
+            return Err(e);
+        }
+
+        Ok(Self(Cow::Borrowed(s)))
+    }
+
+    #[must_use]
+    pub fn as_str(&self) -> &str {
+        &self.0
+    }
+}
+
+const fn validate_id(s: &str, min_len: usize, max_len: usize) -> Result<(), Ics24IdParseError> {
+    let len = s.len();
+
+    if len < min_len || len > max_len {
+        return Err(Ics24IdParseError::InvalidLength(InvalidLength {
+            expected: ExpectedLength::Between(min_len, max_len),
+            found: len,
+        }));
+    }
+
+    let mut i = len - 1;
+    let bz = s.as_bytes();
+
+    // https://github.com/cosmos/ibc/tree/main/spec/core/ics-024-host-requirements#paths-identifiers-separators
+    loop {
+        if i == 0 {
+            break;
+        }
+
+        let c = bz[i];
+        match c {
+            b'a'..=b'z'
+            | b'A'..=b'Z'
+            | b'0'..=b'9'
+            | b'.'
+            | b'_'
+            | b'+'
+            | b'-'
+            | b'#'
+            | b'['
+            | b']'
+            | b'<'
+            | b'>' => {}
+            _ => {
+                return Err(Ics24IdParseError::InvalidCharacter(
+                    InvalidIcs024IdentifierCharacter(c),
+                ))
             }
         }
 
-        Ok(s)
+        i -= 1;
+    }
+
+    Ok(())
+}
+
+impl From<PortId> for String {
+    fn from(value: PortId) -> Self {
+        value.0.into()
     }
 }
 
-pub struct Bounded<const MIN: usize, const MAX: usize>;
+impl TryFrom<String> for PortId {
+    type Error = Ics24IdParseError;
 
-impl<T: AsRef<str>, const MIN: usize, const MAX: usize> Validate<T> for Bounded<MIN, MAX> {
-    type Error = InvalidLength;
-
-    fn validate(s: T) -> Result<T, Self::Error> {
-        const { assert!(MIN <= MAX) };
-
-        let len = s.as_ref().len();
-
-        if (MIN..=MAX).contains(&len) {
-            Ok(s)
-        } else {
-            Err(InvalidLength {
-                expected: ExpectedLength::Between(MIN, MAX),
-                found: len,
-            })
-        }
+    fn try_from(value: String) -> Result<Self, Self::Error> {
+        Self::new(value)
     }
 }
+
+impl FromStr for PortId {
+    type Err = Ics24IdParseError;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        Self::new(s.to_owned())
+    }
+}
+
+impl fmt::Display for PortId {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        fmt::Display::fmt(&self.0, f)
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, thiserror::Error)]
+pub enum Ics24IdParseError {
+    #[error(transparent)]
+    InvalidCharacter(InvalidIcs024IdentifierCharacter),
+    #[error(transparent)]
+    InvalidLength(InvalidLength),
+}
+
+// #[cfg(feature = "schemars")]
+// static_assertions::assert_impl_all!(ClientId: schemars::JsonSchema);
+
+#[derive(Debug, Clone, PartialEq, thiserror::Error)]
+#[error("invalid ics-024 identifier character: `{0:x}`")]
+pub struct InvalidIcs024IdentifierCharacter(u8);
 
 #[cfg(test)]
 mod tests {
-    use alloc::borrow::Cow;
-
     use super::*;
-    use crate::validated::ValidateT;
-
-    fn ics024(
-        s: Cow<'_, str>,
-    ) -> Result<Cow<'_, str>, <Ics024IdentifierCharacters as Validate<Cow<'_, str>>>::Error> {
-        s.validate::<Ics024IdentifierCharacters>()
-            .map(Validated::value)
-    }
 
     #[test]
-    fn ics024_identifier_characters() {
-        assert_eq!(ics024("".into()), Ok("".into()));
-        assert_eq!(ics024("valid".into()), Ok("valid".into()));
+    fn port_id() {
         assert_eq!(
-            ics024(
-                "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890._+-#[]<>".into()
-            ),
-            Ok("abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890._+-#[]<>".into())
+            PortId::new(""),
+            Err(Ics24IdParseError::InvalidLength(InvalidLength {
+                expected: ExpectedLength::Between(PortId::MIN_LEN, PortId::MAX_LEN),
+                found: 0
+            }))
         );
         assert_eq!(
-            ics024("/".into()),
-            Err(InvalidIcs024IdentifierCharacter('/'))
+            PortId::new("a"),
+            Err(Ics24IdParseError::InvalidLength(InvalidLength {
+                expected: ExpectedLength::Between(PortId::MIN_LEN, PortId::MAX_LEN),
+                found: 1
+            }))
         );
-    }
+        assert_eq!(PortId::new("aa").as_ref().map(PortId::as_str), Ok("aa"));
+        assert_eq!(
+            PortId::new("a".repeat(PortId::MAX_LEN))
+                .as_ref()
+                .map(PortId::as_str),
+            Ok(&*"a".repeat(PortId::MAX_LEN))
+        );
 
-    fn bound<const MIN: usize, const MAX: usize>(
-        s: Cow<'_, str>,
-    ) -> Result<Cow<'_, str>, <Bounded<MIN, MAX> as Validate<Cow<'_, str>>>::Error> {
-        s.validate::<Bounded<MIN, MAX>>().map(Validated::value)
-    }
-
-    #[test]
-    fn bounded() {
-        assert_eq!(bound::<0, 1>("".into()), Ok("".into()));
-        assert_eq!(bound::<0, 1>("a".into()), Ok("a".into()));
-        assert_eq!(
-            bound::<0, 1>("aa".into()),
-            Err(InvalidLength {
-                expected: ExpectedLength::Between(0, 1),
-                found: 2
-            })
-        );
+        // assert_eq!(ics024("".into()), Ok("".into()));
+        // assert_eq!(ics024("valid".into()), Ok("valid".into()));
+        // assert_eq!(
+        //     ics024(
+        //         "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890._+-#[]<>".into()
+        //     ),
+        //     Ok("abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890._+-#[]<>".into())
+        // );
+        // assert_eq!(
+        //     ics024("/".into()),
+        //     Err(InvalidIcs024IdentifierCharacter(b'/'))
+        // );
     }
 }

--- a/lib/unionlabs/src/lib.rs
+++ b/lib/unionlabs/src/lib.rs
@@ -25,8 +25,8 @@ use serde::{Deserialize, Serialize};
 pub use typenum;
 
 use crate::{
+    errors::{ExpectedLength, InvalidLength},
     ibc::core::client::height::{Height, HeightFromStrError},
-    id::Bounded,
     validated::Validated,
 };
 
@@ -139,7 +139,22 @@ pub enum TryFromEthAbiBytesErrorAlloy<E> {
 
 /// An empty string. Will only parse/serialize to/from `""`.
 pub type EmptyString<S = String> = Validated<S, EmptyStringValidator>;
-pub type EmptyStringValidator = Bounded<0, 0>;
+pub struct EmptyStringValidator;
+
+impl<T: AsRef<str>> validated::Validate<T> for EmptyStringValidator {
+    type Error = InvalidLength;
+
+    fn validate(s: T) -> Result<T, Self::Error> {
+        if s.as_ref().is_empty() {
+            Ok(s)
+        } else {
+            Err(InvalidLength {
+                expected: ExpectedLength::Exact(0),
+                found: s.as_ref().len(),
+            })
+        }
+    }
+}
 
 #[doc(hidden)]
 pub use paste::paste;

--- a/lib/voyager-message/src/call.rs
+++ b/lib/voyager-message/src/call.rs
@@ -489,7 +489,7 @@ impl CallT<VoyagerMessage> for Call {
                             .ordering,
                         counterparty: channel::counterparty::Counterparty {
                             port_id: event.port_id,
-                            channel_id: event.channel_id.to_string(),
+                            channel_id: Some(event.channel_id),
                         },
                         connection_hops: vec![event.connection.counterparty.connection_id.unwrap()],
                         version: event.version.clone(),

--- a/lib/voyager-message/src/data.rs
+++ b/lib/voyager-message/src/data.rs
@@ -493,7 +493,8 @@ pub fn log_msg(chain_id: &str, effect: &IbcMessage) {
                 %chain_id,
                 %message.client_id,
                 %message.counterparty.client_id,
-                message.counterparty.connection_id = %message.counterparty.connection_id.as_deref().unwrap_or_default(),
+                // TODO: Use Valuable here
+                ?message.counterparty.connection_id,
                 message.counterparty.prefix.key_prefix = %::serde_utils::to_hex(message.counterparty.prefix.key_prefix),
                 %message.version.identifier,
                 message.version.features = %message
@@ -511,7 +512,8 @@ pub fn log_msg(chain_id: &str, effect: &IbcMessage) {
                 %chain_id,
                 %message.client_id,
                 %message.counterparty.client_id,
-                message.counterparty.connection_id = %message.counterparty.connection_id.as_deref().unwrap_or_default(),
+                // TODO: Use Valuable here
+                ?message.counterparty.connection_id,
                 message.counterparty.prefix.key_prefix = %::serde_utils::to_hex(message.counterparty.prefix.key_prefix),
                 %message.delay_period,
                 // TODO: This needs `valuable`
@@ -556,7 +558,8 @@ pub fn log_msg(chain_id: &str, effect: &IbcMessage) {
                 %message.channel.state,
                 %message.channel.ordering,
                 %message.channel.counterparty.port_id,
-                %message.channel.counterparty.channel_id,
+                // TODO: Use Valuable here
+                ?message.channel.counterparty.channel_id,
                 message.channel.connection_hops = %message
                     .channel
                     .connection_hops
@@ -575,7 +578,8 @@ pub fn log_msg(chain_id: &str, effect: &IbcMessage) {
                 %message.channel.state,
                 %message.channel.ordering,
                 %message.channel.counterparty.port_id,
-                %message.channel.counterparty.channel_id,
+                // TODO: Use Valuable here
+                ?message.channel.counterparty.channel_id,
                 message.channel.connection_hops = %message
                     .channel
                     .connection_hops

--- a/light-clients/arbitrum-light-client/types/src/client_state.rs
+++ b/light-clients/arbitrum-light-client/types/src/client_state.rs
@@ -27,10 +27,9 @@ pub mod proto {
     use unionlabs::{
         bounded::BoundedIntError,
         errors::{InvalidLength, MissingField, UnknownEnumVariant},
-        id::ClientIdValidator,
+        id::ParsePrefixedIdError,
         impl_proto_via_try_from_into, required,
         uint::{FromDecStrErr, U256},
-        validated::{Validate, ValidateT},
     };
 
     use crate::ClientState;
@@ -44,7 +43,7 @@ pub mod proto {
             value: protos::union::ibc::lightclients::arbitrum::v1::ClientState,
         ) -> Result<Self, Self::Error> {
             Ok(Self {
-                l1_client_id: value.l1_client_id.validate().map_err(Error::L1ClientId)?,
+                l1_client_id: value.l1_client_id.parse().map_err(Error::L1ClientId)?,
                 chain_id: value
                     .chain_id
                     .parse()
@@ -82,7 +81,7 @@ pub mod proto {
         #[error(transparent)]
         MissingField(#[from] MissingField),
         #[error("invalid l1_client_id")]
-        L1ClientId(#[source] <ClientIdValidator as Validate<String>>::Error),
+        L1ClientId(#[source] ParsePrefixedIdError),
         #[error("invalid l1_contract_address")]
         ChainId(#[source] Arc<FromDecStrErr>),
         #[error("invalid l1_latest_confirmed_slot")]

--- a/voyager/plugins/transaction/aptos/src/main.rs
+++ b/voyager/plugins/transaction/aptos/src/main.rs
@@ -403,7 +403,11 @@ fn process_msgs<T: aptos_move_ibc::ibc::ClientExt>(
                             .collect::<Vec<String>>(),
                         data.channel.ordering as u8,
                         data.channel.counterparty.port_id.to_string(),
-                        data.channel.counterparty.channel_id,
+                        data.channel
+                            .counterparty
+                            .channel_id
+                            .unwrap()
+                            .to_string_prefixed(),
                         data.channel.version,
                     ),
                 ),
@@ -420,7 +424,11 @@ fn process_msgs<T: aptos_move_ibc::ibc::ClientExt>(
                             .collect::<Vec<String>>(),
                         data.channel.ordering as u8,
                         data.channel.counterparty.port_id.to_string(),
-                        data.channel.counterparty.channel_id,
+                        data.channel
+                            .counterparty
+                            .channel_id
+                            .unwrap()
+                            .to_string_prefixed(),
                         data.counterparty_version,
                         data.channel.version,
                         data.proof_init,

--- a/voyager/src/cli.rs
+++ b/voyager/src/cli.rs
@@ -2,14 +2,7 @@ use std::ffi::OsString;
 
 use chain_utils::BoxDynError;
 use clap::{self, Parser, Subcommand};
-use unionlabs::{
-    self,
-    bounded::BoundedI64,
-    ics24::{self, Path},
-    result_unwrap,
-    uint::U256,
-    QueryHeight,
-};
+use unionlabs::{self, bounded::BoundedI64, result_unwrap, QueryHeight};
 use voyager_message::{
     core::ChainId,
     module::{ChainModuleInfo, ClientModuleInfo, ConsensusModuleInfo},
@@ -17,9 +10,9 @@ use voyager_message::{
 };
 use voyager_vm::Op;
 
-use crate::cli::handshake::HandshakeCmd;
+// use crate::cli::handshake::HandshakeCmd;
 
-pub mod handshake;
+// pub mod handshake;
 
 #[derive(Debug, Parser)]
 #[command(arg_required_else_help = true)]
@@ -68,7 +61,7 @@ pub enum Command {
     /// Config related subcommands.
     #[command(subcommand)]
     Config(ConfigCmd),
-    Handshake(HandshakeCmd),
+    // Handshake(HandshakeCmd),
     /// Construct a `FetchBlocks` op to send to the specified chain.
     InitFetch {
         #[arg(value_parser(|s: &str| Ok::<_, BoxDynError>(ChainId::new(s.to_owned()))))]
@@ -91,14 +84,14 @@ pub enum Command {
     Plugin(PluginCmd),
     #[command(subcommand)]
     Module(ModuleCmd),
-    Query {
-        #[arg(value_parser(|s: &str| Ok::<_, BoxDynError>(ChainId::new(s.to_owned()))))]
-        on: ChainId<'static>,
-        #[arg(long, short = 'H', default_value_t = QueryHeight::Latest)]
-        height: QueryHeight,
-        #[command(subcommand)]
-        path: ics24::Path,
-    },
+    // Query {
+    //     #[arg(value_parser(|s: &str| Ok::<_, BoxDynError>(ChainId::new(s.to_owned()))))]
+    //     on: ChainId<'static>,
+    //     #[arg(long, short = 'H', default_value_t = QueryHeight::Latest)]
+    //     height: QueryHeight,
+    //     #[command(subcommand)]
+    //     path: ics24::Path,
+    // },
 }
 
 #[derive(Debug, Subcommand)]
@@ -158,13 +151,13 @@ pub enum QueueCmd {
 
 #[derive(Debug, Subcommand)]
 pub enum UtilCmd {
-    /// Compute the EVM IBC commitment key for the given IBC commitment path.
-    IbcCommitmentKey {
-        #[command(subcommand)]
-        path: Path,
-        #[arg(long, default_value_t = U256::ZERO)]
-        commitment_slot: U256,
-    },
+    // /// Compute the EVM IBC commitment key for the given IBC commitment path.
+    // IbcCommitmentKey {
+    //     #[command(subcommand)]
+    //     path: Path,
+    //     #[arg(long, default_value_t = U256::ZERO)]
+    //     commitment_slot: U256,
+    // },
 }
 
 #[derive(Debug, Subcommand)]

--- a/voyager/src/main.rs
+++ b/voyager/src/main.rs
@@ -23,12 +23,10 @@ use clap::Parser;
 use pg_queue::PgQueueConfig;
 use schemars::gen::{SchemaGenerator, SchemaSettings};
 use serde::Serialize;
-use serde_json::json;
-use serde_utils::Hex;
 use tikv_jemallocator::Jemalloc;
 use tracing::info;
 use tracing_subscriber::EnvFilter;
-use unionlabs::{ethereum::ibc_commitment_key, ics24, QueryHeight};
+use unionlabs::QueryHeight;
 use voyager_message::{
     call::FetchBlocks,
     context::{get_plugin_info, Context, ModulesConfig},
@@ -41,7 +39,7 @@ use voyager_vm::{call, filter::FilterResult, Op, Queue};
 static GLOBAL: Jemalloc = Jemalloc;
 
 use crate::{
-    cli::{AppArgs, Command, ConfigCmd, ModuleCmd, PluginCmd, QueueCmd, UtilCmd},
+    cli::{AppArgs, Command, ConfigCmd, ModuleCmd, PluginCmd, QueueCmd},
     config::{default_rest_laddr, default_rpc_laddr, Config, VoyagerConfig},
     queue::{QueueConfig, Voyager, VoyagerInitError},
 };
@@ -255,63 +253,63 @@ async fn do_main(args: cli::AppArgs) -> Result<(), BoxDynError> {
             ModuleCmd::Consensus(_) => todo!(),
             ModuleCmd::Client(_) => todo!(),
         },
-        Command::Query { on, height, path } => {
-            let voyager = Voyager::new(get_voyager_config()?).await?;
+        // Command::Query { on, height, path } => {
+        //     let voyager = Voyager::new(get_voyager_config()?).await?;
 
-            let height = voyager.context.rpc_server.query_height(&on, height).await?;
+        //     let height = voyager.context.rpc_server.query_height(&on, height).await?;
 
-            let state = voyager
-                .context
-                .rpc_server
-                .query_ibc_state(&on, height, path.clone())
-                .await?
-                .state;
+        //     let state = voyager
+        //         .context
+        //         .rpc_server
+        //         .query_ibc_state(&on, height, path.clone())
+        //         .await?
+        //         .state;
 
-            let state = match &path {
-                ics24::Path::ClientState(path) => {
-                    let client_info = voyager
-                        .context
-                        .rpc_server
-                        .client_info(&on, path.client_id.clone())
-                        .await?;
+        //     let state = match &path {
+        //         ics24::Path::ClientState(path) => {
+        //             let client_info = voyager
+        //                 .context
+        //                 .rpc_server
+        //                 .client_info(&on, path.client_id.clone())
+        //                 .await?;
 
-                    voyager
-                        .context
-                        .rpc_server
-                        .decode_client_state(
-                            &client_info.client_type,
-                            &client_info.ibc_interface,
-                            serde_json::from_value::<Hex<Vec<u8>>>(state).unwrap().0,
-                        )
-                        .await?
-                }
-                ics24::Path::ClientConsensusState(path) => {
-                    let client_info = voyager
-                        .context
-                        .rpc_server
-                        .client_info(&on, path.client_id.clone())
-                        .await?;
+        //             voyager
+        //                 .context
+        //                 .rpc_server
+        //                 .decode_client_state(
+        //                     &client_info.client_type,
+        //                     &client_info.ibc_interface,
+        //                     serde_json::from_value::<Hex<Vec<u8>>>(state).unwrap().0,
+        //                 )
+        //                 .await?
+        //         }
+        //         ics24::Path::ClientConsensusState(path) => {
+        //             let client_info = voyager
+        //                 .context
+        //                 .rpc_server
+        //                 .client_info(&on, path.client_id.clone())
+        //                 .await?;
 
-                    voyager
-                        .context
-                        .rpc_server
-                        .decode_consensus_state(
-                            &client_info.client_type,
-                            &client_info.ibc_interface,
-                            serde_json::from_value::<Hex<Vec<u8>>>(state).unwrap().0,
-                        )
-                        .await?
-                }
-                _ => state,
-            };
+        //             voyager
+        //                 .context
+        //                 .rpc_server
+        //                 .decode_consensus_state(
+        //                     &client_info.client_type,
+        //                     &client_info.ibc_interface,
+        //                     serde_json::from_value::<Hex<Vec<u8>>>(state).unwrap().0,
+        //                 )
+        //                 .await?
+        //         }
+        //         _ => state,
+        //     };
 
-            voyager.shutdown().await;
+        //     voyager.shutdown().await;
 
-            print_json(&json!({
-               "path": path.to_string(),
-               "state": state,
-            }));
-        }
+        //     print_json(&json!({
+        //        "path": path.to_string(),
+        //        "state": state,
+        //     }));
+        // }
         Command::Queue(cli_msg) => {
             let db = match get_voyager_config()?.voyager.queue {
                 QueueConfig::PgQueue(cfg) => pg_queue::PgQueue::<VoyagerMessage>::new(cfg).await?,
@@ -362,7 +360,6 @@ async fn do_main(args: cli::AppArgs) -> Result<(), BoxDynError> {
                 }
             }
         }
-        Command::Handshake(_) => todo!(),
         // Command::Handshake(HandshakeCmd {
         //     chain_a,
         //     chain_b,
@@ -477,10 +474,10 @@ async fn do_main(args: cli::AppArgs) -> Result<(), BoxDynError> {
             }
         }
         Command::Util(util) => match util {
-            UtilCmd::IbcCommitmentKey {
-                path,
-                commitment_slot,
-            } => print_json(&ibc_commitment_key(&path.to_string(), commitment_slot).to_be_hex()),
+            // UtilCmd::IbcCommitmentKey {
+            //     path,
+            //     commitment_slot,
+            // } => print_json(&ibc_commitment_key(&path.to_string(), commitment_slot).to_be_hex()),
         },
     }
 


### PR DESCRIPTION
[parse, don't validate](https://lexi-lambda.github.io/blog/2019/11/05/parse-don-t-validate/)

- connection and channel id are now just u32
  - both have `from_str_prefixed` constructors, as well as alternate display formatting (via `{:#}`) and a `to_string_prefixed` method to emulate the old behaviour
- port id is as per the ics24 specification (same as it was previously, but no longer using `Validated`)
- client id is now a tuple of (prefix, id)
  - note that it is *not* client type as the prefix, as that is not necessarily true - see `08-wasm`
- added alternate display formatting to `Height` to always display the revision number, even if it's zero
- a bit of hacking on `#[ibc_path]`, this will be deprecated soon so don't look too hard at it
- disabled some voyager commands temporarily, they will be re-enabled soon