### PR TITLE
fix(hubble): replace httpie with xh

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -499,7 +499,7 @@
                 openssl
                 pkg-config
                 protobuf
-                httpie
+                xh
                 self'.packages.tdc
                 yq
               ])


### PR DESCRIPTION
httpie includes the cacert package, which ignores certificates installed on the system, which is not desirable.

xh is a rust-clone of httpie