### PR TITLE
feat: openvscode-server nix setup

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -1,5 +1,12 @@
 [[ -f .envrc.local ]] && source_env .envrc.local
 use flake
+
+watch_file flake.nix
+watch_file flake.lock
+
+watch_file treefmt.nix
+watch_file devShell.nix
+
 export DIRENV_WARN_TIMEOUT=2m
 # ^ our devShell is big
 export GIT_LFS_SKIP_SMUDGE=true

--- a/.gitattributes
+++ b/.gitattributes
@@ -17,3 +17,4 @@ evm/contracts/proto/** linguist-generated
 site/public/union-logo.zip filter=lfs diff=lfs merge=lfs -text
 biome.json linguist-language=JSON-with-Comments
 knip.json linguist-language=JSON-with-Comments
+.vscode/*.json linguist-language=JSON-with-Comments

--- a/.gitignore
+++ b/.gitignore
@@ -35,8 +35,8 @@ vk.bin
 pk.bin
 
 out
-.vscode
-
+!./.vscode
+*/.vscode
 dump
 
 fuzzing-code-coverage

--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,0 +1,45 @@
+{
+  "unwantedRecommendations": [
+    /* we use biome for linting */
+    "dbaeumer.vscode-eslint"
+  ],
+  "recommendations": [
+    /* nix dev shell */
+    "mkhl.direnv",
+    "bbenoist.nix",
+    "jnoortheen.nix-ide",
+    "bmalehorn.vscode-fish",
+    "arrterian.nix-env-selector",
+    /* lint & format */
+    "biomejs.biome",
+    "timonwong.shellcheck",
+    /* solidity */
+    "juanblanco.solidity",
+    /* rust */
+    "fill-labs.dependi",
+    "rust-lang.rust-analyzer",
+    /* js */
+    "svelte.svelte-vscode",
+    "astro-build.astro-vscode",
+    "bradlc.vscode-tailwindcss",
+    "better-ts-errors.better-ts-errors",
+    /* git & github */
+    "mk12.better-git-line-blame",
+    "antfu.open-in-github-button",
+    "github.vscode-github-actions",
+    "christian-kohler.path-intellisense",
+    /* theme */
+    "catppuccin.catppuccin-vsc",
+    "pkief.material-icon-theme",
+    /* syntax */
+    "mikestead.dotenv",
+    "redhat.vscode-yaml",
+    "hashhar.gitattributes",
+    "tamasfe.even-better-toml",
+    "tobermory.es6-string-html",
+    "yzhang.markdown-all-in-one",
+    "orta.vscode-twoslash-queries",
+    "graphql.vscode-graphql-syntax",
+    "jeff-hykin.better-shellscript-syntax"
+  ]
+}

--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -23,10 +23,13 @@
     "astro-build.astro-vscode",
     "bradlc.vscode-tailwindcss",
     "better-ts-errors.better-ts-errors",
+    /* go */
+    "golang.go",
     /* git & github */
     "mk12.better-git-line-blame",
     "antfu.open-in-github-button",
     "github.vscode-github-actions",
+    "GitHub.vscode-pull-request-github",
     "christian-kohler.path-intellisense",
     /* theme */
     "catppuccin.catppuccin-vsc",

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -17,6 +17,10 @@
   "[solidity]": {
     "editor.defaultFormatter": "JuanBlanco.solidity"
   },
+
+  // use go tools from devshell
+  "go.toolsGopath": ".",
+
   // https://code.visualstudio.com/docs/typescript/typescript-compiling#_using-the-workspace-version-of-typescript
   "typescript.tsdk": "./docs/node_modules/typescript/lib",
   "typescript.enablePromptUseWorkspaceTsdk": true,
@@ -130,7 +134,7 @@
   "editor.minimap.renderCharacters": false,
   "workbench.layoutControl.enabled": false,
   "scm.diffDecorationsGutterAction": "none",
-  "workbench.activityBar.location": "default",
+  "workbench.activityBar.location": "top",
   "workbench.editor.highlightModifiedTabs": true,
   "scm.diffDecorationsGutterVisibility": "hover",
   "npm-intellisense.packageSubfoldersIntellisense": true,
@@ -176,5 +180,6 @@
     "editorGutter.deletedBackground": "#00000000",
     "editorGutter.modifiedBackground": "#00000000",
     "diffEditor.removedTextBackground": "#00000000"
-  }
+  },
+
 }

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,178 @@
+{
+  // https://github.com/nix-community/nixd/blob/main/nixd/docs/configuration.md#where-to-place-the-configuration
+  "direnv.watchForChanges": true,
+  "direnv.restart.automatic": true,
+  "nix.enableLanguageServer": true,
+  "nix.serverPath": "nixd",
+  "nix.serverSettings": {
+    "nixd": {
+      "formatting": {
+        "command": ["nixfmt", "--width=100"]
+      }
+    }
+  },
+  // https://book.getfoundry.sh/config/vscode?highlight=vscode#3-formatter
+  "editor.formatOnSave": true,
+  "solidity.formatter": "forge",
+  "[solidity]": {
+    "editor.defaultFormatter": "JuanBlanco.solidity"
+  },
+  // https://code.visualstudio.com/docs/typescript/typescript-compiling#_using-the-workspace-version-of-typescript
+  "typescript.tsdk": "./docs/node_modules/typescript/lib",
+  "typescript.enablePromptUseWorkspaceTsdk": true,
+  "biome.enabled": true,
+  "[json]": {
+    "editor.defaultFormatter": "biomejs.biome"
+  },
+  "[jsonc]": {
+    "editor.defaultFormatter": "biomejs.biome"
+  },
+  "[typescript]": {
+    "editor.defaultFormatter": "biomejs.biome"
+  },
+  "[javascript]": {
+    "editor.defaultFormatter": "biomejs.biome"
+  },
+  "[css]": {
+    "editor.defaultFormatter": "biomejs.biome"
+  },
+  "[graphql]": {
+    "editor.defaultFormatter": "biomejs.biome"
+  },
+  "[svelte]": {
+    "editor.defaultFormatter": "svelte.svelte-vscode"
+  },
+  "[astro]": {
+    "editor.defaultFormatter": "astro-build.astro-vscode"
+  },
+  // https://github.com/tailwindlabs/tailwindcss-intellisense#recommended-vs-code-settings
+  "editor.quickSuggestions": {
+    "strings": "on"
+  },
+  "tailwindCSS.emmetCompletions": true,
+  "tailwindCSS.includeLanguages": {
+    "plaintext": "html"
+  },
+  "files.associations": {
+    "*.css": "tailwindcss",
+    ".envrc": "dotenv"
+  },
+  "evenBetterToml.schema.enabled": true,
+  "files.exclude": {
+    "result": true,
+    ".direnv": true
+  },
+  /* font */
+  "editor.fontSize": 14,
+  "editor.fontLigatures": true,
+  "terminal.integrated.fontSize": 14,
+  "editor.fontFamily": "BlexMono Nerd Font Mono",
+  "terminal.integrated.fontFamily": "BlexMono Nerd Font Mono",
+  /* theme and icon settings */
+  "workbench.colorTheme": "Catppuccin Mocha",
+  "workbench.iconTheme": "material-icon-theme",
+  /* excluding files and directoriwes from global search */
+  "search.exclude": {
+    "._*": true,
+    "*.lock": true,
+    "**/dist": true,
+    "**/_/**": true,
+    "**/*.svg": true,
+    "**/build": true,
+    "**/target": true,
+    "**/.astro": true,
+    "**/result": true,
+    "**/.direnv": true,
+    "**/.vercel": true,
+    "**/.netlify": true,
+    "**/flake.lock": true,
+    "**/.svelte-kit": true,
+    "**/node_modules": true,
+    "**/package-lock.json": true
+  },
+  /**
+   * various opinionated UI and UX settings
+   * feel free to change if you have any strong preferences
+   */
+  "editor.padding.top": 0,
+  "editor.padding.bottom": 0,
+  "editor.glyphMargin": false,
+  "scm.diffDecorations": "none",
+  "scm.showActionButton": false,
+  "window.commandCenter": false,
+  "editor.smoothScrolling": true,
+  "scm.alwaysShowActions": false,
+  "files.autoGuessEncoding": true,
+  "yaml.schemaStore.enable": true,
+  "editor.minimap.enabled": false,
+  "svelte.enable-ts-plugin": true,
+  "editor.suggest.showWords": false,
+  "editor.inlayHints.padding": false,
+  "editor.overviewRulerBorder": false,
+  "editor.suggest.showModules": false,
+  "explorer.openEditors.minVisible": 0,
+  "diffEditor.renderGutterMenu": false,
+  "diffEditor.renderIndicators": false,
+  "workbench.sideBar.location": "right",
+  "editor.scrollbar.vertical": "hidden",
+  "window.title": "${activeEditorShort}",
+  "workbench.editor.tabSizing": "shrink",
+  "editor.scrollbar.horizontal": "hidden",
+  "betterTypeScriptErrors.prettify": true,
+  "extensions.experimental.affinity": {
+    "better-ts-errors.better-ts-errors": 1
+  },
+  "workbench.editor.empty.hint": "hidden",
+  "editor.renderControlCharacters": false,
+  "workbench.editor.enablePreview": false,
+  "editor.minimap.renderCharacters": false,
+  "workbench.layoutControl.enabled": false,
+  "scm.diffDecorationsGutterAction": "none",
+  "workbench.activityBar.location": "default",
+  "workbench.editor.highlightModifiedTabs": true,
+  "scm.diffDecorationsGutterVisibility": "hover",
+  "npm-intellisense.packageSubfoldersIntellisense": true,
+  "github-actions.workflows.pinned.refresh.enabled": true,
+  "workbench.editor.enablePreviewFromCodeNavigation": true,
+  /* theme modifications */
+  "workbench.colorCustomizations": {
+    "focusBorder": "#1E1E2E",
+    "sideBar.border": "#1E1E2E",
+    "menu.background": "#1e1e2e",
+    "scrollbar.shadow": "#1E1E2E",
+    "panel.background": "#1E1E2E",
+    "banner.background": "#1E1E2E",
+    "sideBar.background": "#1E1E2E",
+    "minimap.background": "#1E1E2E",
+    "window.activeBorder": "#1E1E2E",
+    "statusBar.background": "#1E1E2E",
+    "breadcrumb.background": "#1E1E2E",
+    "tab.inactiveBackground": "#191926",
+    "tab.selectedForeground": "#1E1E2E",
+    "tab.selectedBackground": "#1E1E2E",
+    "sideBar.dropBackground": "#1E1E2E",
+    "activityBar.background": "#1E1E2E",
+    "editorGutter.background": "#1E1E2E",
+    "sideBarTitle.background": "#1E1E2E",
+    "menu.separatorBackground": "#1E1E2E",
+    "minimapSlider.background": "#1E1E2E",
+    "toolbar.activeBackground": "#1E1E2E",
+    "titleBar.activeBackground": "#1E1E2E",
+    "scrollbarSlider.background": "#1E1E2E",
+    "editorGroup.dropBackground": "#1E1E2E",
+    "sideBarStickyScroll.border": "#1E1E2E",
+    "sideBarSectionHeader.border": "#1E1E2E",
+    "tree.tableOddRowsBackground": "#1E1E2E",
+    "editorGroupHeader.tabsBorder": "#1E1E2E",
+    "statusBar.noFolderBackground": "#1E1E2E",
+    "statusBar.debuggingBackground": "#1E1E2E",
+    "editorGutter.addedBackground": "#00000000",
+    "sideBarStickyScroll.background": "#1E1E2E",
+    "sideBarSectionHeader.background": "#1E1E2E",
+    "scrollbarSlider.activeBackground": "#1E1E2E",
+    "editorGroupHeader.tabsBackground": "#1E1E2E",
+    "editorGutter.deletedBackground": "#00000000",
+    "editorGutter.modifiedBackground": "#00000000",
+    "diffEditor.removedTextBackground": "#00000000"
+  }
+}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -54,8 +54,10 @@
     "plaintext": "html"
   },
   "files.associations": {
+    ".envrc": "dotenv",
+    "biome.json": "jsonc",
     "*.css": "tailwindcss",
-    ".envrc": "dotenv"
+    ".vscode/*.json": "jsonc"
   },
   "evenBetterToml.schema.enabled": true,
   "files.exclude": {

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -11,6 +11,7 @@
       }
     }
   },
+
   // https://book.getfoundry.sh/config/vscode?highlight=vscode#3-formatter
   "editor.formatOnSave": true,
   "solidity.formatter": "forge",
@@ -18,7 +19,7 @@
     "editor.defaultFormatter": "JuanBlanco.solidity"
   },
 
-  // use go tools from devshell
+  // Use go tools from devshell
   "go.toolsGopath": ".",
 
   // https://code.visualstudio.com/docs/typescript/typescript-compiling#_using-the-workspace-version-of-typescript
@@ -68,14 +69,7 @@
     "result": true,
     ".direnv": true
   },
-  /* font */
-  "editor.fontSize": 14,
-  "editor.fontLigatures": true,
-  "terminal.integrated.fontSize": 14,
-  "editor.fontFamily": "BlexMono Nerd Font Mono",
-  "terminal.integrated.fontFamily": "BlexMono Nerd Font Mono",
   /* theme and icon settings */
-  "workbench.colorTheme": "Catppuccin Mocha",
   "workbench.iconTheme": "material-icon-theme",
   /* excluding files and directoriwes from global search */
   "search.exclude": {
@@ -100,86 +94,17 @@
    * various opinionated UI and UX settings
    * feel free to change if you have any strong preferences
    */
-  "editor.padding.top": 0,
-  "editor.padding.bottom": 0,
-  "editor.glyphMargin": false,
-  "scm.diffDecorations": "none",
-  "scm.showActionButton": false,
   "window.commandCenter": false,
   "editor.smoothScrolling": true,
-  "scm.alwaysShowActions": false,
   "files.autoGuessEncoding": true,
   "yaml.schemaStore.enable": true,
   "editor.minimap.enabled": false,
   "svelte.enable-ts-plugin": true,
-  "editor.suggest.showWords": false,
-  "editor.inlayHints.padding": false,
   "editor.overviewRulerBorder": false,
-  "editor.suggest.showModules": false,
-  "explorer.openEditors.minVisible": 0,
-  "diffEditor.renderGutterMenu": false,
-  "diffEditor.renderIndicators": false,
-  "workbench.sideBar.location": "right",
-  "editor.scrollbar.vertical": "hidden",
-  "window.title": "${activeEditorShort}",
-  "workbench.editor.tabSizing": "shrink",
-  "editor.scrollbar.horizontal": "hidden",
-  "betterTypeScriptErrors.prettify": true,
+  "workbench.activityBar.location": "top",
+  "window.title": "Join the Union",
   "extensions.experimental.affinity": {
     "better-ts-errors.better-ts-errors": 1
   },
-  "workbench.editor.empty.hint": "hidden",
-  "editor.renderControlCharacters": false,
-  "workbench.editor.enablePreview": false,
-  "editor.minimap.renderCharacters": false,
-  "workbench.layoutControl.enabled": false,
-  "scm.diffDecorationsGutterAction": "none",
-  "workbench.activityBar.location": "top",
-  "workbench.editor.highlightModifiedTabs": true,
-  "scm.diffDecorationsGutterVisibility": "hover",
-  "npm-intellisense.packageSubfoldersIntellisense": true,
-  "github-actions.workflows.pinned.refresh.enabled": true,
-  "workbench.editor.enablePreviewFromCodeNavigation": true,
-  /* theme modifications */
-  "workbench.colorCustomizations": {
-    "focusBorder": "#1E1E2E",
-    "sideBar.border": "#1E1E2E",
-    "menu.background": "#1e1e2e",
-    "scrollbar.shadow": "#1E1E2E",
-    "panel.background": "#1E1E2E",
-    "banner.background": "#1E1E2E",
-    "sideBar.background": "#1E1E2E",
-    "minimap.background": "#1E1E2E",
-    "window.activeBorder": "#1E1E2E",
-    "statusBar.background": "#1E1E2E",
-    "breadcrumb.background": "#1E1E2E",
-    "tab.inactiveBackground": "#191926",
-    "tab.selectedForeground": "#1E1E2E",
-    "tab.selectedBackground": "#1E1E2E",
-    "sideBar.dropBackground": "#1E1E2E",
-    "activityBar.background": "#1E1E2E",
-    "editorGutter.background": "#1E1E2E",
-    "sideBarTitle.background": "#1E1E2E",
-    "menu.separatorBackground": "#1E1E2E",
-    "minimapSlider.background": "#1E1E2E",
-    "toolbar.activeBackground": "#1E1E2E",
-    "titleBar.activeBackground": "#1E1E2E",
-    "scrollbarSlider.background": "#1E1E2E",
-    "editorGroup.dropBackground": "#1E1E2E",
-    "sideBarStickyScroll.border": "#1E1E2E",
-    "sideBarSectionHeader.border": "#1E1E2E",
-    "tree.tableOddRowsBackground": "#1E1E2E",
-    "editorGroupHeader.tabsBorder": "#1E1E2E",
-    "statusBar.noFolderBackground": "#1E1E2E",
-    "statusBar.debuggingBackground": "#1E1E2E",
-    "editorGutter.addedBackground": "#00000000",
-    "sideBarStickyScroll.background": "#1E1E2E",
-    "sideBarSectionHeader.background": "#1E1E2E",
-    "scrollbarSlider.activeBackground": "#1E1E2E",
-    "editorGroupHeader.tabsBackground": "#1E1E2E",
-    "editorGutter.deletedBackground": "#00000000",
-    "editorGutter.modifiedBackground": "#00000000",
-    "diffEditor.removedTextBackground": "#00000000"
-  },
-
+  "github-actions.workflows.pinned.refresh.enabled": true
 }

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -51,6 +51,12 @@
       "label": "npm: dev - app",
       "dependsOn": ["npm: install - site"],
       "detail": "Site - Dev"
+    },
+    {
+      "type": "shell",
+      "command": "nix run .#devnet-union -L",
+      "label": "devnet-union",
+      "problemMatcher": []
     }
   ]
 }

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -1,0 +1,56 @@
+{
+  "version": "2.0.0",
+  "tasks": [
+    {
+      "type": "npm",
+      "path": "./docs",
+      "script": "install",
+      "problemMatcher": [],
+      "label": "npm: install - docs",
+      "detail": "Docs - Install dependencies"
+    },
+    {
+      "type": "npm",
+      "script": "dev",
+      "path": "./docs",
+      "problemMatcher": [],
+      "label": "npm: dev - docs",
+      "dependsOn": ["npm: install - docs"],
+      "detail": "Docs - Dev"
+    },
+    {
+      "type": "npm",
+      "script": "install",
+      "path": "./app",
+      "problemMatcher": [],
+      "label": "npm: install - app",
+      "detail": "App - Install dependencies"
+    },
+    {
+      "type": "npm",
+      "script": "dev",
+      "path": "./app",
+      "problemMatcher": [],
+      "label": "npm: dev - app",
+      "dependsOn": ["npm: install - app"],
+      "detail": "App - Dev"
+    },
+    {
+      "type": "npm",
+      "script": "install",
+      "path": "./site",
+      "problemMatcher": [],
+      "label": "npm: install - site",
+      "detail": "Site - Install dependencies"
+    },
+    {
+      "type": "npm",
+      "script": "dev",
+      "path": "./site",
+      "problemMatcher": [],
+      "label": "npm: dev - app",
+      "dependsOn": ["npm: install - site"],
+      "detail": "Site - Dev"
+    }
+  ]
+}

--- a/biome.json
+++ b/biome.json
@@ -26,7 +26,8 @@
       "*.jsonc",
       "*.astro",
       "*.svelte",
-      "*.graphql"
+      "*.graphql",
+      "*.webmanifest"
     ],
     "ignore": [
       "_",
@@ -101,7 +102,8 @@
       "*.jsonc",
       "*.astro",
       "*.svelte",
-      "*.graphql"
+      "*.graphql",
+      "*.webmanifest"
     ],
     "ignoreUnknown": true,
     "ignore": [
@@ -165,7 +167,8 @@
       "*.jsonc",
       "*.astro",
       "*.svelte",
-      "*.graphql"
+      "*.graphql",
+      "*.webmanifest"
     ],
     "ignore": [
       "_",
@@ -293,7 +296,8 @@
       "*.jsonc",
       "*.astro",
       "*.svelte",
-      "*.graphql"
+      "*.graphql",
+      "*.webmanifest"
     ],
     "ignore": [
       "_",

--- a/devShell.nix
+++ b/devShell.nix
@@ -1,7 +1,6 @@
 _: {
   perSystem =
     {
-      lib,
       pkgs,
       jsPkgs,
       ensureAtRepositoryRoot,

--- a/flake.lock
+++ b/flake.lock
@@ -514,11 +514,11 @@
     },
     "nixpkgs_3": {
       "locked": {
-        "lastModified": 1726481836,
-        "narHash": "sha256-MWTBH4dd5zIz2iatDb8IkqSjIeFum9jAqkFxgHLdzO4=",
+        "lastModified": 1731890469,
+        "narHash": "sha256-D1FNZ70NmQEwNxpSSdTXCSklBH1z2isPR84J6DQrJGs=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "20f9370d5f588fb8c72e844c54511cab054b5f40",
+        "rev": "5083ec887760adfe12af64830a66807423a859a7",
         "type": "github"
       },
       "original": {
@@ -720,11 +720,11 @@
         "nixpkgs": "nixpkgs_3"
       },
       "locked": {
-        "lastModified": 1727098951,
-        "narHash": "sha256-gplorAc0ISAUPemUNOnRUs7jr3WiLiHZb3DJh++IkZs=",
+        "lastModified": 1732292307,
+        "narHash": "sha256-5WSng844vXt8uytT5djmqBCkopyle6ciFgteuA9bJpw=",
         "owner": "numtide",
         "repo": "treefmt-nix",
-        "rev": "35dfece10c642eb52928a48bee7ac06a59f93e9a",
+        "rev": "705df92694af7093dfbb27109ce16d828a79155f",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -504,6 +504,7 @@
                 bun
                 deno
                 nixd
+                procs
                 emmet-language-server
                 nodePackages_latest.nodejs
                 nodePackages_latest.graphqurl

--- a/flake.nix
+++ b/flake.nix
@@ -503,6 +503,7 @@
               ++ (with jsPkgs; [
                 bun
                 deno
+                nixd
                 emmet-language-server
                 nodePackages_latest.nodejs
                 nodePackages_latest.graphqurl
@@ -557,7 +558,6 @@
             inherit (self'.packages) movefmt;
             inherit
               pkgs
-              goPkgs
               jsPkgs
               rust
               ;

--- a/site/public/manifest.webmanifest
+++ b/site/public/manifest.webmanifest
@@ -1,7 +1,10 @@
 {
   "icons": [
     {
-       "src": "/icon-192.png", "type": "image/png", "sizes": "192x192" },
+      "src": "/icon-192.png",
+      "type": "image/png",
+      "sizes": "192x192"
+    },
     { "src": "/icon-512.png", "type": "image/png", "sizes": "512x512" }
-  ] 
+  ]
 }

--- a/treefmt.nix
+++ b/treefmt.nix
@@ -2,7 +2,6 @@
 {
   pkgs,
   rust,
-  goPkgs,
   jsPkgs,
   movefmt,
 }:
@@ -131,14 +130,38 @@ in
         "_/**"
         "*.ttf"
         "*.png"
+        "*.prv"
+        "*.bin"
+        "*.jpg"
+        "*.svg"
+        "*.jpeg"
         ".git/**"
+        "*.woff2"
+        "*.lockb"
+        ".ignore"
+        "LICENSE"
+        "LICENSE*"
+        "**/*.ico"
+        "**/*.zip"
+        "**/.npmrc"
+        "**/LICENSE"
+        ".gitignore"
+        "CODEOWNERS"
+        "*.template"
+        ".gitignore"
         "**/.sqlx/**"
         "**/vendor/**"
         "*.splinecode"
+        "**/.gitignore"
+        ".gitattributes"
+        "**/testdata/**"
+        "**/testswap/**"
         "**/generated/**"
         ".github/**/*.sh"
         ".github/**/*.md"
+        "**/.gitattributes"
         "uniond/docs/static/**"
+        ".git-blame-ignore-revs"
       ];
     };
   };


### PR DESCRIPTION


how to run this:

```sh
# assuming you're inside the union repo

nix run github:nixos/nixpkgs/nixpkgs-unstable#openvscode-server -- \
  --disable-telemetry \
  --host="127.0.0.1" \
  --accept-server-license-terms \
  --update-extensions \
  --start-server
```

with this setup and the declared vscode extensions, we end up with the following:

nix lsp support in vscode that runs from a NixOS vm (through OrbStack)

as well as lsp support for astro, svelte, typescript and svelte (and whatever else im forgetting)

![image](https://github.com/user-attachments/assets/a53925d1-e8aa-4b2a-bfe0-a1c4d3ef69fc)

<img width="420" alt="image" src="https://github.com/user-attachments/assets/33195728-dd24-4d17-84c5-1e7717a6379c">

ability to run dev within the vscode web app and launch an embdded browser

<img width="1427" alt="image" src="https://github.com/user-attachments/assets/66bb4718-8027-4996-80f5-2bf350e10dd8">
