### PR TITLE
add a missing feature in dependency

### DIFF
--- a/lib/ibc-union-spec/Cargo.toml
+++ b/lib/ibc-union-spec/Cargo.toml
@@ -7,7 +7,7 @@ version      = "0.1.0"
 
 [dependencies]
 enumorph     = { workspace = true }
-ibc-solidity = { workspace = true }
+ibc-solidity = { workspace = true, features = ["serde"] }
 macros       = { workspace = true }
 serde        = { workspace = true, features = ["derive"] }
 sha3         = { workspace = true }


### PR DESCRIPTION
for the ibc-union-spec crate, you need to enable the `serde` feature on the ibc-solidity dependency, in order to use the solidity types in cosmwasm messages.