### PR TITLE
chore(voyager): clean up eth rpc config param naming

### DIFF
--- a/networks/e2e-setup.nix
+++ b/networks/e2e-setup.nix
@@ -353,8 +353,8 @@ _: {
   #                 "signer": {
   #                   "raw": "0x'"$EVM_WALLET"'"
   #                 },
-  #                 "eth_rpc_api": "'"$EVM_WS_URL"'",
-  #                 "eth_beacon_rpc_api": "'"$EVM_BEACON_RPC_URL"'",
+  #                 "rpc_url": "'"$EVM_WS_URL"'",
+  #                 "beacon_rpc_url": "'"$EVM_BEACON_RPC_URL"'",
   #                 "wasm_code_id": "0x'"$WASM_CODE_ID"'"
   #               },
   #               "union-devnet": {

--- a/voyager/config.json
+++ b/voyager/config.json
@@ -35,7 +35,7 @@
         },
         "config": {
           "ibc_handler_address": "0xed2af2ad7fe0d92011b26a2e5d1b4dc7d12a47c5",
-          "eth_rpc_api": "http://localhost:8545"
+          "rpc_url": "http://localhost:8545"
         }
       }
     ],
@@ -62,7 +62,7 @@
         },
         "config": {
           "ibc_handler_address": "0xed2af2ad7fe0d92011b26a2e5d1b4dc7d12a47c5",
-          "eth_rpc_api": "http://localhost:8545"
+          "rpc_url": "http://localhost:8545"
         }
       }
     ],
@@ -90,8 +90,8 @@
         "config": {
           "chain_spec": "minimal",
           "ibc_handler_address": "0xed2af2ad7fe0d92011b26a2e5d1b4dc7d12a47c5",
-          "eth_rpc_api": "http://localhost:8545",
-          "eth_beacon_rpc_api": "http://localhost:9596"
+          "rpc_url": "http://localhost:8545",
+          "beacon_rpc_url": "http://localhost:9596"
         }
       }
     ],
@@ -158,8 +158,8 @@
       "config": {
         "chain_id": "32382",
         "ibc_handler_address": "0xed2af2ad7fe0d92011b26a2e5d1b4dc7d12a47c5",
-        "eth_rpc_api": "http://localhost:8545",
-        "eth_beacon_rpc_api": "http://localhost:9596"
+        "rpc_url": "http://localhost:8545",
+        "beacon_rpc_url": "http://localhost:9596"
       }
     },
     {
@@ -225,7 +225,7 @@
             }
           ]
         },
-        "eth_rpc_api": "http://localhost:8545"
+        "rpc_url": "http://localhost:8545"
       }
     },
     {
@@ -275,8 +275,8 @@
         "chain_id": "32382",
         "chain_spec": "minimal",
         "ibc_handler_address": "0xed2af2ad7fe0d92011b26a2e5d1b4dc7d12a47c5",
-        "eth_rpc_api": "http://localhost:8545",
-        "eth_beacon_rpc_api": "http://localhost:9596"
+        "rpc_url": "http://localhost:8545",
+        "beacon_rpc_url": "http://localhost:9596"
       }
     }
   ],

--- a/voyager/modules/client-bootstrap/ethereum/src/main.rs
+++ b/voyager/modules/client-bootstrap/ethereum/src/main.rs
@@ -56,9 +56,9 @@ pub struct Config {
     pub ibc_handler_address: H160,
 
     /// The RPC endpoint for the execution chain.
-    pub eth_rpc_api: String,
+    pub rpc_url: String,
     /// The RPC endpoint for the beacon chain.
-    pub eth_beacon_rpc_api: String,
+    pub beacon_rpc_url: String,
 }
 
 impl Module {
@@ -116,16 +116,14 @@ impl ClientBootstrapModule for Module {
         config: Self::Config,
         info: ClientBootstrapModuleInfo,
     ) -> Result<Self, BoxDynError> {
-        let provider = ProviderBuilder::new()
-            .on_builtin(&config.eth_rpc_api)
-            .await?;
+        let provider = ProviderBuilder::new().on_builtin(&config.rpc_url).await?;
 
         let chain_id = ChainId::new(provider.get_chain_id().await?.to_string());
 
         info.ensure_chain_id(chain_id.to_string())?;
         info.ensure_client_type(ClientType::ETHEREUM)?;
 
-        let beacon_api_client = BeaconApiClient::new(config.eth_beacon_rpc_api).await?;
+        let beacon_api_client = BeaconApiClient::new(config.beacon_rpc_url).await?;
 
         let spec = beacon_api_client.spec().await.unwrap().data;
 

--- a/voyager/modules/consensus/berachain/src/main.rs
+++ b/voyager/modules/consensus/berachain/src/main.rs
@@ -45,7 +45,7 @@ pub struct Config {
     pub l1_client_id: u32,
     pub l1_chain_id: ChainId,
     pub ibc_handler_address: H160,
-    pub eth_rpc_api: String,
+    pub rpc_url: String,
     pub comet_ws_url: String,
 }
 
@@ -55,9 +55,7 @@ impl ConsensusModule for Module {
     async fn new(config: Self::Config, info: ConsensusModuleInfo) -> Result<Self, BoxDynError> {
         let tm_client = cometbft_rpc::Client::new(config.comet_ws_url).await?;
 
-        let eth_provider = ProviderBuilder::new()
-            .on_builtin(&config.eth_rpc_api)
-            .await?;
+        let eth_provider = ProviderBuilder::new().on_builtin(&config.rpc_url).await?;
 
         let l2_chain_id = ChainId::new(eth_provider.get_chain_id().await?.to_string());
 

--- a/voyager/modules/consensus/ethereum/src/main.rs
+++ b/voyager/modules/consensus/ethereum/src/main.rs
@@ -42,9 +42,9 @@ pub struct Config {
     pub chain_spec: PresetBaseKind,
 
     /// The RPC endpoint for the execution chain.
-    pub eth_rpc_api: String,
+    pub rpc_url: String,
     /// The RPC endpoint for the beacon chain.
-    pub eth_beacon_rpc_api: String,
+    pub beacon_rpc_url: String,
 }
 
 impl Module {
@@ -99,16 +99,14 @@ impl ConsensusModule for Module {
     type Config = Config;
 
     async fn new(config: Self::Config, info: ConsensusModuleInfo) -> Result<Self, BoxDynError> {
-        let provider = ProviderBuilder::new()
-            .on_builtin(&config.eth_rpc_api)
-            .await?;
+        let provider = ProviderBuilder::new().on_builtin(&config.rpc_url).await?;
 
         let chain_id = ChainId::new(provider.get_chain_id().await?.to_string());
 
         info.ensure_chain_id(chain_id.to_string())?;
         info.ensure_consensus_type(ConsensusType::ETHEREUM)?;
 
-        let beacon_api_client = BeaconApiClient::new(config.eth_beacon_rpc_api).await?;
+        let beacon_api_client = BeaconApiClient::new(config.beacon_rpc_url).await?;
 
         let spec = beacon_api_client.spec().await.unwrap().data;
 

--- a/voyager/modules/proof/ethereum/src/main.rs
+++ b/voyager/modules/proof/ethereum/src/main.rs
@@ -49,16 +49,14 @@ pub struct Config {
     pub ibc_handler_address: H160,
 
     /// The RPC endpoint for the execution chain.
-    pub eth_rpc_api: String,
+    pub rpc_url: String,
 }
 
 impl ProofModule<IbcUnion> for Module {
     type Config = Config;
 
     async fn new(config: Self::Config, info: ProofModuleInfo) -> Result<Self, BoxDynError> {
-        let provider = ProviderBuilder::new()
-            .on_builtin(&config.eth_rpc_api)
-            .await?;
+        let provider = ProviderBuilder::new().on_builtin(&config.rpc_url).await?;
 
         let chain_id = provider.get_chain_id().await?;
 

--- a/voyager/plugins/client-update/ethereum/src/main.rs
+++ b/voyager/plugins/client-update/ethereum/src/main.rs
@@ -78,9 +78,9 @@ pub struct Config {
     pub ibc_handler_address: H160,
 
     /// The RPC endpoint for the execution chain.
-    pub eth_rpc_api: String,
+    pub rpc_url: String,
     /// The RPC endpoint for the beacon chain.
-    pub eth_beacon_rpc_api: String,
+    pub beacon_rpc_url: String,
 }
 
 fn plugin_name(chain_id: &ChainId) -> String {
@@ -130,9 +130,7 @@ impl Plugin for Module {
     type Cmd = DefaultCmd;
 
     async fn new(config: Self::Config) -> Result<Self, chain_utils::BoxDynError> {
-        let provider = ProviderBuilder::new()
-            .on_builtin(&config.eth_rpc_api)
-            .await?;
+        let provider = ProviderBuilder::new().on_builtin(&config.rpc_url).await?;
 
         let chain_id = ChainId::new(provider.get_chain_id().await?.to_string());
 
@@ -144,7 +142,7 @@ impl Plugin for Module {
             .into());
         }
 
-        let beacon_api_client = BeaconApiClient::new(config.eth_beacon_rpc_api).await?;
+        let beacon_api_client = BeaconApiClient::new(config.beacon_rpc_url).await?;
 
         let spec = beacon_api_client
             .spec()

--- a/voyager/plugins/event-source/ethereum/src/main.rs
+++ b/voyager/plugins/event-source/ethereum/src/main.rs
@@ -70,9 +70,9 @@ pub struct Config {
     pub ibc_handler_address: H160,
 
     /// The RPC endpoint for the execution chain.
-    pub eth_rpc_api: String,
+    pub rpc_url: String,
     /// The RPC endpoint for the beacon chain.
-    pub eth_beacon_rpc_api: String,
+    pub beacon_rpc_url: String,
 }
 
 impl Plugin for Module {
@@ -113,9 +113,7 @@ impl Module {
     }
 
     pub async fn new(config: Config) -> Result<Self, BoxDynError> {
-        let provider = ProviderBuilder::new()
-            .on_builtin(&config.eth_rpc_api)
-            .await?;
+        let provider = ProviderBuilder::new().on_builtin(&config.rpc_url).await?;
 
         // TODO: Assert chain id is correct
         let chain_id = provider.get_chain_id().await?;
@@ -124,7 +122,7 @@ impl Module {
             chain_id: ChainId::new(chain_id.to_string()),
             ibc_handler_address: config.ibc_handler_address,
             provider,
-            beacon_api_client: BeaconApiClient::new(config.eth_beacon_rpc_api).await?,
+            beacon_api_client: BeaconApiClient::new(config.beacon_rpc_url).await?,
         })
     }
 

--- a/voyager/plugins/transaction/ethereum/src/main.rs
+++ b/voyager/plugins/transaction/ethereum/src/main.rs
@@ -76,7 +76,7 @@ pub struct Config {
     pub multicall_address: H160,
 
     /// The RPC endpoint for the execution chain.
-    pub eth_rpc_api: String,
+    pub rpc_url: String,
 
     pub keyring: KeyringConfig,
 
@@ -95,9 +95,7 @@ impl Plugin for Module {
     type Cmd = DefaultCmd;
 
     async fn new(config: Self::Config) -> Result<Self, BoxDynError> {
-        let provider = ProviderBuilder::new()
-            .on_builtin(&config.eth_rpc_api)
-            .await?;
+        let provider = ProviderBuilder::new().on_builtin(&config.rpc_url).await?;
 
         let raw_chain_id = provider.get_chain_id().await?;
         let chain_id = ChainId::new(raw_chain_id.to_string());


### PR DESCRIPTION
also denied unwraps in the eth state module