### PR TITLE
Minor union-ibc cleanup

### DIFF
--- a/cosmwasm/union-ibc/core/src/contract.rs
+++ b/cosmwasm/union-ibc/core/src/contract.rs
@@ -1267,13 +1267,13 @@ fn process_receive(
     let connection = ensure_connection_state(deps.as_ref(), channel.connectionId)?;
 
     if !intent {
-        let proof_commitment_key = match packets.len() {
-            1 => unionlabs::ics24::ethabi::batch_receipts_key(source_channel, commit_packet(first)),
-            _ => unionlabs::ics24::ethabi::batch_receipts_key(
-                source_channel,
-                commit_packets(&packets),
-            ),
-        };
+        let proof_commitment_key = unionlabs::ics24::ethabi::batch_packets_key(
+            source_channel,
+            match packets.len() {
+                1 => commit_packet(first),
+                _ => commit_packets(&packets),
+            },
+        );
 
         let client_impl = client_impl(deps.as_ref(), connection.clientId)?;
         deps.querier.query_wasm_smart::<()>(

--- a/cosmwasm/union-ibc/core/src/contract.rs
+++ b/cosmwasm/union-ibc/core/src/contract.rs
@@ -692,7 +692,7 @@ fn update_client(
         &client_impl,
         &LightClientQuery::VerifyClientMessage {
             client_id,
-            message: client_message.to_vec().into(),
+            message: client_message.into(),
         },
     )?;
     store_commit(
@@ -767,7 +767,7 @@ fn connection_open_try(
         &LightClientQuery::VerifyMembership {
             client_id,
             height: proof_height,
-            proof: proof_init.to_vec().into(),
+            proof: proof_init.into(),
             path: unionlabs::ics24::ethabi::connection_key(counterparty_connection_id)
                 .into_bytes()
                 .into(),
@@ -818,7 +818,7 @@ fn connection_open_ack(
         &LightClientQuery::VerifyMembership {
             client_id: connection.clientId,
             height: proof_height,
-            proof: proof_try.to_vec().into(),
+            proof: proof_try.into(),
             path: unionlabs::ics24::ethabi::connection_key(counterparty_connection_id)
                 .into_bytes()
                 .into(),
@@ -873,7 +873,7 @@ fn connection_open_confirm(
         &LightClientQuery::VerifyMembership {
             client_id: connection.clientId,
             height: proof_height,
-            proof: proof_ack.to_vec().into(),
+            proof: proof_ack.into(),
             path: unionlabs::ics24::ethabi::connection_key(connection.counterpartyConnectionId)
                 .into_bytes()
                 .into(),
@@ -972,7 +972,7 @@ fn channel_open_try(
         &LightClientQuery::VerifyMembership {
             client_id: connection.clientId,
             height: proof_height,
-            proof: proof_init.to_vec().into(),
+            proof: proof_init.into(),
             path: unionlabs::ics24::ethabi::channel_key(channel.counterpartyChannelId)
                 .into_bytes()
                 .into(),
@@ -1048,7 +1048,7 @@ fn channel_open_ack(
         &LightClientQuery::VerifyMembership {
             client_id: connection.clientId,
             height: proof_height,
-            proof: proof_try.to_vec().into(),
+            proof: proof_try.into(),
             path: unionlabs::ics24::ethabi::channel_key(counterparty_channel_id)
                 .into_bytes()
                 .into(),
@@ -1114,7 +1114,7 @@ fn channel_open_confirm(
         &LightClientQuery::VerifyMembership {
             client_id: connection.clientId,
             height: proof_height,
-            proof: proof_ack.to_vec().into(),
+            proof: proof_ack.into(),
             path: unionlabs::ics24::ethabi::channel_key(channel.counterpartyChannelId)
                 .into_bytes()
                 .into(),
@@ -1211,7 +1211,7 @@ fn channel_close_confirm(
         &LightClientQuery::VerifyMembership {
             client_id: connection.clientId,
             height: proof_height,
-            proof: proof_init.to_vec().into(),
+            proof: proof_init.into(),
             path: unionlabs::ics24::ethabi::channel_key(channel.counterpartyChannelId)
                 .into_bytes()
                 .into(),


### PR DESCRIPTION
- **fix(union-ibc): remove redundant to_vec calls**
- **fix(union-ibc): simplify proof_commitment_key**
