### PR TITLE
Three suggestions for this text: Update node-configuration.mdx

### DIFF
--- a/docs/src/content/docs/infrastructure/node-operators/node-configuration.mdx
+++ b/docs/src/content/docs/infrastructure/node-operators/node-configuration.mdx
@@ -60,7 +60,7 @@ minimum-gas-prices = "0muno"
 
 Located under the "Base Configuration" section of `config/app.toml`.
 
-Several options are available here, ensure you've selected the one that best fits your nodes storage capabilities.
+Several options are available here, ensure you've selected the one that best fits your node's storage capabilities.
 
 ```toml
 # default: the last 362880 states are kept, pruning at 10 block intervals
@@ -129,7 +129,7 @@ laddr = "tcp://0.0.0.0:26656"
 
 Located in the `p2p` TOML table under the "P2P Configuration Options" section.
 
-If you've configured a domain name for your node, this is the place to inform your node of it.
+If you've configured a domain name for your node, specify it here.
 
 ```toml
 # Address to advertise to peers for them to dial
@@ -165,7 +165,7 @@ If you plan for your node to be a validator, it should not also be a seed node.
 :::
 
 ```toml
-# Seed mode, in which node constantly crawls the network and looks for
+# Seed mode, in which the node constantly crawls the network and looks for
 # peers. If another node asks it for addresses, it responds and disconnects.
 #
 # Does not work if the peer-exchange reactor is disabled.


### PR DESCRIPTION
Hi,

I have three suggestions to improve this text gramatically.

1. "Several options are available here, ensure you've selected the one that best fits your nodes storage capabilities."

Missing apostrophe in "node's." Suggested fix: "Several options are available here; ensure you've selected the one that best fits your node's storage capabilities."

2. "If you've configured a domain name for your node, this is the place to inform your node of it."

The phrase is awkward. Suggested fix: "If you've configured a domain name for your node, specify it here."

3. "Seed mode, in which node constantly crawls the network and looks for peers."

Missing article. Suggested fix: "Seed mode, in which the node constantly crawls the network and looks for peers."

Thanks.