### PR TITLE
refactor(app): changes to stores

### DIFF
--- a/app/src/lib/components/TransferFrom/components/Cube/faces/Assets.svelte
+++ b/app/src/lib/components/TransferFrom/components/Cube/faces/Assets.svelte
@@ -12,7 +12,6 @@ interface Props {
   stores: {
     rawIntents: RawIntentsStore
     intents: Readable<IntentsStore>
-    context: Readable<ContextStore>
   }
   rotateTo: (face: CubeFaces) => void
 }
@@ -20,7 +19,7 @@ interface Props {
 export let stores: Props["stores"]
 export let rotateTo: Props["rotateTo"]
 
-let { rawIntents, context, intents } = stores
+let { rawIntents, intents } = stores
 
 $: sortedAssets = [...($intents.sourceAssets ?? [])].sort((a, b) => {
   if (a.isSupported !== b.isSupported) {

--- a/app/src/lib/components/TransferFrom/components/Cube/faces/Intent.svelte
+++ b/app/src/lib/components/TransferFrom/components/Cube/faces/Intent.svelte
@@ -2,7 +2,10 @@
 import Direction from "$lib/components/TransferFrom/components/Direction.svelte"
 import SelectedAsset from "$lib/components/TransferFrom/components/SelectedAsset.svelte"
 import type { Readable } from "svelte/store"
-import type { ValidationStoreAndMethods } from "$lib/components/TransferFrom/transfer/validation.ts"
+import type {
+  ValidationStore,
+  ValidationStoreAndMethods
+} from "$lib/components/TransferFrom/transfer/validation.ts"
 import type { ContextStore } from "$lib/components/TransferFrom/transfer/context.ts"
 import { Button } from "$lib/components/ui/button"
 import type { IntentsStore } from "$lib/components/TransferFrom/transfer/intents.ts"
@@ -14,8 +17,7 @@ interface Props {
   stores: {
     rawIntents: RawIntentsStore
     intents: Readable<IntentsStore>
-    context: Readable<ContextStore>
-    validation: ValidationStoreAndMethods
+    validation: Readable<ValidationStore>
   }
   rotateTo: (face: CubeFaces) => void
 }
@@ -23,7 +25,7 @@ interface Props {
 export let stores: Props["stores"]
 export let rotateTo: Props["rotateTo"]
 
-let { rawIntents, intents, validation, context } = stores
+let { rawIntents, intents, validation } = stores
 </script>
 
 <div class="flex flex-col w-full h-full ">

--- a/app/src/lib/components/TransferFrom/components/Cube/faces/Intent.svelte
+++ b/app/src/lib/components/TransferFrom/components/Cube/faces/Intent.svelte
@@ -35,8 +35,9 @@ let { rawIntents, intents, validation } = stores
   </div>
   <div class="flex flex-col h-full w-full justify-between p-4">
     <div class="flex flex-col gap-4">
-      <Direction {intents} {validation} getSourceChain={() => rotateTo("sourceFace")} getDestinationChain={() => rotateTo("destinationFace")}/>
-      <SelectedAsset {intents} onSelectAsset={() => rotateTo("assetsFace")}/>
+      <Direction {intents} {validation} {rawIntents} getSourceChain={() => rotateTo("sourceFace")}
+                 getDestinationChain={() => rotateTo("destinationFace")}/>
+      <SelectedAsset {intents} {validation} {rawIntents} onSelectAsset={() => rotateTo("assetsFace")}/>
       <div class="flex flex-col gap-1">
         <Input
                 id="amount"

--- a/app/src/lib/components/TransferFrom/components/Cube/faces/Transfer.svelte
+++ b/app/src/lib/components/TransferFrom/components/Cube/faces/Transfer.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
 import type { IntentsStore } from "$lib/components/TransferFrom/transfer/intents.ts"
-import type { ValidationStoreAndMethods } from "$lib/components/TransferFrom/transfer/validation.ts"
+import type { ValidationStore } from "$lib/components/TransferFrom/transfer/validation.ts"
 import { derived, get, type Readable, writable, type Writable } from "svelte/store"
 import type { ContextStore } from "$lib/components/TransferFrom/transfer/context.ts"
 import { Button } from "$lib/components/ui/button"
@@ -32,14 +32,11 @@ import { goto } from "$app/navigation"
 import type { CubeFaces } from "$lib/components/TransferFrom/components/Cube/types.ts"
 import Stepper from "$lib/components/stepper.svelte"
 import type { Step } from "$lib/stepper-types.ts"
-import type { RawIntentsStore } from "$lib/components/TransferFrom/transfer/raw-intents.ts"
 
 interface Props {
   stores: {
-    rawIntents: RawIntentsStore
-    intents: Readable<IntentsStore>
     context: Readable<ContextStore>
-    validation: ValidationStoreAndMethods
+    validation: Readable<ValidationStore>
   }
   rotateTo: (face: CubeFaces) => void
 }
@@ -47,35 +44,18 @@ interface Props {
 export let stores: Props["stores"]
 export let rotateTo: Props["rotateTo"]
 
-let { intents, context } = stores
+let { validation, context } = stores
 
 const REDIRECT_DELAY_MS = 5000
 let transferState: Writable<TransferState> = writable({ kind: "PRE_TRANSFER" })
 
 const transfer = async () => {
-  if (!$intents.selectedAsset.address) return toast.error(`Please select a asset`)
-  if (!$intents.sourceChain?.chain_id) return toast.error("Please select a from chain")
-  if (!$intents.sourceChain) return toast.error("can't find chain in config")
-  if (!$intents.destinationChain) return toast.error("can't find chain in config")
-  if (!$intents.destinationChain.chain_id) return toast.error("Please select a to chain")
+  if (!$validation.isValid) return
 
-  if (!$intents.amount) return toast.error("Please select an amount")
-  if ($intents.sourceChain.rpc_type === "evm" && !$context.userAddress.evm)
-    return toast.error("No evm wallet connected")
-  if ($intents.sourceChain.rpc_type === "cosmos" && !$context.userAddress.cosmos)
-    return toast.error("No cosmos wallet connected")
-  if ($intents.sourceChain.rpc_type === "aptos" && !$context.userAddress.aptos)
-    return toast.error("No aptos wallet connected")
-
-  if (!$intents.receiver) return toast.error("Invalid receiver")
-
-  console.log("click")
-
-  let decimals = $intents.selectedAsset.decimals
-  let parsedAmount = parseUnits($intents.amount, decimals)
+  let parsedAmount = parseUnits($validation.transfer.amount, $validation.transfer.asset.decimals)
 
   /** --- APTOS START --- */
-  if ($intents.sourceChain?.rpc_type === "aptos") {
+  if ($validation.transfer.sourceChain.rpc_type === "aptos") {
     const { connectedWallet, connectionStatus } = get(aptosStore)
     if ($userAddressAptos === null) return toast.error("No aptos user address found")
 
@@ -99,13 +79,14 @@ const transfer = async () => {
     // @ts-ignore
     transferState.set({ kind: "SWITCHING_TO_CHAIN" })
 
-    const rpcUrl = $intents.sourceChain?.rpcs.find(rpc => rpc.type === "rpc")?.url
-    if (!rpcUrl) return toast.error(`no rpc available for ${$intents.sourceChain?.display_name}`)
+    const rpcUrl = $validation.transfer.sourceChain?.rpcs.find(rpc => rpc.type === "rpc")?.url
+    if (!rpcUrl)
+      return toast.error(`no rpc available for ${$validation.transfer.sourceChain?.display_name}`)
 
     if (stepBefore($transferState, "CONFIRMING_TRANSFER")) {
       const chainInfo = await wallet.getNetwork()
 
-      if (chainInfo?.chainId.toString() !== $intents.sourceChain.chain_id) {
+      if (chainInfo?.chainId.toString() !== $validation.transfer.sourceChain.chain_id) {
         transferState.set({
           kind: "SWITCHING_TO_CHAIN",
           warning: new Error("Failed to switch chain")
@@ -127,11 +108,11 @@ const transfer = async () => {
 
         const transferPayload = {
           simulate: true,
-          receiver: $intents.receiver,
+          receiver: $validation.transfer.receiver,
           amount: parsedAmount,
           authAccess: "wallet",
-          denomAddress: $intents.selectedAsset.address,
-          destinationChainId: $intents.destinationChain.chain_id as ChainId
+          denomAddress: $validation.transfer.asset.address,
+          destinationChainId: $validation.transfer.destinationChain.chain_id as ChainId
         } satisfies TransferAssetsParameters<"2">
 
         const transfer = await client.transferAsset(transferPayload)
@@ -148,7 +129,7 @@ const transfer = async () => {
     }
 
     /** --- APTOS END --- */
-  } else if ($intents.sourceChain.rpc_type === "cosmos") {
+  } else if ($validation.transfer.sourceChain.rpc_type === "cosmos") {
     const { connectedWallet, connectionStatus } = get(cosmosStore)
     if ($userAddrCosmos === null) return toast.error("No Cosmos user address found")
 
@@ -173,11 +154,15 @@ const transfer = async () => {
     // @ts-ignore
     transferState.set({ kind: "SWITCHING_TO_CHAIN" })
 
-    const rpcUrl = $intents.sourceChain.rpcs.find(rpc => rpc.type === "rpc")?.url
-    if (!rpcUrl) return toast.error(`no rpc available for ${$intents.sourceChain.display_name}`)
+    const rpcUrl = $validation.transfer.sourceChain.rpcs.find(rpc => rpc.type === "rpc")?.url
+    if (!rpcUrl)
+      return toast.error(`no rpc available for ${$validation.transfer.sourceChain.display_name}`)
 
     if (stepBefore($transferState, "CONFIRMING_TRANSFER")) {
-      const chainInfo = getCosmosChainInfo($intents.sourceChain.chain_id, connectedWallet)
+      const chainInfo = getCosmosChainInfo(
+        $validation.transfer.sourceChain.chain_id,
+        connectedWallet
+      )
 
       if (chainInfo === null) {
         transferState.set({
@@ -189,7 +174,7 @@ const transfer = async () => {
 
       try {
         await wallet.experimentalSuggestChain(chainInfo)
-        await wallet.enable([$intents.sourceChain.chain_id])
+        await wallet.enable([$validation.transfer.sourceChain.chain_id])
       } catch (error) {
         if (error instanceof Error) {
           transferState.set({
@@ -212,24 +197,24 @@ const transfer = async () => {
       try {
         const cosmosOfflineSigner = await getCosmosOfflineSigner({
           connectedWallet,
-          chainId: $intents.sourceChain.chain_id
+          chainId: $validation.transfer.sourceChain.chain_id
         })
         const unionClient = createUnionClient({
           account: cosmosOfflineSigner,
           transport: http(`https://${rpcUrl}`),
-          chainId: $intents.sourceChain.chain_id as CosmosChainId,
-          gasPrice: { amount: "0.0025", denom: $intents.selectedAsset.address }
+          chainId: $validation.transfer.sourceChain.chain_id as CosmosChainId,
+          gasPrice: { amount: "0.0025", denom: $validation.transfer.asset.address }
         })
 
         const transfer = await unionClient.transferAsset({
           autoApprove: true,
-          receiver: $intents.receiver,
+          receiver: $validation.transfer.receiver,
           amount: parsedAmount,
-          denomAddress: $intents.selectedAsset.address,
+          denomAddress: $validation.transfer.asset.address,
           account: cosmosOfflineSigner,
           // TODO: verify chain id is correct
-          destinationChainId: $intents.destinationChain.chain_id as ChainId,
-          gasPrice: { amount: "0.0025", denom: $intents.selectedAsset.address }
+          destinationChainId: $validation.transfer.destinationChain.chain_id as ChainId,
+          gasPrice: { amount: "0.0025", denom: $validation.transfer.asset.address }
         })
         if (transfer.isErr()) throw transfer.error
         transferState.set({ kind: "TRANSFERRING", transferHash: transfer.value })
@@ -241,13 +226,13 @@ const transfer = async () => {
         return
       }
     }
-  } else if ($intents.sourceChain.rpc_type === "evm") {
+  } else if ($validation.transfer.sourceChain.rpc_type === "evm") {
     const connectorClient = await getConnectorClient(config)
-    const selectedChain = evmChainFromChainId($intents.sourceChain.chain_id)
+    const selectedChain = evmChainFromChainId($validation.transfer.sourceChain.chain_id)
 
     const unionClient = createUnionClient({
       account: connectorClient.account,
-      chainId: $intents.sourceChain.chain_id as EvmChainId,
+      chainId: $validation.transfer.sourceChain.chain_id as EvmChainId,
       transport: custom(window.ethereum) as unknown as HttpTransport
     })
 
@@ -289,10 +274,10 @@ const transfer = async () => {
       try {
         const approve = await unionClient.approveTransaction({
           amount: parsedAmount,
-          receiver: $intents.receiver,
-          denomAddress: getAddress($intents.selectedAsset.address),
+          receiver: $validation.transfer.receiver,
+          denomAddress: getAddress($validation.transfer.asset.address),
           // TODO: verify chain id is correct
-          destinationChainId: $intents.destinationChain.chain_id as ChainId
+          destinationChainId: $validation.transfer.destinationChain.chain_id as ChainId
         })
 
         if (approve.isErr()) throw approve.error
@@ -350,10 +335,9 @@ const transfer = async () => {
         const transfer = await unionClient.transferAsset({
           autoApprove: false,
           amount: parsedAmount,
-          receiver: $intents.receiver,
-          denomAddress: getAddress($intents.selectedAsset.address),
-          // TODO: verify chain id is correct
-          destinationChainId: $intents.destinationChain.chain_id as ChainId
+          receiver: $validation.transfer.receiver,
+          denomAddress: getAddress($validation.transfer.asset.address),
+          destinationChainId: $validation.transfer.destinationChain.chain_id as ChainId
         })
         if (transfer.isErr()) throw transfer.error
         transferState.set({ kind: "AWAITING_TRANSFER_RECEIPT", transferHash: transfer.value })
@@ -393,22 +377,23 @@ const transfer = async () => {
     submittedTransfers.update(ts => {
       // @ts-ignore
       ts[$transferState.transferHash] = {
-        source_chain_id: $intents.sourceChain.chain_id,
-        destination_chain_id: $intents.destinationChain?.chain_id,
+        source_chain_id: $validation.transfer?.sourceChain.chain_id,
+        destination_chain_id: $validation.transfer?.destinationChain?.chain_id,
         source_transaction_hash: $transferState.transferHash,
-        hop_chain_id: $intents.destinationChain?.chain_id,
-        sender: userAddrOnChain($context.userAddress, $intents.sourceChain),
+        hop_chain_id: $validation.transfer?.destinationChain?.chain_id,
+        sender: userAddrOnChain($context.userAddress, $validation.transfer?.sourceChain),
         normalized_sender:
-          $intents.sourceChain?.rpc_type === "cosmos"
+          $validation.transfer?.sourceChain?.rpc_type === "cosmos"
             ? $userAddrCosmos?.normalized
             : $userAddrEvm?.normalized,
         transfer_day: toIsoString(new Date(Date.now())).split("T")[0],
-        receiver: $intents.receiver,
+        receiver: $validation.transfer?.receiver,
         assets: {
-          [$intents.selectedAsset.address]: {
+          [$validation.transfer?.asset.address]: {
             info:
-              $intents.sourceChain?.assets?.find(d => d.denom === $intents.selectedAsset.address) ??
-              null,
+              $validation.transfer?.sourceChain?.assets?.find(
+                d => d.denom === $validation.transfer?.asset.address
+              ) ?? null,
             amount: parsedAmount
           }
         },
@@ -441,209 +426,216 @@ const stateToStatus = <K extends TransferState["kind"]>(
           ? errorFormatter(state as Extract<TransferState, { kind: K }>)
           : progressFormatter(state as Extract<TransferState, { kind: K }>)
 
-let stepperSteps = derived([context, transferState], ([$context, $transferState]) => {
-  if ($transferState.kind === "PRE_TRANSFER") return [] // don"t generate steps before transfer is ready
-  if ($intents.sourceChain?.rpc_type === "evm") {
-    // TODO: Refactor this by implementing Ord for transferState
-    return [
-      // Do not uncomment
-      stateToStatus(
-        $transferState,
-        "SWITCHING_TO_CHAIN",
-        `Switch to ${$intents.sourceChain.display_name}`,
-        `Switched to ${$intents.sourceChain.display_name}`,
-        ts => ({
-          status: "ERROR",
-          title: `Error switching to ${$intents.sourceChain.display_name}`,
-          description: `There was an issue switching to ${$intents.sourceChain.display_name} to your wallet. ${ts.warning}`
-        }),
-        () => ({
-          status: "WARNING",
-          title: `Could not automatically switch chain.`,
-          description: `Please make sure your wallet is connected to  ${$intents.sourceChain.display_name}`
-        }),
-        () => ({
-          status: "IN_PROGRESS",
-          title: `Switching to ${$intents.sourceChain.display_name}`,
-          description: `Click "Approve" in wallet.`
-        })
-      ),
-      stateToStatus(
-        $transferState,
-        "APPROVING_ASSET",
-        "Approve ERC20",
-        "Approved ERC20",
-        ts => ({
-          status: "ERROR",
-          title: `Error approving ERC20`,
-          description: `${ts.error}`
-        }),
-        () => ({}),
-        () => ({
-          status: "IN_PROGRESS",
-          title: "Approving ERC20",
-          description: "Click 'Next' and 'Approve' in wallet."
-        })
-      ),
-      stateToStatus(
-        $transferState,
-        "AWAITING_APPROVAL_RECEIPT",
-        "Wait for approval receipt",
-        "Received approval receipt",
-        ts => ({
-          status: "ERROR",
-          title: `Error waiting for approval receipt`,
-          description: `${ts.error}`
-        }),
-        () => ({}),
-        () => ({
-          status: "IN_PROGRESS",
-          title: "Awaiting approval receipt",
-          description: `Waiting on ${$intents.sourceChain.display_name}`
-        })
-      ),
-      stateToStatus(
-        $transferState,
-        "SIMULATING_TRANSFER",
-        "Simulate transfer",
-        "Simulated transfer",
-        ts => ({
-          status: "ERROR",
-          title: `Error simulating transfer on ${$intents.sourceChain.display_name}`,
-          // @ts-expect-error
-          description: `${ts.error}`
-        }),
-        () => ({
-          status: "WARNING",
-          title: `Failed to simulate transfer`,
-          description: `You can still attempt to make this transfer in your wallet`
-        }),
-        () => ({
-          status: "IN_PROGRESS",
-          title: "Simulating transfer",
-          description: `Waiting on ${$intents.sourceChain.display_name}`
-        })
-      ),
-      stateToStatus(
-        $transferState,
-        "CONFIRMING_TRANSFER",
-        "Confirm transfer",
-        "Confirmed transfer",
-        ts => ({
-          status: "ERROR",
-          title: "Error confirming transfer",
-          description: `${ts.error}`
-        }),
-        () => ({}),
-        () => ({
-          status: "IN_PROGRESS",
-          title: "Confirming your transfer",
-          description: `Click "Confirm" in your wallet`
-        })
-      ),
-      stateToStatus(
-        $transferState,
-        "AWAITING_TRANSFER_RECEIPT",
-        "Wait for transfer receipt",
-        "Confirmed transfer",
-        ts => ({
-          status: "ERROR",
-          title: "Error while waiting on transfer receipt",
-          description: `tx hash: ${ts.transferHash}, error: ${ts.error}`
-        }),
-        () => ({}),
-        () => ({
-          status: "IN_PROGRESS",
-          title: "Awaiting transfer receipt",
-          description: `Waiting on ${$intents.sourceChain.display_name}`
-        })
-      ),
-      stateToStatus(
-        $transferState,
-        "TRANSFERRING",
-        "Transfer assets",
-        "Transferred assets",
-        () => ({}),
-        () => ({}),
-        () => ({
-          status: "IN_PROGRESS",
-          title: "Transferring assets",
-          description: `Successfully initiated transfer`
-        })
-      )
-    ] as Array<Step>
+let stepperSteps = derived(
+  [context, transferState, validation],
+  ([$context, $transferState, $validation]) => {
+    if (!$validation.isValid) return []
+    if ($transferState.kind === "PRE_TRANSFER") return [] // don"t generate steps before transfer is ready
+    if ($validation.transfer.sourceChain?.rpc_type === "evm") {
+      // TODO: Refactor this by implementing Ord for transferState
+      return [
+        // Do not uncomment
+        stateToStatus(
+          $transferState,
+          "SWITCHING_TO_CHAIN",
+          `Switch to ${$validation.transfer.sourceChain.display_name}`,
+          `Switched to ${$validation.transfer.sourceChain.display_name}`,
+          ts => ({
+            status: "ERROR",
+            title: `Error switching to ${$validation.transfer.sourceChain.display_name}`,
+            description: `There was an issue switching to ${$validation.transfer.sourceChain.display_name} to your wallet. ${ts.warning}`
+          }),
+          () => ({
+            status: "WARNING",
+            title: `Could not automatically switch chain.`,
+            description: `Please make sure your wallet is connected to  ${$validation.transfer.sourceChain.display_name}`
+          }),
+          () => ({
+            status: "IN_PROGRESS",
+            title: `Switching to ${$validation.transfer.sourceChain.display_name}`,
+            description: `Click "Approve" in wallet.`
+          })
+        ),
+        stateToStatus(
+          $transferState,
+          "APPROVING_ASSET",
+          "Approve ERC20",
+          "Approved ERC20",
+          ts => ({
+            status: "ERROR",
+            title: `Error approving ERC20`,
+            description: `${ts.error}`
+          }),
+          () => ({}),
+          () => ({
+            status: "IN_PROGRESS",
+            title: "Approving ERC20",
+            description: "Click 'Next' and 'Approve' in wallet."
+          })
+        ),
+        stateToStatus(
+          $transferState,
+          "AWAITING_APPROVAL_RECEIPT",
+          "Wait for approval receipt",
+          "Received approval receipt",
+          ts => ({
+            status: "ERROR",
+            title: `Error waiting for approval receipt`,
+            description: `${ts.error}`
+          }),
+          () => ({}),
+          () => ({
+            status: "IN_PROGRESS",
+            title: "Awaiting approval receipt",
+            description: `Waiting on ${$validation.transfer.sourceChain.display_name}`
+          })
+        ),
+        stateToStatus(
+          $transferState,
+          "SIMULATING_TRANSFER",
+          "Simulate transfer",
+          "Simulated transfer",
+          ts => ({
+            status: "ERROR",
+            title: `Error simulating transfer on ${$validation.transfer.sourceChain.display_name}`,
+            // @ts-expect-error
+            description: `${ts.error}`
+          }),
+          () => ({
+            status: "WARNING",
+            title: `Failed to simulate transfer`,
+            description: `You can still attempt to make this transfer in your wallet`
+          }),
+          () => ({
+            status: "IN_PROGRESS",
+            title: "Simulating transfer",
+            description: `Waiting on ${$validation.transfer.sourceChain.display_name}`
+          })
+        ),
+        stateToStatus(
+          $transferState,
+          "CONFIRMING_TRANSFER",
+          "Confirm transfer",
+          "Confirmed transfer",
+          ts => ({
+            status: "ERROR",
+            title: "Error confirming transfer",
+            description: `${ts.error}`
+          }),
+          () => ({}),
+          () => ({
+            status: "IN_PROGRESS",
+            title: "Confirming your transfer",
+            description: `Click "Confirm" in your wallet`
+          })
+        ),
+        stateToStatus(
+          $transferState,
+          "AWAITING_TRANSFER_RECEIPT",
+          "Wait for transfer receipt",
+          "Confirmed transfer",
+          ts => ({
+            status: "ERROR",
+            title: "Error while waiting on transfer receipt",
+            description: `tx hash: ${ts.transferHash}, error: ${ts.error}`
+          }),
+          () => ({}),
+          () => ({
+            status: "IN_PROGRESS",
+            title: "Awaiting transfer receipt",
+            description: `Waiting on ${$validation.transfer.sourceChain.display_name}`
+          })
+        ),
+        stateToStatus(
+          $transferState,
+          "TRANSFERRING",
+          "Transfer assets",
+          "Transferred assets",
+          () => ({}),
+          () => ({}),
+          () => ({
+            status: "IN_PROGRESS",
+            title: "Transferring assets",
+            description: `Successfully initiated transfer`
+          })
+        )
+      ] as Array<Step>
+    }
+    if (
+      $validation.transfer.sourceChain?.rpc_type === "cosmos" ||
+      $validation.transfer.sourceChain?.rpc_type === "aptos"
+    ) {
+      return [
+        stateToStatus(
+          $transferState,
+          "SWITCHING_TO_CHAIN",
+          `Switch to ${$validation.transfer.sourceChain.display_name}`,
+          `Switched to ${$validation.transfer.sourceChain.display_name}`,
+          ts => ({
+            status: "ERROR",
+            title: `Error switching to ${$validation.transfer.sourceChain.display_name}`,
+            description: `There was an issue switching to ${$validation.transfer.sourceChain.display_name} to your wallet. ${ts.warning}`
+          }),
+          () => ({
+            status: "WARNING",
+            title: `Could not automatically switch chain.`,
+            description: `Please make sure your wallet is connected to  ${$validation.transfer.sourceChain.display_name}`
+          }),
+          () => ({
+            status: "IN_PROGRESS",
+            title: `Switching to ${$validation.transfer.sourceChain.display_name}`,
+            description: `Click "Approve" in wallet.`
+          })
+        ),
+        stateToStatus(
+          $transferState,
+          "CONFIRMING_TRANSFER",
+          "Confirm transfer",
+          "Confirmed transfer",
+          ts => ({
+            status: "ERROR",
+            title: "Error confirming transfer",
+            description: `${ts.error}`
+          }),
+          () => ({}),
+          () => ({
+            status: "IN_PROGRESS",
+            title: "Confirming your transfer",
+            description: `Click "Approve" in your wallet`
+          })
+        ),
+        stateToStatus(
+          $transferState,
+          "TRANSFERRING",
+          "Transfer assets",
+          "Transferred assets",
+          () => ({}),
+          () => ({}),
+          () => ({
+            status: "IN_PROGRESS",
+            title: "Transferring assets",
+            description: `Successfully initiated transfer`
+          })
+        )
+      ] as Array<Step>
+    }
+    raise("trying to make stepper for unsupported chain")
   }
-  if ($intents.sourceChain?.rpc_type === "cosmos" || $intents.sourceChain?.rpc_type === "aptos") {
-    return [
-      stateToStatus(
-        $transferState,
-        "SWITCHING_TO_CHAIN",
-        `Switch to ${$intents.sourceChain.display_name}`,
-        `Switched to ${$intents.sourceChain.display_name}`,
-        ts => ({
-          status: "ERROR",
-          title: `Error switching to ${$intents.sourceChain.display_name}`,
-          description: `There was an issue switching to ${$intents.sourceChain.display_name} to your wallet. ${ts.warning}`
-        }),
-        () => ({
-          status: "WARNING",
-          title: `Could not automatically switch chain.`,
-          description: `Please make sure your wallet is connected to  ${$intents.sourceChain.display_name}`
-        }),
-        () => ({
-          status: "IN_PROGRESS",
-          title: `Switching to ${$intents.sourceChain.display_name}`,
-          description: `Click "Approve" in wallet.`
-        })
-      ),
-      stateToStatus(
-        $transferState,
-        "CONFIRMING_TRANSFER",
-        "Confirm transfer",
-        "Confirmed transfer",
-        ts => ({
-          status: "ERROR",
-          title: "Error confirming transfer",
-          description: `${ts.error}`
-        }),
-        () => ({}),
-        () => ({
-          status: "IN_PROGRESS",
-          title: "Confirming your transfer",
-          description: `Click "Approve" in your wallet`
-        })
-      ),
-      stateToStatus(
-        $transferState,
-        "TRANSFERRING",
-        "Transfer assets",
-        "Transferred assets",
-        () => ({}),
-        () => ({}),
-        () => ({
-          status: "IN_PROGRESS",
-          title: "Transferring assets",
-          description: `Successfully initiated transfer`
-        })
-      )
-    ] as Array<Step>
-  }
-  raise("trying to make stepper for unsupported chain")
-})
+)
 </script>
 
 <div class="h-full w-full flex flex-col justify-between p-4 overflow-y-scroll">
   <div>
     <h2>Transfer</h2>
-    <p>RPC_TYPE: {$intents?.sourceChain?.rpc_type}</p>
-    <p>SOURCE: {$intents?.sourceChain?.display_name}</p>
-    <p>DESTINATION: {$intents?.destinationChain?.display_name}</p>
-    <p>ASSET: {$intents?.selectedAsset?.address ? truncate($intents.selectedAsset.address, 12) : ""}</p>
-    <p>AMOUNT: {$intents.amount}</p>
-    <p>RECEIVER: {truncateAddress({address: $intents.receiver})}</p>
+    <p>RPC_TYPE: {$validation.transfer?.sourceChain?.rpc_type}</p>
+    <p>SOURCE: {$validation.transfer?.sourceChain?.display_name}</p>
+    <p>DESTINATION: {$validation.transfer?.destinationChain?.display_name}</p>
+    <p>ASSET: {$validation.transfer?.asset?.address ? truncate($validation.transfer?.asset.address, 12) : ""}</p>
+    <p>AMOUNT: {$validation.transfer?.amount}</p>
+    <p>RECEIVER: {truncateAddress({address: $validation.transfer?.receiver ?? ''})}</p>
   </div>
 
-  {#if $intents.sourceChain}
+  {#if $validation.transfer?.sourceChain}
     <Stepper
             steps={stepperSteps}
             on:cancel={() => transferState.set({ kind: 'PRE_TRANSFER' })}

--- a/app/src/lib/components/TransferFrom/components/Direction.svelte
+++ b/app/src/lib/components/TransferFrom/components/Direction.svelte
@@ -2,11 +2,11 @@
 import type { IntentsStore } from "../transfer/intents.ts"
 import type { Readable } from "svelte/store"
 import { Button } from "$lib/components/ui/button"
-import type { ValidationStoreAndMethods } from "$lib/components/TransferFrom/transfer/validation.ts"
+import type { ValidationStore } from "$lib/components/TransferFrom/transfer/validation.ts"
 
 interface Props {
   intents: Readable<IntentsStore>
-  validation: ValidationStoreAndMethods
+  validation: Readable<ValidationStore>
   getSourceChain: () => void
   getDestinationChain: () => void
 }
@@ -27,6 +27,9 @@ export let getDestinationChain: Props["getDestinationChain"]
   >
     {$intents?.sourceChain?.display_name.split(" ")[0] ?? 'Source chain'}
   </Button>
+  {#if $validation.errors.source}
+    <p class="text-red-500 text-sm">{$validation.errors.source}</p>
+  {/if}
   <Button
           variant="outline"
           type="button"
@@ -36,15 +39,7 @@ export let getDestinationChain: Props["getDestinationChain"]
   >
     {$intents?.destinationChain?.display_name.split(" ")[0] ?? "Destination chain"}
   </Button>
+  {#if $validation.errors.destination}
+    <p class="text-red-500 text-sm"> {$validation.errors.destination}</p>
+  {/if}
 </div>
-{#if $validation.errors.destination || $validation.errors.source}
-  <span class="text-red-500 text-sm">
-    {#if $validation.errors.destination}
-      {$validation.errors.destination}
-    {/if}
-    {#if $validation.errors.source}
-      {#if $validation.errors.destination}<br>{/if}
-      {$validation.errors.source}
-    {/if}
-  </span>
-{/if}

--- a/app/src/lib/components/TransferFrom/components/Direction.svelte
+++ b/app/src/lib/components/TransferFrom/components/Direction.svelte
@@ -3,14 +3,17 @@ import type { IntentsStore } from "../transfer/intents.ts"
 import type { Readable } from "svelte/store"
 import { Button } from "$lib/components/ui/button"
 import type { ValidationStore } from "$lib/components/TransferFrom/transfer/validation.ts"
+import type { RawIntentsStore } from "$lib/components/TransferFrom/transfer/raw-intents.ts"
 
 interface Props {
+  rawIntents: RawIntentsStore
   intents: Readable<IntentsStore>
   validation: Readable<ValidationStore>
   getSourceChain: () => void
   getDestinationChain: () => void
 }
 
+export let rawIntents: Props["rawIntents"]
 export let intents: Props["intents"]
 export let validation: Props["validation"]
 export let getSourceChain: Props["getSourceChain"]
@@ -25,7 +28,12 @@ export let getDestinationChain: Props["getDestinationChain"]
           class="border-2 font-bold"
           on:click={getSourceChain}
   >
-    {$intents?.sourceChain?.display_name.split(" ")[0] ?? 'Source chain'}
+    {$intents?.sourceChain?.display_name
+      ? $intents.sourceChain.display_name.split(" ")[0]
+      : $rawIntents.source
+        ? $rawIntents.source
+        : 'Source chain'
+    }
   </Button>
   {#if $validation.errors.source}
     <p class="text-red-500 text-sm">{$validation.errors.source}</p>
@@ -37,7 +45,12 @@ export let getDestinationChain: Props["getDestinationChain"]
           class="border-2 font-bold"
           on:click={getDestinationChain}
   >
-    {$intents?.destinationChain?.display_name.split(" ")[0] ?? "Destination chain"}
+    {$intents?.destinationChain?.display_name
+      ? $intents.destinationChain.display_name.split(" ")[0]
+      : $rawIntents.destination
+        ? $rawIntents.destination
+        : "Destination chain"
+    }
   </Button>
   {#if $validation.errors.destination}
     <p class="text-red-500 text-sm"> {$validation.errors.destination}</p>

--- a/app/src/lib/components/TransferFrom/components/SelectedAsset.svelte
+++ b/app/src/lib/components/TransferFrom/components/SelectedAsset.svelte
@@ -3,23 +3,37 @@ import type { Readable } from "svelte/store"
 import { Button } from "$lib/components/ui/button"
 import { truncate } from "$lib/utilities/format.ts"
 import type { IntentsStore } from "$lib/components/TransferFrom/transfer/intents.ts"
+import type { ValidationStore } from "$lib/components/TransferFrom/transfer/validation.ts"
+import type { RawIntentsStore } from "$lib/components/TransferFrom/transfer/raw-intents.ts"
 
 interface Props {
+  rawIntents: RawIntentsStore
   intents: Readable<IntentsStore>
+  validation: Readable<ValidationStore>
   onSelectAsset: () => void
 }
 
+export let rawIntents: Props["rawIntents"]
 export let intents: Props["intents"]
+export let validation: Props["validation"]
 export let onSelectAsset: Props["onSelectAsset"]
 </script>
 
-<Button
-        disabled={!$intents.sourceChain}
-        type="button"
-        size="sm"
-        variant="outline"
-        class="border-2 font-bold"
-        on:click={onSelectAsset}
->
-  {$intents.selectedAsset.symbol ? truncate($intents.selectedAsset.symbol, 18) : "Select Asset"}
-</Button>
+<div class="flex flex-col w-full gap-2">
+  <Button
+          disabled={!$intents.sourceChain}
+          type="button"
+          size="sm"
+          variant="outline"
+          class="border-2 font-bold"
+          on:click={onSelectAsset}
+  >
+    {$intents.selectedAsset.symbol ?
+      truncate($intents.selectedAsset.symbol, 18) :
+      $rawIntents.asset ? truncate($rawIntents.asset, 6) :
+        "Select Asset"}
+  </Button>
+  {#if $validation.errors.asset}
+    <p class="text-red-500 text-sm">{$validation.errors.asset}</p>
+  {/if}
+</div>

--- a/app/src/lib/components/TransferFrom/index.svelte
+++ b/app/src/lib/components/TransferFrom/index.svelte
@@ -7,9 +7,9 @@ import Chains from "$lib/components/TransferFrom/components/Cube/faces/Chains.sv
 import Assets from "$lib/components/TransferFrom/components/Cube/faces/Assets.svelte"
 import Transfer from "$lib/components/TransferFrom/components/Cube/faces/Transfer.svelte"
 import Cube from "$lib/components/TransferFrom/components/Cube/index.svelte"
-import type {Chain, UserAddresses} from "$lib/types.ts";
-import {userBalancesQuery} from "$lib/queries/balance";
-import {balanceStore, userAddress} from "$lib/components/TransferFrom/transfer/balances.ts";
+import type { Chain, UserAddresses } from "$lib/types.ts"
+import { userBalancesQuery } from "$lib/queries/balance"
+import { balanceStore, userAddress } from "$lib/components/TransferFrom/transfer/balances.ts"
 
 export let chains: Array<Chain>
 

--- a/app/src/lib/components/TransferFrom/index.svelte
+++ b/app/src/lib/components/TransferFrom/index.svelte
@@ -7,8 +7,21 @@ import Chains from "$lib/components/TransferFrom/components/Cube/faces/Chains.sv
 import Assets from "$lib/components/TransferFrom/components/Cube/faces/Assets.svelte"
 import Transfer from "$lib/components/TransferFrom/components/Cube/faces/Transfer.svelte"
 import Cube from "$lib/components/TransferFrom/components/Cube/index.svelte"
+import type {Chain, UserAddresses} from "$lib/types.ts";
+import {userBalancesQuery} from "$lib/queries/balance";
+import {balanceStore, userAddress} from "$lib/components/TransferFrom/transfer/balances.ts";
 
-const stores = createTransferStore()
+export let chains: Array<Chain>
+
+$: userBalancesQuery({
+  chains,
+  userAddr: $userAddress,
+  connected: true
+}).subscribe(x => {
+  balanceStore.set(x)
+})
+
+const stores = createTransferStore(chains)
 </script>
 
 <Cube>

--- a/app/src/lib/components/TransferFrom/transfer/balances.ts
+++ b/app/src/lib/components/TransferFrom/transfer/balances.ts
@@ -4,6 +4,7 @@ import { userAddrCosmos } from "$lib/wallet/cosmos"
 import { userAddrEvm } from "$lib/wallet/evm"
 import { userAddressAptos } from "$lib/wallet/aptos"
 import type { QueryObserverResult } from "@tanstack/query-core"
+import type { BalanceResult } from "$lib/queries/balance"
 
 export let userAddress: Readable<UserAddresses> = derived(
   [userAddrCosmos, userAddrEvm, userAddressAptos],
@@ -14,4 +15,4 @@ export let userAddress: Readable<UserAddresses> = derived(
   })
 )
 
-export let balanceStore = writable<Array<QueryObserverResult<any>>>([])
+export const balanceStore = writable<Array<QueryObserverResult<Array<BalanceResult>, Error>>>()

--- a/app/src/lib/components/TransferFrom/transfer/balances.ts
+++ b/app/src/lib/components/TransferFrom/transfer/balances.ts
@@ -1,9 +1,9 @@
-import {derived, type Readable, writable} from "svelte/store";
-import type {UserAddresses} from "$lib/types.ts";
-import {userAddrCosmos} from "$lib/wallet/cosmos";
-import {userAddrEvm} from "$lib/wallet/evm";
-import {userAddressAptos} from "$lib/wallet/aptos";
-import type {QueryObserverResult} from "@tanstack/query-core";
+import { derived, type Readable, writable } from "svelte/store"
+import type { UserAddresses } from "$lib/types.ts"
+import { userAddrCosmos } from "$lib/wallet/cosmos"
+import { userAddrEvm } from "$lib/wallet/evm"
+import { userAddressAptos } from "$lib/wallet/aptos"
+import type { QueryObserverResult } from "@tanstack/query-core"
 
 export let userAddress: Readable<UserAddresses> = derived(
   [userAddrCosmos, userAddrEvm, userAddressAptos],
@@ -14,4 +14,4 @@ export let userAddress: Readable<UserAddresses> = derived(
   })
 )
 
-export let balanceStore = writable<QueryObserverResult<any>[]>([])
+export let balanceStore = writable<Array<QueryObserverResult<any>>>([])

--- a/app/src/lib/components/TransferFrom/transfer/balances.ts
+++ b/app/src/lib/components/TransferFrom/transfer/balances.ts
@@ -1,0 +1,17 @@
+import {derived, type Readable, writable} from "svelte/store";
+import type {UserAddresses} from "$lib/types.ts";
+import {userAddrCosmos} from "$lib/wallet/cosmos";
+import {userAddrEvm} from "$lib/wallet/evm";
+import {userAddressAptos} from "$lib/wallet/aptos";
+import type {QueryObserverResult} from "@tanstack/query-core";
+
+export let userAddress: Readable<UserAddresses> = derived(
+  [userAddrCosmos, userAddrEvm, userAddressAptos],
+  ([$userAddrCosmos, $userAddrEvm, $userAddressAptos]) => ({
+    evm: $userAddrEvm,
+    cosmos: $userAddrCosmos,
+    aptos: $userAddressAptos
+  })
+)
+
+export let balanceStore = writable<QueryObserverResult<any>[]>([])

--- a/app/src/lib/components/TransferFrom/transfer/context.ts
+++ b/app/src/lib/components/TransferFrom/transfer/context.ts
@@ -2,6 +2,8 @@ import { derived, type Readable } from "svelte/store"
 import type { Chain, UserAddresses } from "$lib/types"
 import type { Address } from "$lib/wallet/types"
 import { balanceStore, userAddress } from "./balances.ts"
+import type { BalanceResult } from "$lib/queries/balance"
+import type { QueryObserverResult } from "@tanstack/query-core"
 
 export type BalanceRecord = {
   balance: bigint
@@ -24,37 +26,40 @@ export interface ContextStore {
 }
 
 export function createContextStore(chains: Array<Chain>): Readable<ContextStore> {
-  const balances = derived(balanceStore, $rawBalances => {
-    if ($rawBalances?.length === 0) {
-      return chains.map(chain => ({
-        chainId: chain.chain_id,
-        balances: []
-      }))
-    }
-
-    return chains.map((chain, chainIndex) => {
-      const balanceResult = $rawBalances[chainIndex]
-
-      if (!balanceResult?.isSuccess || balanceResult.data instanceof Error) {
-        console.log(`No balances fetched yet for chain ${chain.chain_id}`)
-        return {
+  const balances = derived(
+    balanceStore as Readable<Array<QueryObserverResult<Array<BalanceResult>, Error>>>,
+    $rawBalances => {
+      if ($rawBalances?.length === 0) {
+        return chains.map(chain => ({
           chainId: chain.chain_id,
           balances: []
-        }
-      }
-
-      return {
-        chainId: chain.chain_id,
-        balances: balanceResult.data.map(balance => ({
-          ...balance,
-          balance: BigInt(balance.balance),
-          gasToken: balance.gasToken ?? false,
-          address: balance.address as Address,
-          symbol: balance.symbol || balance.address
         }))
       }
-    })
-  }) as Readable<BalancesList>
+
+      return chains.map((chain, chainIndex) => {
+        const balanceResult = $rawBalances[chainIndex]
+
+        if (!(balanceResult?.isSuccess && balanceResult.data)) {
+          console.log(`No balances fetched yet for chain ${chain.chain_id}`)
+          return {
+            chainId: chain.chain_id,
+            balances: []
+          }
+        }
+
+        return {
+          chainId: chain.chain_id,
+          balances: balanceResult.data.map((balance: BalanceResult) => ({
+            ...balance,
+            balance: BigInt(balance.balance),
+            gasToken: "gasToken" in balance ? (balance.gasToken ?? false) : false,
+            address: balance.address as Address,
+            symbol: balance.symbol || balance.address
+          }))
+        }
+      })
+    }
+  ) as Readable<BalancesList>
 
   return derived([userAddress, balances], ([$userAddress, $balances]) => ({
     chains,

--- a/app/src/lib/components/TransferFrom/transfer/index.ts
+++ b/app/src/lib/components/TransferFrom/transfer/index.ts
@@ -12,9 +12,7 @@ import {
   createValidationStore,
   type ValidationStore
 } from "$lib/components/TransferFrom/transfer/validation.ts"
-import type { Chain, UserAddresses } from "$lib/types"
-import type { QueryObserverResult } from "@tanstack/svelte-query"
-
+import type { Chain } from "$lib/types"
 
 export interface TransferStore {
   rawIntents: RawIntentsStore

--- a/app/src/lib/components/TransferFrom/transfer/index.ts
+++ b/app/src/lib/components/TransferFrom/transfer/index.ts
@@ -12,6 +12,9 @@ import {
   createValidationStore,
   type ValidationStore
 } from "$lib/components/TransferFrom/transfer/validation.ts"
+import type { Chain, UserAddresses } from "$lib/types"
+import type { QueryObserverResult } from "@tanstack/svelte-query"
+
 
 export interface TransferStore {
   rawIntents: RawIntentsStore
@@ -20,9 +23,9 @@ export interface TransferStore {
   validation: Readable<ValidationStore>
 }
 
-export function createTransferStore(): TransferStore {
+export function createTransferStore(chains: Array<Chain>): TransferStore {
   const rawIntents = createRawIntentsStore()
-  const context = createContextStore()
+  const context = createContextStore(chains)
   const intents = createIntentStore(rawIntents, context)
   const validation = createValidationStore(rawIntents, intents, context)
 

--- a/app/src/lib/components/TransferFrom/transfer/index.ts
+++ b/app/src/lib/components/TransferFrom/transfer/index.ts
@@ -5,19 +5,19 @@ import {
   createContextStore
 } from "$lib/components/TransferFrom/transfer/context.ts"
 import {
-  createValidationStore,
-  type ValidationStoreAndMethods
-} from "$lib/components/TransferFrom/transfer/validation.ts"
-import {
   createRawIntentsStore,
   type RawIntentsStore
 } from "$lib/components/TransferFrom/transfer/raw-intents.ts"
+import {
+  createValidationStore,
+  type ValidationStore
+} from "$lib/components/TransferFrom/transfer/validation.ts"
 
 export interface TransferStore {
   rawIntents: RawIntentsStore
   intents: Readable<IntentsStore>
   context: Readable<ContextStore>
-  validation: ValidationStoreAndMethods
+  validation: Readable<ValidationStore>
 }
 
 export function createTransferStore(): TransferStore {

--- a/app/src/lib/components/TransferFrom/transfer/intents.ts
+++ b/app/src/lib/components/TransferFrom/transfer/intents.ts
@@ -16,17 +16,17 @@ export type AssetListItem = {
 }
 
 export interface SelectedAsset {
-  address: string | undefined
-  balance: bigint | undefined
-  symbol: string | undefined
+  address: string | null
+  balance: bigint | null
+  symbol: string | null
   decimals: number
-  gasToken: boolean | undefined
-  supported: ChainAsset | undefined
+  gasToken: boolean
+  supported: ChainAsset | null
 }
 
 export interface IntentsStore {
-  sourceChain: Chain | undefined
-  destinationChain: Chain | undefined
+  sourceChain: Chain | null
+  destinationChain: Chain | null
   selectedAsset: SelectedAsset
   sourceAssets: Array<AssetListItem>
   receiver: string
@@ -46,11 +46,13 @@ export function createIntentStore(
   const queryClient = useQueryClient()
 
   const sourceChain = derived([rawIntents, context], ([$intents, $context]) => {
-    return $context.chains.find(chain => chain.chain_id === $intents.source)
+    return $context.chains.find(chain => chain.chain_id === $intents.source) ?? null
   })
 
-  const destinationChain = derived([rawIntents, context], ([$intents, $context]) =>
-    $context.chains.find(chain => chain.chain_id === $intents.destination)
+  const destinationChain = derived(
+    [rawIntents, context],
+    ([$intents, $context]) =>
+      $context.chains.find(chain => chain.chain_id === $intents.destination) ?? null
   )
 
   //Assets of selected chain
@@ -91,12 +93,12 @@ export function createIntentStore(
 
   //Create th selected asset with all info
   const selectedAsset = derived([asset, supportedAsset], ([$asset, $supportedAsset]) => ({
-    address: $asset?.address,
-    balance: $asset?.balance,
-    symbol: getDisplaySymbol($asset, $supportedAsset),
+    address: $asset?.address ?? "",
+    balance: $asset?.balance ?? 0n,
+    symbol: getDisplaySymbol($asset, $supportedAsset) ?? "",
     decimals: $supportedAsset?.decimals ?? 0,
-    gasToken: $asset?.gasToken,
-    supported: $supportedAsset
+    gasToken: $asset?.gasToken ?? false,
+    supported: $supportedAsset ?? null
   }))
 
   return derived(

--- a/app/src/lib/components/TransferFrom/transfer/schema.ts
+++ b/app/src/lib/components/TransferFrom/transfer/schema.ts
@@ -62,7 +62,7 @@ export const transferSchema = v.pipe(
             }
           }
           const amountBigInt = parseAmount(input.amount, input.decimals)
-          return amountBigInt <= input.balance // input.balance is already BigInt
+          return amountBigInt > 0n && amountBigInt <= input.balance
         } catch (error) {
           console.error("Validation error:", error)
           return false

--- a/app/src/lib/components/TransferFrom/transfer/validation.ts
+++ b/app/src/lib/components/TransferFrom/transfer/validation.ts
@@ -54,6 +54,14 @@ export function createValidationStore(
   const errors = derived([rawIntents, intents, context], ([$rawIntents, $intents, $context]) => {
     const errors: FieldErrors = {}
 
+    if ($rawIntents.source) {
+      if (!$intents.sourceChain) errors.source = "Chain not supported"
+    }
+
+    if ($rawIntents.destination) {
+      if (!$intents.destinationChain) errors.destination = "Chain not supported"
+    }
+
     // Source chain wallet validation
     if ($intents.sourceChain) {
       if ($intents.sourceChain?.rpc_type === "evm" && !$context.userAddress.evm) {
@@ -73,6 +81,7 @@ export function createValidationStore(
 
     // Required fields when asset is selected
     if ($rawIntents.asset) {
+      if (!$intents.selectedAsset.address) errors.asset = "Asset not found in wallet"
       if (!$rawIntents.amount) errors.amount = "Amount is required"
       if (!$rawIntents.receiver) errors.receiver = "Receiver is required"
 

--- a/app/src/lib/components/TransferFrom/transfer/validation.ts
+++ b/app/src/lib/components/TransferFrom/transfer/validation.ts
@@ -52,12 +52,11 @@ export function createValidationStore(
       amount: $rawIntents.amount
     }
 
-    if (formFields.asset && !formFields.amount) {
-      return { amount: "Amount is required" }
-    }
-
-    if (formFields.asset && !formFields.receiver) {
-      return { receiver: "Receiver is required" }
+    if (formFields.asset) {
+      const errors: FieldErrors = {}
+      if (!formFields.amount) errors.amount = "Amount is required"
+      if (!formFields.receiver) errors.receiver = "Receiver is required"
+      if (Object.keys(errors).length > 0) return errors
     }
 
     const parseInput = {

--- a/app/src/lib/components/TransferFrom/transfer/validation.ts
+++ b/app/src/lib/components/TransferFrom/transfer/validation.ts
@@ -1,39 +1,49 @@
 import type { Readable } from "svelte/store"
 import { derived } from "svelte/store"
-import type { IntentsStore, SelectedAsset } from "./intents.ts"
-import type { Chain } from "$lib/types"
+import type { IntentsStore } from "./intents.ts"
+import type { Chain, ChainAsset } from "$lib/types"
 import type { ContextStore } from "$lib/components/TransferFrom/transfer/context"
 import { transferSchema } from "./schema.ts"
 import { safeParse } from "valibot"
-import type {
-  FormFields,
-  RawIntentsStore
-} from "$lib/components/TransferFrom/transfer/raw-intents.ts"
+import type { FormFields, RawIntentsStore } from "$lib/components/TransferFrom/transfer/raw-intents"
 
 export type FieldErrors = Partial<Record<keyof FormFields, string>>
 
-export interface ValidationStore {
+export interface ValidTransfer {
+  sourceChain: Chain
+  destinationChain: Chain
+  asset: {
+    address: string
+    balance: bigint
+    symbol: string
+    decimals: number
+    gasToken: boolean
+    supported: ChainAsset
+  }
+  receiver: string
+  amount: string
+}
+
+export interface InvalidValidationStore {
+  transfer: undefined
   errors: FieldErrors
-  isValid: boolean
+  isValid: false
 }
 
-export interface ValidationStoreAndMethods extends Readable<ValidationStore> {
-  validate: () => Promise<boolean>
+export interface ValidValidationStore {
+  transfer: ValidTransfer
+  errors: FieldErrors
+  isValid: true
 }
 
-interface ValidationContext {
-  sourceChain: Chain | undefined
-  destinationChain: Chain | undefined
-  selectedAsset: SelectedAsset
-  chains: Array<Chain>
-}
+export type ValidationStore = InvalidValidationStore | ValidValidationStore
 
 export function createValidationStore(
   rawIntents: RawIntentsStore,
   intents: Readable<IntentsStore>,
   context: Readable<ContextStore>
-): ValidationStoreAndMethods {
-  const store = derived([rawIntents, intents, context], ([$rawIntents, $intents, $context]) => {
+): Readable<ValidationStore> {
+  const errors = derived([rawIntents, intents, context], ([$rawIntents, $intents, _$context]) => {
     const formFields = {
       source: $rawIntents.source,
       destination: $rawIntents.destination,
@@ -42,104 +52,80 @@ export function createValidationStore(
       amount: $rawIntents.amount
     }
 
-    // Check if all required fields have values
-    const hasAllRequiredValues = Object.values(formFields).every(value => Boolean(value))
-
-    // Parse input with schema if all fields are present
-    let schemaValid = false
-    if (hasAllRequiredValues) {
-      const parseInput = {
-        ...formFields,
-        balance: $intents.selectedAsset.balance ?? 0n,
-        decimals: $intents.selectedAsset.decimals ?? 0
-      }
-      const schemaResult = safeParse(transferSchema, parseInput)
-      schemaValid = schemaResult.success
+    if (formFields.asset && !formFields.amount) {
+      return { amount: "Amount is required" }
     }
 
-    // Always validate fields for error display
-    const errors = validateAll({
-      formFields,
-      sourceChain: $intents.sourceChain,
-      destinationChain: $intents.destinationChain,
-      selectedAsset: $intents.selectedAsset,
-      chains: $context.chains
-    })
-
-    return {
-      errors,
-      // isValid only when all fields present, schema valid, and no validation errors
-      isValid: hasAllRequiredValues && schemaValid && Object.keys(errors).length === 0
+    if (formFields.asset && !formFields.receiver) {
+      return { receiver: "Receiver is required" }
     }
-  })
 
-  function validateAll({
-    formFields,
-    sourceChain,
-    destinationChain,
-    selectedAsset,
-    chains
-  }: {
-    formFields: FormFields
-    sourceChain: Chain | undefined
-    destinationChain: Chain | undefined
-    selectedAsset: SelectedAsset
-    chains: Array<Chain>
-  }): FieldErrors {
     const parseInput = {
       ...formFields,
-      balance: selectedAsset.balance ?? 0n,
-      decimals: selectedAsset.decimals ?? 0
+      balance: $intents.selectedAsset.balance ?? 0n,
+      decimals: $intents.selectedAsset.decimals ?? 0
     }
 
     const schemaResult = safeParse(transferSchema, parseInput)
-
-    // If schema validation fails, return those errors
     if (!schemaResult.success) {
       return schemaResult.issues.reduce((acc, issue) => {
         const fieldName = issue.path?.[0]?.key as keyof FormFields
         if (fieldName && formFields[fieldName]) {
-          // Only show error if field has a value
           acc[fieldName] = issue.message
         }
         return acc
       }, {} as FieldErrors)
     }
 
-    // Only proceed with rules if schema validation passes
-    return validateRules(formFields, {
-      sourceChain,
-      destinationChain,
-      selectedAsset,
-      chains
-    })
-  }
-
-  function validateRules(formFields: FormFields, _context: ValidationContext): FieldErrors {
-    const errors: FieldErrors = {}
-
     if (
       formFields.source &&
       formFields.destination &&
       formFields.source === formFields.destination
     ) {
-      errors.destination = "Source and destination chains must be different"
+      return { destination: "Source and destination chains must be different" }
     }
 
-    return errors
-  }
+    return {}
+  })
 
-  return {
-    subscribe: store.subscribe,
-    validate: () => {
-      return new Promise(resolve => {
-        let currentState: ValidationStore | undefined
-        const unsubscribe = store.subscribe(value => {
-          currentState = value
-          unsubscribe()
-          resolve(currentState?.isValid ?? false)
-        })
-      })
+  const transfer = derived([rawIntents, intents, errors], ([$rawIntents, $intents, $errors]) => {
+    if (Object.keys($errors).length > 0 || !$rawIntents.amount || !$rawIntents.receiver)
+      return undefined
+
+    if (
+      !(
+        $intents.sourceChain &&
+        $intents.destinationChain &&
+        $intents.selectedAsset.address &&
+        $intents.selectedAsset.balance &&
+        $intents.selectedAsset.symbol &&
+        $intents.selectedAsset.supported
+      )
+    ) {
+      return undefined
     }
-  }
+
+    return {
+      sourceChain: $intents.sourceChain,
+      destinationChain: $intents.destinationChain,
+      asset: {
+        address: $intents.selectedAsset.address,
+        balance: $intents.selectedAsset.balance,
+        symbol: $intents.selectedAsset.symbol,
+        decimals: $intents.selectedAsset.decimals,
+        gasToken: $intents.selectedAsset.gasToken,
+        supported: $intents.selectedAsset.supported
+      },
+      receiver: $rawIntents.receiver,
+      amount: $rawIntents.amount
+    } as ValidTransfer
+  })
+
+  return derived([transfer, errors], ([$transfer, $errors]): ValidationStore => {
+    const isValid = $transfer !== undefined
+
+    return isValid
+      ? { transfer: $transfer as ValidTransfer, errors: $errors, isValid: true }
+      : { transfer: undefined, errors: $errors, isValid: false }
+  })
 }

--- a/app/src/lib/queries/balance/index.ts
+++ b/app/src/lib/queries/balance/index.ts
@@ -9,12 +9,37 @@ import type { Chain, UserAddresses } from "$lib/types.ts"
 import { getBalancesFromAlchemy } from "./evm/alchemy.ts"
 import { getBalancesFromRoutescan } from "./evm/routescan.ts"
 
+export type BalanceResult =
+  // EVM balance result (from multicall)
+  | {
+      balance: string | bigint
+      address: string
+      name?: string | null
+      symbol: string
+      gasToken?: boolean
+    }
+  // Cosmos balance result
+  | {
+      address: string
+      symbol: string
+      balance: string | number
+      decimals: number
+      gasToken?: boolean
+    }
+  // Aptos balance result
+  | {
+      balance: string | bigint
+      address: string
+      symbol: string
+      gasToken?: boolean
+    }
+
 export function userBalancesQuery({
   userAddr,
   chains,
   connected = true
 }: { userAddr: UserAddresses; chains: Array<Chain>; connected?: boolean }) {
-  return createQueries({
+  return createQueries<Array<BalanceResult>>({
     queries: chains.map(chain => ({
       queryKey: [
         "balances",

--- a/app/src/routes/transfer/+page.svelte
+++ b/app/src/routes/transfer/+page.svelte
@@ -7,8 +7,8 @@ import TransferFrom from "$lib/components/TransferFrom/index.svelte"
   <title>Union | Send</title>
 </svelte:head>
 
-<ChainsGate>
+<ChainsGate let:chains>
   <div class="w-full flex flex-col justify-center items-center">
-    <TransferFrom />
+    <TransferFrom {chains} />
   </div>
 </ChainsGate>


### PR DESCRIPTION
Since the stores rely on rawIntents, propagated values can be undefined. However, when validation is valid, we know all values are correct and available. We could of course work with default values to never have source and destination undefined. Selected asset, receiver and amount cant be set to a default value tho. 

so now we have

```js
export type FieldErrors = Partial<Record<keyof FormFields, string>>

export interface ValidTransfer {
  sourceChain: Chain
  destinationChain: Chain
  asset: {
    address: string
    balance: bigint
    symbol: string
    decimals: number
    gasToken: boolean
    supported: ChainAsset
  }
  receiver: string
  amount: string
}

export interface InvalidValidationStore {
  transfer: undefined
  errors: FieldErrors
  isValid: false
}

export interface ValidValidationStore {
  transfer: ValidTransfer
  errors: FieldErrors
  isValid: true
}

export type ValidationStore = InvalidValidationStore | ValidValidationStore
```

this gives us access to validated data for the transfer

### Example

```js
const transfer = async () => {
  if (!$validation.isValid) return
  let parsedAmount = parseUnits($validation.transfer.amount, $validation.transfer.asset.decimals)
}
```

We can take this further and include balance and sender etc. Not sure we need valibot with this store tbh.