### PR TITLE
Refactor: Use h256 from own crate in evm storage verifier

### DIFF
--- a/lib/aptos.nix
+++ b/lib/aptos.nix
@@ -97,6 +97,7 @@ _: {
 
         src = builtins.fetchGit {
           url = "https://github.com/movebit/movefmt";
+          ref = "develop";
           rev = version;
         };
 

--- a/lib/evm-storage-verifier/src/error.rs
+++ b/lib/evm-storage-verifier/src/error.rs
@@ -1,4 +1,5 @@
 use trie_db::TrieError;
+use unionlabs::hash::H256;
 
 #[derive(Debug, Clone, PartialEq, thiserror::Error)]
 pub enum Error {
@@ -11,14 +12,14 @@ pub enum Error {
     #[error("proof is invalid due to missing value: {v}", v = serde_utils::to_hex(value))]
     ValueMissing { value: Vec<u8> },
     #[error("trie error ({0:?})")]
-    Trie(Box<TrieError<primitive_types::H256, rlp::DecoderError>>),
+    Trie(Box<TrieError<H256, rlp::DecoderError>>),
     #[error("rlp decoding failed: {0:?}")]
     RlpDecode(#[from] rlp::DecoderError),
 }
 
-// NOTE: Implemented here instead of via #[from] since Box<TrieError<primitive_types::H256, rlp::DecoderError>> doesn't implement core::error::Error
-impl From<Box<TrieError<primitive_types::H256, rlp::DecoderError>>> for Error {
-    fn from(e: Box<TrieError<primitive_types::H256, rlp::DecoderError>>) -> Self {
+// NOTE: Implemented here instead of via #[from] since Box<TrieError<H256, rlp::DecoderError>> doesn't implement core::error::Error
+impl From<Box<TrieError<H256, rlp::DecoderError>>> for Error {
+    fn from(e: Box<TrieError<H256, rlp::DecoderError>>) -> Self {
         Error::Trie(e)
     }
 }

--- a/lib/evm-storage-verifier/src/lib.rs
+++ b/lib/evm-storage-verifier/src/lib.rs
@@ -112,7 +112,6 @@ fn get_node(
         db.insert(hash_db::EMPTY_PREFIX, n.as_ref());
     });
 
-    let root: primitive_types::H256 = root.into();
     let trie = TrieDBBuilder::<EthLayout>::new(&db, &root).build();
     Ok(trie.get(&keccak_256(key.as_ref()))?)
 }

--- a/lib/evm-storage-verifier/src/rlp_node_codec.rs
+++ b/lib/evm-storage-verifier/src/rlp_node_codec.rs
@@ -19,7 +19,6 @@
 use std::{borrow::Borrow, marker::PhantomData, ops::Range};
 
 use hash_db::Hasher;
-// use primitive_types::H256;
 use rlp::{DecoderError, Prototype, Rlp, RlpStream};
 use sha3::{Digest, Keccak256};
 use trie_db::{

--- a/lib/evm-storage-verifier/src/rlp_node_codec.rs
+++ b/lib/evm-storage-verifier/src/rlp_node_codec.rs
@@ -19,13 +19,14 @@
 use std::{borrow::Borrow, marker::PhantomData, ops::Range};
 
 use hash_db::Hasher;
-use primitive_types::H256;
+// use primitive_types::H256;
 use rlp::{DecoderError, Prototype, Rlp, RlpStream};
 use sha3::{Digest, Keccak256};
 use trie_db::{
     node::{NibbleSlicePlan, NodeHandlePlan, NodePlan, Value, ValuePlan},
     ChildReference, NodeCodec, TrieLayout,
 };
+use unionlabs::hash::H256;
 
 #[derive(Default, Clone)]
 pub struct EthLayout;
@@ -72,7 +73,7 @@ const HASHED_NULL_NODE_BYTES: [u8; 32] = [
     0x56, 0xe8, 0x1f, 0x17, 0x1b, 0xcc, 0x55, 0xa6, 0xff, 0x83, 0x45, 0xe6, 0x92, 0xc0, 0xf8, 0x6e,
     0x5b, 0x48, 0xe0, 0x1b, 0x99, 0x6c, 0xad, 0xc0, 0x01, 0x62, 0x2f, 0xb5, 0xe3, 0x63, 0xb4, 0x21,
 ];
-const HASHED_NULL_NODE: H256 = H256(HASHED_NULL_NODE_BYTES);
+const HASHED_NULL_NODE: H256 = H256::new(HASHED_NULL_NODE_BYTES);
 
 /// Encode a partial value with an iterator as input.
 fn encode_partial_from_iterator_iter<'a>(

--- a/lib/unionlabs/src/hash.rs
+++ b/lib/unionlabs/src/hash.rs
@@ -252,6 +252,12 @@ pub mod hash_v2 {
         }
     }
 
+    impl<const BYTES: usize, E: Encoding> AsMut<[u8]> for Hash<BYTES, E> {
+        fn as_mut(&mut self) -> &mut [u8] {
+            self.get_mut()
+        }
+    }
+
     impl<const BYTES: usize, E: Encoding> Clone for Hash<BYTES, E> {
         fn clone(&self) -> Self {
             *self


### PR DESCRIPTION
Fixes https://github.com/unionlabs/union/issues/3363

Since Unionlabs::Hash::H256 is already implemented, this refactors the codes that uses primitive_types::H256 to our own one.

Additionally ,this PR implements AsMut to hash.rs as Hasher need AsMut trait to be resolved.