### PR TITLE
Further fixes to the ethereum light client

### DIFF
--- a/generated/rust/protos/src/union.ibc.lightclients.ethereum.v1.rs
+++ b/generated/rust/protos/src/union.ibc.lightclients.ethereum.v1.rs
@@ -45,28 +45,22 @@ impl ::prost::Name for AccountProof {
 pub struct ClientState {
     #[prost(string, tag = "1")]
     pub chain_id: ::prost::alloc::string::String,
-    #[prost(bytes = "vec", tag = "2")]
+    #[prost(string, tag = "2")]
+    pub chain_spec: ::prost::alloc::string::String,
+    #[prost(bytes = "vec", tag = "3")]
     pub genesis_validators_root: ::prost::alloc::vec::Vec<u8>,
-    #[prost(uint64, tag = "3")]
-    pub min_sync_committee_participants: u64,
     #[prost(uint64, tag = "4")]
     pub genesis_time: u64,
     #[prost(message, optional, tag = "5")]
     pub fork_parameters: ::core::option::Option<ForkParameters>,
     #[prost(uint64, tag = "6")]
-    pub seconds_per_slot: u64,
-    #[prost(uint64, tag = "7")]
-    pub slots_per_epoch: u64,
-    #[prost(uint64, tag = "8")]
-    pub epochs_per_sync_committee_period: u64,
-    #[prost(uint64, tag = "9")]
     pub latest_slot: u64,
-    #[prost(message, optional, tag = "10")]
+    #[prost(message, optional, tag = "7")]
     pub frozen_height:
         ::core::option::Option<super::super::super::super::super::ibc::core::client::v1::Height>,
-    #[prost(bytes = "vec", tag = "11")]
+    #[prost(bytes = "vec", tag = "8")]
     pub ibc_commitment_slot: ::prost::alloc::vec::Vec<u8>,
-    #[prost(bytes = "vec", tag = "12")]
+    #[prost(bytes = "vec", tag = "9")]
     pub ibc_contract_address: ::prost::alloc::vec::Vec<u8>,
 }
 impl ::prost::Name for ClientState {

--- a/light-clients/ethereum-light-client/types/src/client_state.rs
+++ b/light-clients/ethereum-light-client/types/src/client_state.rs
@@ -1,4 +1,4 @@
-use beacon_api_types::ForkParameters;
+use beacon_api_types::{ForkParameters, PresetBaseKind};
 use unionlabs::{
     hash::{H160, H256},
     ibc::core::client::height::Height,
@@ -9,13 +9,10 @@ use unionlabs::{
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct ClientState {
     pub chain_id: U256,
+    pub chain_spec: PresetBaseKind,
     pub genesis_validators_root: H256,
-    pub min_sync_committee_participants: u64,
     pub genesis_time: u64,
     pub fork_parameters: ForkParameters,
-    pub seconds_per_slot: u64,
-    pub slots_per_epoch: u64,
-    pub epochs_per_sync_committee_period: u64,
     pub latest_slot: u64,
     // even though it would be better to have option, ethabicodec don't handle it as zero struct...
     pub frozen_height: Height,
@@ -28,6 +25,7 @@ pub struct ClientState {
 pub mod proto {
     use std::{str::FromStr, sync::Arc};
 
+    use beacon_api_types::PresetBaseKind;
     use unionlabs::{
         errors::{InvalidLength, MissingField},
         impl_proto_via_try_from_into, required,
@@ -42,13 +40,10 @@ pub mod proto {
         fn from(value: ClientState) -> Self {
             Self {
                 chain_id: value.chain_id.to_string(),
+                chain_spec: value.chain_spec.to_string(),
                 genesis_validators_root: value.genesis_validators_root.into(),
-                min_sync_committee_participants: value.min_sync_committee_participants,
                 genesis_time: value.genesis_time,
                 fork_parameters: Some(fork_parameters_proto::into_proto(value.fork_parameters)),
-                seconds_per_slot: value.seconds_per_slot,
-                slots_per_epoch: value.slots_per_epoch,
-                epochs_per_sync_committee_period: value.epochs_per_sync_committee_period,
                 latest_slot: value.latest_slot,
                 frozen_height: Some(value.frozen_height.into()),
                 ibc_commitment_slot: value.ibc_commitment_slot.to_be_bytes().into(),
@@ -61,6 +56,8 @@ pub mod proto {
     pub enum TryFromClientStateError {
         #[error(transparent)]
         MissingField(#[from] MissingField),
+        #[error("invalid chain spec: {0}")]
+        ChainSpec(String),
         #[error("invalid chain id: {0:?}")]
         ChainId(Arc<FromDecStrErr>),
         #[error("invalid fork parameters")]
@@ -82,17 +79,15 @@ pub mod proto {
             Ok(Self {
                 chain_id: U256::from_str(&value.chain_id)
                     .map_err(|err| TryFromClientStateError::ChainId(Arc::new(err)))?,
+                chain_spec: PresetBaseKind::from_str(&value.chain_spec)
+                    .map_err(TryFromClientStateError::ChainSpec)?,
                 genesis_validators_root: value
                     .genesis_validators_root
                     .try_into()
                     .map_err(TryFromClientStateError::GenesisValidatorsRoot)?,
-                min_sync_committee_participants: value.min_sync_committee_participants,
                 genesis_time: value.genesis_time,
                 fork_parameters: required!(value.fork_parameters)
                     .map(fork_parameters_proto::try_from_proto)??,
-                seconds_per_slot: value.seconds_per_slot,
-                slots_per_epoch: value.slots_per_epoch,
-                epochs_per_sync_committee_period: value.epochs_per_sync_committee_period,
                 latest_slot: value.latest_slot,
                 frozen_height: value.frozen_height.unwrap_or_default().into(),
                 ibc_commitment_slot: U256::try_from_be_bytes(&value.ibc_commitment_slot)

--- a/light-clients/ethereum-light-client/types/src/light_client_update_data.rs
+++ b/light-clients/ethereum-light-client/types/src/light_client_update_data.rs
@@ -19,7 +19,7 @@ pub struct LightClientUpdateData {
 }
 
 impl LightClientUpdateData {
-    pub fn new_beacon_light_client_update(
+    pub fn into_beacon_light_client_update(
         self,
         next_sync_committee: Option<SyncCommittee>,
         next_sync_committee_branch: Option<NextSyncCommitteeBranch>,

--- a/uniond/proto/union/ibc/lightclients/ethereum/v1/ethereum.proto
+++ b/uniond/proto/union/ibc/lightclients/ethereum/v1/ethereum.proto
@@ -24,17 +24,14 @@ message AccountProof {
 
 message ClientState {
   string chain_id = 1;
-  bytes genesis_validators_root = 2;
-  uint64 min_sync_committee_participants = 3;
+  string chain_spec = 2;
+  bytes genesis_validators_root = 3;
   uint64 genesis_time = 4;
   ForkParameters fork_parameters = 5;
-  uint64 seconds_per_slot = 6;
-  uint64 slots_per_epoch = 7;
-  uint64 epochs_per_sync_committee_period = 8;
-  uint64 latest_slot = 9;
-  .ibc.core.client.v1.Height frozen_height = 10;
-  bytes ibc_commitment_slot = 11;
-  bytes ibc_contract_address = 12;
+  uint64 latest_slot = 6;
+  .ibc.core.client.v1.Height frozen_height = 7;
+  bytes ibc_commitment_slot = 8;
+  bytes ibc_contract_address = 9;
 }
 
 

--- a/voyager/modules/consensus/ethereum/src/main.rs
+++ b/voyager/modules/consensus/ethereum/src/main.rs
@@ -142,14 +142,11 @@ impl ConsensusModuleServer for Module {
                 .as_str()
                 .parse()
                 .expect("self.chain_id is a valid u256"),
+            chain_spec: spec.preset_base,
             genesis_validators_root: genesis.genesis_validators_root,
             genesis_time: genesis.genesis_time,
             fork_parameters: spec.to_fork_parameters(),
-            seconds_per_slot: spec.seconds_per_slot,
-            slots_per_epoch: spec.slots_per_epoch,
-            epochs_per_sync_committee_period: spec.epochs_per_sync_committee_period,
             latest_slot: height.height(),
-            min_sync_committee_participants: 0,
             frozen_height: Height::new(0),
             ibc_commitment_slot: IBC_HANDLER_COMMITMENTS_SLOT,
             ibc_contract_address: self.ibc_handler_address,


### PR DESCRIPTION
This fix involves:
1. Adding chain spec to the client state and branching off based on that during verification.
2. Removing unnecessary fields from the client state.
3. Fixing misbehaviour and minor improvements to the client.