### PR TITLE
Hubble fix baecon no block handling

### DIFF
--- a/hubble/src/indexer/tm/fetcher_client.rs
+++ b/hubble/src/indexer/tm/fetcher_client.rs
@@ -320,7 +320,7 @@ impl TmFetcherClient {
                         let message = inner.data().unwrap_or_default();
                         if matches!(code, Code::InternalError)
                             && (message.contains("must be less than or equal to")
-                                | message.contains("could not find results for height"))
+                                || message.contains("could not find results for height"))
                         {
                             trace!("{}: no block: beyond tip error: {}", selection, message,);
                             Ok(None)


### PR DESCRIPTION
beacon implementation was inspecting response body to detect there was no block. the response body of the endpoint changed (returning `{"code":404,"message":"No block found for id '4845861'"}`).

change it to use the http response code (also kept original implementation, because we're not sure if all rpc behave like this)