### PR TITLE
chore: revert "fix(union-testnet-9): decrease unbonding time"

### DIFF
--- a/networks/genesis/union-testnet-9/genesis.json
+++ b/networks/genesis/union-testnet-9/genesis.json
@@ -1831,7 +1831,7 @@
     },
     "staking": {
       "params": {
-        "unbonding_time": "60s",
+        "unbonding_time": "1814400s",
         "max_validators": 100,
         "max_entries": 7,
         "historical_entries": 0,


### PR DESCRIPTION
This reverts commit 34ee7cba7a152e116dfa3843580a35628028e61f.