### PR TITLE
feat(voyager): make the state lens client update module fully generic

### DIFF
--- a/lib/ibc-union-spec/src/lib.rs
+++ b/lib/ibc-union-spec/src/lib.rs
@@ -103,7 +103,7 @@ impl ClientStatePath {
 impl IbcStorePathKey for ClientStatePath {
     type Spec = IbcUnion;
 
-    type Value = Bytes;
+    type Value = Option<Bytes>;
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
@@ -127,7 +127,7 @@ impl ConsensusStatePath {
 impl IbcStorePathKey for ConsensusStatePath {
     type Spec = IbcUnion;
 
-    type Value = Bytes;
+    type Value = Option<Bytes>;
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]

--- a/lib/voyager-message/src/call.rs
+++ b/lib/voyager-message/src/call.rs
@@ -85,10 +85,12 @@ pub struct FetchBlocks {
 pub struct FetchUpdateHeaders {
     /// The type of client that is tracking the consensus on `self.chain_id`.
     pub client_type: ClientType,
-    /// The ID of the chain that is being tracked by a client on `self.counterparty_chain_id`.
+    /// The ID of the chain that is being tracked by the `self.client_id` client on `self.counterparty_chain_id`.
     pub chain_id: ChainId,
     /// The chain that the light client tracking `self.chain_id` is on.
     pub counterparty_chain_id: ChainId,
+    /// The ID of the client that is being updated.
+    pub client_id: RawClientId,
     /// The currently trusted height of the client on `self.chain_id`.
     pub update_from: Height,
     /// The *minimum* height to update the client to. This is assumed to be finalized. Note that the generated update may not be to this exact height, but it *must* be >= it.
@@ -160,13 +162,14 @@ impl CallT<VoyagerMessage> for Call {
                 client_type,
                 chain_id,
                 counterparty_chain_id,
+                client_id,
                 update_from,
                 update_to,
             }) => {
                 let message = format!(
-                    "client update request received for a {client_type} client on \
-                    {counterparty_chain_id} tracking {chain_id} from height {update_from}
-                    to {update_to} but it was not picked up by a plugin"
+                    "client update request received for a {client_type} client \
+                    on (id {client_id}) {counterparty_chain_id} tracking {chain_id} from
+                    height {update_from} to {update_to} but it was not picked up by a plugin"
                 );
 
                 error!(%message);

--- a/lib/voyager-message/src/rpc.rs
+++ b/lib/voyager-message/src/rpc.rs
@@ -167,10 +167,16 @@ impl IbcState<Value> {
 
 #[model]
 pub struct IbcProof {
+    // pub proof_type: ProofType,
     /// The height that the proof was read at.
     pub height: Height,
     pub proof: Value,
 }
+
+// enum ProofType {
+//     Membership,
+//     NonMembership,
+// }
 
 #[model]
 pub struct SelfClientState {

--- a/lib/voyager-message/src/rpc/server.rs
+++ b/lib/voyager-message/src/rpc/server.rs
@@ -283,7 +283,7 @@ impl Server {
             .await
     }
 
-    #[instrument(skip_all, fields(%chain_id, %height))]
+    #[instrument(skip_all, fields(%chain_id, %height, ?path))]
     pub async fn query_ibc_state<P: IbcStorePathKey>(
         &self,
         chain_id: &ChainId,
@@ -317,7 +317,15 @@ impl Server {
             .await
     }
 
-    #[instrument(skip_all, fields(%chain_id, %height))]
+    #[instrument(
+        skip_all,
+        fields(
+            %chain_id,
+            ibc_spec_id = %P::Spec::ID,
+            %height,
+            path = %into_value(path.clone())
+        )
+    )]
     pub async fn query_ibc_proof<P: IbcStorePathKey>(
         &self,
         chain_id: &ChainId,
@@ -572,7 +580,7 @@ impl VoyagerRpcServer for Server {
             .await
     }
 
-    #[instrument(skip_all, fields(%chain_id, %height))]
+    #[instrument(skip_all, fields(%chain_id, %ibc_spec_id, %height, %path))]
     async fn query_ibc_state(
         &self,
         chain_id: ChainId,
@@ -602,7 +610,7 @@ impl VoyagerRpcServer for Server {
         Ok(IbcState { height, state })
     }
 
-    #[instrument(skip_all, fields(%chain_id, %height))]
+    #[instrument(skip_all, fields(%chain_id, %ibc_spec_id, %height, %path))]
     async fn query_ibc_proof(
         &self,
         chain_id: ChainId,

--- a/voyager/plugins/client-update/berachain/src/main.rs
+++ b/voyager/plugins/client-update/berachain/src/main.rs
@@ -255,6 +255,7 @@ impl PluginServer<ModuleCall, ModuleCallback> for Module {
                         client_type: ClientType::new(ClientType::BEACON_KIT),
                         counterparty_chain_id: counterparty_chain_id.clone(),
                         chain_id: self.l1_chain_id.clone(),
+                        client_id: RawClientId::new(self.l1_client_id),
                         update_from,
                         update_to,
                     }),

--- a/voyager/plugins/client-update/ethereum/src/call.rs
+++ b/voyager/plugins/client-update/ethereum/src/call.rs
@@ -1,7 +1,7 @@
 use enumorph::Enumorph;
 use macros::model;
 use unionlabs::ibc::core::client::height::Height;
-use voyager_message::core::ChainId;
+use voyager_message::{core::ChainId, RawClientId};
 
 #[model]
 #[derive(Enumorph)]
@@ -14,4 +14,5 @@ pub struct FetchUpdate {
     pub from_height: Height,
     pub to_height: Height,
     pub counterparty_chain_id: ChainId,
+    pub client_id: RawClientId,
 }

--- a/voyager/plugins/client-update/state-lens/src/call.rs
+++ b/voyager/plugins/client-update/state-lens/src/call.rs
@@ -3,6 +3,8 @@ use macros::model;
 use unionlabs::ibc::core::client::height::Height;
 use voyager_message::core::ChainId;
 
+use crate::StateLensClientState;
+
 #[model]
 #[derive(Enumorph)]
 pub enum ModuleCall {
@@ -13,6 +15,7 @@ pub enum ModuleCall {
 #[model]
 pub struct FetchUpdate {
     pub counterparty_chain_id: ChainId,
+    pub client_id: u32,
     pub update_from: Height,
     pub update_to: Height,
 }
@@ -20,6 +23,8 @@ pub struct FetchUpdate {
 #[model]
 pub struct FetchUpdateAfterL1Update {
     pub counterparty_chain_id: ChainId,
+    pub state_lens_client_state: StateLensClientState,
+    pub client_id: u32,
     pub update_from: Height,
     pub update_to: Height,
 }

--- a/voyager/plugins/client-update/state-lens/src/main.rs
+++ b/voyager/plugins/client-update/state-lens/src/main.rs
@@ -1,15 +1,16 @@
 use std::{collections::VecDeque, fmt::Debug};
 
 use call::FetchUpdateAfterL1Update;
-use ibc_union_spec::{ConsensusStatePath, IbcUnion};
+use ibc_union_spec::{ClientStatePath, ConsensusStatePath, IbcUnion};
 use jsonrpsee::{
     core::{async_trait, RpcResult},
+    types::ErrorObject,
     Extensions,
 };
 use serde::{Deserialize, Serialize};
 use state_lens_light_client_types::Header;
 use tracing::{debug, instrument};
-use unionlabs::ibc::core::commitment::merkle_proof::MerkleProof;
+use unionlabs::ErrorReporter;
 use voyager_message::{
     call::{Call, FetchUpdateHeaders, WaitForTrustedHeight},
     callback::AggregateMsgUpdateClientsFromOrderedHeaders,
@@ -18,7 +19,9 @@ use voyager_message::{
     hook::UpdateHook,
     into_value,
     module::{PluginInfo, PluginServer},
+    rpc::missing_state,
     DefaultCmd, ExtensionsExt, Plugin, PluginMessage, RawClientId, VoyagerClient, VoyagerMessage,
+    FATAL_JSONRPC_ERROR_CODE,
 };
 use voyager_vm::{call, conc, data, pass::PassResult, promise, seq, BoxDynError, Op, Visit};
 
@@ -35,26 +38,51 @@ async fn main() {
     Module::run().await
 }
 
+/// Representation of the client state of a state lens client.
+///
+/// For a state lens client A->B->C, where the state lens is running on A and tracking C, the terminology is as follows:
+///
+/// - B is L1
+/// - C is L2
+///
+/// where C "settles" on B with the client `self.l2_client_id`, and B "settles" on A with `self.l1_client_id`.
+// NOTE: Purposely DOESN'T use deny_unknown_fields
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct StateLensClientState /* <Extra> */ {
+    /// L2 chain ID. This is the same as the ID of the chain being tracked by `self.l2_client_id`.
+    ///
+    /// ("C")
+    pub l2_chain_id: ChainId,
+
+    /// L1 client ID. This is the ID of the L1 client running on A that is used to check the L2 inclusion proof against.
+    ///
+    /// ("B" on "A")
+    pub l1_client_id: u32,
+
+    /// L2 client ID. This is the ID of the L2 client running on B (L1) tracking the C (L2).
+    ///
+    /// ("C" on "B")
+    pub l2_client_id: u32,
+
+    /// L2 latest height
+    pub l2_latest_height: u64,
+    // #[serde(flatten)]
+    // pub extra: Extra,
+}
+
 #[derive(Debug, Clone)]
 pub struct Module {
-    pub l0_client_id: u32,
-    pub l1_client_id: u32,
-    pub l1_chain_id: ChainId,
-    pub l2_chain_id: ChainId,
-    pub l2_client_type: ClientType,
+    /// The ID of the chain this plugin creates updates for.
+    pub chain_id: ChainId,
+    /// The state lens client type (state-lens/*/*) that this plugin creates updates for.
     pub state_lens_client_type: ClientType,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(deny_unknown_fields)]
 pub struct Config {
-    pub l0_client_id: u32,
-    pub l1_client_id: u32,
-    pub l1_chain_id: ChainId,
-    pub l2_chain_id: ChainId,
-    pub l2_client_type: ClientType,
+    pub chain_id: ChainId,
     pub state_lens_client_type: ClientType,
-    pub host_chain_id: ChainId,
 }
 
 impl Plugin for Module {
@@ -66,30 +94,15 @@ impl Plugin for Module {
 
     async fn new(config: Self::Config) -> Result<Self, BoxDynError> {
         Ok(Self {
-            l0_client_id: config.l0_client_id,
-            l1_client_id: config.l1_client_id,
-            l1_chain_id: config.l1_chain_id,
-            l2_chain_id: config.l2_chain_id,
-            l2_client_type: config.l2_client_type,
+            chain_id: config.chain_id,
             state_lens_client_type: config.state_lens_client_type,
         })
     }
 
     fn info(config: Self::Config) -> PluginInfo {
         PluginInfo {
-            name: plugin_name(
-                config.l0_client_id,
-                config.l1_client_id,
-                &config.l2_chain_id,
-            ),
-            // interest_filter: UpdateHook::filter(
-            //     &config.l2_chain_id,
-            //     &config.state_lens_client_type,
-            // ),
-            interest_filter: format!(
-                r#"[.. | ."@type"? == "fetch_update_headers" and ."@value".chain_id == "{}" and ."@value".client_type == "{}" and ."@value".counterparty_chain_id == "{}"] | any"#,
-                config.l2_chain_id, config.state_lens_client_type, config.host_chain_id
-            ),
+            name: plugin_name(&config.chain_id, &config.state_lens_client_type),
+            interest_filter: UpdateHook::filter(&config.chain_id, &config.state_lens_client_type),
         }
     }
 
@@ -98,21 +111,21 @@ impl Plugin for Module {
     }
 }
 
-fn plugin_name(l0_client_id: u32, l1_client_id: u32, l2_chain_id: &ChainId) -> String {
+fn plugin_name(chain_id: &ChainId, state_lens_client_type: &ClientType) -> String {
     pub const PLUGIN_NAME: &str = env!("CARGO_PKG_NAME");
 
-    format!("{PLUGIN_NAME}/{l0_client_id}/{l1_client_id}/{l2_chain_id}")
+    format!("{PLUGIN_NAME}/{chain_id}/{state_lens_client_type}")
 }
 
 impl Module {
     fn plugin_name(&self) -> String {
-        plugin_name(self.l0_client_id, self.l1_client_id, &self.l2_chain_id)
+        plugin_name(&self.chain_id, &self.state_lens_client_type)
     }
 }
 
 #[async_trait]
 impl PluginServer<ModuleCall, ModuleCallback> for Module {
-    #[instrument(skip_all, fields(chain_id = %self.l2_chain_id))]
+    #[instrument(skip_all, fields(chain_id = %self.chain_id))]
     async fn run_pass(
         &self,
         _: &Extensions,
@@ -123,11 +136,23 @@ impl PluginServer<ModuleCall, ModuleCallback> for Module {
             ready: msgs
                 .into_iter()
                 .map(|mut op| {
-                    UpdateHook::new(&self.l2_chain_id, &self.state_lens_client_type, |fetch| {
+                    UpdateHook::new(&self.chain_id, &self.state_lens_client_type, |fetch| {
                         Call::Plugin(PluginMessage::new(
                             self.plugin_name(),
                             ModuleCall::from(FetchUpdate {
                                 counterparty_chain_id: fetch.counterparty_chain_id.clone(),
+                                client_id: fetch
+                                    .client_id
+                                    .clone()
+                                    .decode_spec::<IbcUnion>()
+                                    .unwrap(),
+                                // .map_err(|e| {
+                                //     ErrorObject::owned(
+                                //         FATAL_JSONRPC_ERROR_CODE,
+                                //         format!("invalid client id `{}`", fetch.client_id),
+                                //         None::<()>,
+                                //     )
+                                // })?,
                                 update_from: fetch.update_from,
                                 update_to: fetch.update_to,
                             }),
@@ -143,72 +168,141 @@ impl PluginServer<ModuleCall, ModuleCallback> for Module {
         })
     }
 
-    #[instrument(skip_all, fields(chain_id = %self.l2_chain_id))]
+    #[instrument(skip_all, fields(chain_id = %self.chain_id))]
     async fn call(&self, ext: &Extensions, msg: ModuleCall) -> RpcResult<Op<VoyagerMessage>> {
         match msg {
             ModuleCall::FetchUpdate(FetchUpdate {
                 counterparty_chain_id,
+                client_id,
                 update_from,
                 update_to,
             }) => {
-                let voy_client = ext.try_get::<VoyagerClient>()?;
-                let l1_latest_height = voy_client
-                    .query_latest_height(self.l1_chain_id.clone(), true)
+                let voyager_client = ext.try_get::<VoyagerClient>()?;
+
+                // state lens client running on the counterparty, tracking self.chain_id
+                let raw_state_lens_client_state = voyager_client
+                    .query_ibc_state(
+                        counterparty_chain_id.clone(),
+                        QueryHeight::Latest,
+                        ClientStatePath { client_id },
+                    )
+                    .await?
+                    .state
+                    .ok_or_else(missing_state(
+                        "state lens client state doesn't exist?",
+                        None,
+                    ))?;
+
+                debug!(?raw_state_lens_client_state);
+
+                let state_lens_client_state_info = voyager_client
+                    .client_info::<IbcUnion>(counterparty_chain_id.clone(), client_id)
                     .await?;
-                let l2_consensus_state_proof = serde_json::from_value::<MerkleProof>(
-                    voy_client
-                        .query_ibc_proof(
-                            self.l1_chain_id.clone(),
-                            QueryHeight::Specific(l1_latest_height),
-                            ConsensusStatePath {
-                                client_id: self.l1_client_id,
-                                height: update_to.height(),
-                            },
-                        )
-                        .await
-                        .expect("big trouble")
-                        .proof,
-                )
-                .expect("impossible");
-                let l2_merkle_proof = unionlabs::union::ics23::merkle_proof::MerkleProof::try_from(
-                    protos::ibc::core::commitment::v1::MerkleProof::from(l2_consensus_state_proof),
-                )
-                .expect("impossible");
+
+                debug!(?state_lens_client_state_info);
+
+                let state_lens_client_state_json = voyager_client
+                    .decode_client_state::<IbcUnion>(
+                        state_lens_client_state_info.client_type.clone(),
+                        state_lens_client_state_info.ibc_interface,
+                        raw_state_lens_client_state,
+                    )
+                    .await?;
+
+                debug!(%state_lens_client_state_json);
+
+                let state_lens_client_state =
+                    serde_json::from_value::<StateLensClientState>(state_lens_client_state_json)
+                        .map_err(|e| {
+                            ErrorObject::owned(
+                                FATAL_JSONRPC_ERROR_CODE,
+                                format!(
+                                    "unable to deserialize state lens client state: {}",
+                                    ErrorReporter(e)
+                                ),
+                                None::<()>,
+                            )
+                        })?;
+
+                debug!(?state_lens_client_state);
+
+                let l1_client_meta = voyager_client
+                    .client_meta::<IbcUnion>(
+                        counterparty_chain_id.clone(),
+                        QueryHeight::Latest,
+                        state_lens_client_state.l1_client_id,
+                    )
+                    .await?;
+
+                debug!(?l1_client_meta);
+
+                let l1_latest_height = voyager_client
+                    .query_latest_height(state_lens_client_state.l2_chain_id.clone(), true)
+                    .await?;
+
+                debug!(%l1_latest_height);
+
+                assert_eq!(state_lens_client_state.l2_chain_id, self.chain_id);
+
+                let l2_consensus_state_proof = voyager_client
+                    .query_ibc_state(
+                        l1_client_meta.chain_id.clone(),
+                        QueryHeight::Specific(l1_latest_height),
+                        ConsensusStatePath {
+                            client_id: state_lens_client_state.l2_client_id,
+                            height: update_to.height(),
+                        },
+                    )
+                    .await?
+                    .state;
+
+                debug!(%l1_latest_height);
+
                 let continuation = call(PluginMessage::new(
                     self.plugin_name(),
                     ModuleCall::from(FetchUpdateAfterL1Update {
                         counterparty_chain_id,
+                        state_lens_client_state: state_lens_client_state.clone(),
+                        client_id,
                         update_from,
                         update_to,
                     }),
                 ));
-                // If the L2 consensus proof exists on the L1, we don't have to update the L2 on the L1.
-                match l2_merkle_proof {
-                    unionlabs::union::ics23::merkle_proof::MerkleProof::Membership(_, _) => {
-                        Ok(continuation)
-                    }
-                    _ => Ok(conc([
-                        // Update the L2 (eth) client on L1 (union) and then dispatch the continuation
+
+                let l2_client_type = voyager_client
+                    .client_info::<IbcUnion>(
+                        l1_client_meta.chain_id.clone(),
+                        state_lens_client_state.l2_client_id,
+                    )
+                    .await?
+                    .client_type;
+
+                // if the L2 consensus state exists on the L1, we don't have to update the L2 on the L1.
+                match l2_consensus_state_proof {
+                    Some(_) => Ok(continuation),
+                    None => Ok(conc([
+                        // update the L2 client on L1 and then dispatch the continuation
                         promise(
                             [call(FetchUpdateHeaders {
-                                client_type: self.l2_client_type.clone(),
-                                chain_id: self.l2_chain_id.clone(),
-                                counterparty_chain_id: self.l1_chain_id.clone(),
+                                client_type: l2_client_type,
+                                chain_id: self.chain_id.clone(),
+                                counterparty_chain_id: l1_client_meta.chain_id.clone(),
+                                client_id: RawClientId::new(state_lens_client_state.l2_client_id),
                                 update_from,
                                 update_to,
                             })],
                             [],
                             AggregateMsgUpdateClientsFromOrderedHeaders {
                                 ibc_spec_id: IbcUnion::ID,
-                                chain_id: self.l1_chain_id.clone(),
-                                client_id: RawClientId::new(self.l1_client_id),
+                                chain_id: l1_client_meta.chain_id.clone(),
+                                client_id: RawClientId::new(state_lens_client_state.l2_client_id),
                             },
                         ),
                         seq([
                             call(WaitForTrustedHeight {
-                                chain_id: self.l1_chain_id.clone(),
+                                chain_id: l1_client_meta.chain_id.clone(),
                                 ibc_spec_id: IbcUnion::ID,
-                                client_id: RawClientId::new(self.l1_client_id),
+                                client_id: RawClientId::new(state_lens_client_state.l2_client_id),
                                 height: update_to,
                                 finalized: true,
                             }),
@@ -219,93 +313,138 @@ impl PluginServer<ModuleCall, ModuleCallback> for Module {
             }
             ModuleCall::FetchUpdateAfterL1Update(FetchUpdateAfterL1Update {
                 counterparty_chain_id,
-                ..
+                state_lens_client_state,
+                client_id,
+                update_from: _,
+                update_to,
             }) => {
-                let voy_client = ext.try_get::<VoyagerClient>()?;
-                let l1_latest_height = voy_client
-                    .query_latest_height(self.l1_chain_id.clone(), false)
-                    .await?;
-                debug!("l1 latest height {}", l1_latest_height);
-                let l0_client_meta = voy_client
+                let voyager_client = ext.try_get::<VoyagerClient>()?;
+
+                // the client on the counterparty that is tracking the L1
+                let l1_client_meta = voyager_client
                     .client_meta::<IbcUnion>(
                         counterparty_chain_id.clone(),
                         QueryHeight::Latest,
-                        self.l0_client_id,
+                        state_lens_client_state.l1_client_id,
                     )
                     .await?;
-                let l1_client_meta = voy_client
+                debug!(?l1_client_meta);
+
+                // the client on the counterparty that is tracking the L1
+                let l1_client_info = voyager_client
+                    .client_info::<IbcUnion>(
+                        counterparty_chain_id.clone(),
+                        state_lens_client_state.l1_client_id,
+                    )
+                    .await?;
+                debug!(?l1_client_info);
+
+                // the client on the L1 that is tracking the L2
+                let l2_client_meta = voyager_client
                     .client_meta::<IbcUnion>(
-                        self.l1_chain_id.clone(),
-                        QueryHeight::Specific(l1_latest_height),
-                        self.l1_client_id,
+                        l1_client_meta.chain_id.clone(),
+                        QueryHeight::Latest,
+                        state_lens_client_state.l2_client_id,
                     )
                     .await?;
-                // The client has been updated to at least update_to
-                let update_to = l1_client_meta.counterparty_height;
-                debug!("l0 client meta {:?}", l0_client_meta);
+                debug!(?l1_client_meta);
+
+                let l1_latest_height = voyager_client
+                    .query_latest_height(l1_client_meta.chain_id.clone(), false)
+                    .await?;
+                debug!(
+                    "l1 ({}) latest height {}",
+                    l1_client_meta.chain_id, l1_latest_height
+                );
+
+                // client meta of the state lens client on the counterparty
+                let state_lens_client_meta = voyager_client
+                    .client_meta::<IbcUnion>(
+                        counterparty_chain_id.clone(),
+                        QueryHeight::Latest,
+                        client_id,
+                    )
+                    .await?;
+                debug!(?state_lens_client_meta);
+
+                let state_lens_client_info = voyager_client
+                    .client_info::<IbcUnion>(counterparty_chain_id.clone(), client_id)
+                    .await?;
+                debug!(?state_lens_client_info);
+
+                // ensure that the l2 client on the l1 has been updated to at least update_to
+                if l2_client_meta.counterparty_height < update_to {
+                    return Err(ErrorObject::owned(
+                        FATAL_JSONRPC_ERROR_CODE,
+                        format!(
+                            "l2_client_meta.counterparty_height is {} but update_to \
+                            request is {update_to}",
+                            l2_client_meta.counterparty_height
+                        ),
+                        None::<()>,
+                    ));
+                }
+
+                let update_to = l2_client_meta.counterparty_height;
 
                 let l2_consensus_state_path = ConsensusStatePath {
-                    client_id: self.l1_client_id,
+                    client_id: state_lens_client_state.l2_client_id,
                     height: update_to.height(),
                 };
 
-                let l2_consensus_state = voy_client
+                let l2_consensus_state = voyager_client
                     .query_ibc_state(
-                        self.l1_chain_id.clone(),
+                        l1_client_meta.chain_id.clone(),
                         QueryHeight::Specific(l1_latest_height),
                         l2_consensus_state_path.clone(),
                     )
                     .await?
-                    .state;
+                    .state
+                    .ok_or_else(missing_state("l2 consensus on l1 doesn't exist", None))?;
 
-                debug!("l2 consensus state {:?}", l2_consensus_state);
+                debug!(?l2_consensus_state);
 
-                let l2_consensus_state_proof = voy_client
+                let l2_consensus_state_proof = voyager_client
                     .query_ibc_proof(
-                        self.l1_chain_id.clone(),
+                        l1_client_meta.chain_id.clone(),
                         QueryHeight::Specific(l1_latest_height),
                         l2_consensus_state_path,
                     )
-                    .await
-                    .expect("big trouble")
+                    .await?
                     .proof;
+                debug!(?l2_consensus_state_proof);
 
-                let state_lens_client = voy_client
-                    .client_info::<IbcUnion>(counterparty_chain_id.clone(), self.l0_client_id)
-                    .await?;
-
-                debug!("l2 consensus state proof {:?}", l2_consensus_state_proof);
-
-                let l2_consensus_state_proof_bytes = voy_client
+                let l2_consensus_state_proof_bytes = voyager_client
                     .encode_proof::<IbcUnion>(
-                        ClientType::new(ClientType::COMETBLS),
-                        state_lens_client.ibc_interface,
+                        l1_client_info.client_type.clone(),
+                        state_lens_client_info.ibc_interface,
                         l2_consensus_state_proof,
                     )
                     .await?;
 
-                // Dispatch an update for the L1 on the destination, then dispatch the L2 update on the destination
+                // dispatch an update for the L1 on the destination, then dispatch the L2 update on the destination
                 Ok(conc([
                     promise(
                         [call(FetchUpdateHeaders {
-                            client_type: ClientType::new(ClientType::COMETBLS),
-                            chain_id: self.l1_chain_id.clone(),
+                            client_type: l1_client_info.client_type,
+                            chain_id: l1_client_meta.chain_id.clone(),
                             counterparty_chain_id: counterparty_chain_id.clone(),
-                            update_from: l0_client_meta.counterparty_height,
+                            client_id: RawClientId::new(state_lens_client_state.l1_client_id),
+                            update_from: l1_client_meta.counterparty_height,
                             update_to: l1_latest_height,
                         })],
                         [],
                         AggregateMsgUpdateClientsFromOrderedHeaders {
                             ibc_spec_id: IbcUnion::ID,
                             chain_id: counterparty_chain_id.clone(),
-                            client_id: RawClientId::new(self.l0_client_id),
+                            client_id: RawClientId::new(state_lens_client_state.l1_client_id),
                         },
                     ),
                     seq([
                         call(WaitForTrustedHeight {
                             chain_id: counterparty_chain_id,
                             ibc_spec_id: IbcUnion::ID,
-                            client_id: RawClientId::new(self.l0_client_id),
+                            client_id: RawClientId::new(state_lens_client_state.l1_client_id),
                             height: l1_latest_height,
                             finalized: false,
                         }),
@@ -326,7 +465,7 @@ impl PluginServer<ModuleCall, ModuleCallback> for Module {
         }
     }
 
-    #[instrument(skip_all, fields(chain_id = %self.l2_chain_id))]
+    #[instrument(skip_all, fields(chain_id = %self.chain_id))]
     async fn callback(
         &self,
         _: &Extensions,

--- a/voyager/plugins/periodic-client-update/src/main.rs
+++ b/voyager/plugins/periodic-client-update/src/main.rs
@@ -139,6 +139,7 @@ impl Module {
                         client_type: client_info.client_type,
                         chain_id: client_meta.chain_id,
                         counterparty_chain_id: chain_id.clone(),
+                        client_id: client_id.clone(),
                         update_from: client_meta.counterparty_height,
                         update_to: latest_finalized_height,
                     })],

--- a/voyager/plugins/transaction-batch/src/call.rs
+++ b/voyager/plugins/transaction-batch/src/call.rs
@@ -117,6 +117,7 @@ where
                         client_type: client_info.client_type,
                         counterparty_chain_id: module.chain_id.clone(),
                         chain_id: client_meta.chain_id,
+                        client_id: RawClientId::new(self.client_id.clone()),
                         update_from: client_meta.counterparty_height,
                         update_to: latest_height,
                     })],

--- a/voyager/src/cli.rs
+++ b/voyager/src/cli.rs
@@ -207,9 +207,9 @@ pub enum RpcCmd {
     ClientInfo {
         #[arg(value_parser(|s: &str| ok(ChainId::new(s.to_owned()))))]
         on: ChainId,
-        client_id: RawClientId,
         #[arg(value_parser(|s: &str| ok(IbcSpecId::new(s.to_owned()))))]
         ibc_spec_id: IbcSpecId,
+        client_id: RawClientId,
     },
     ConsensusState {
         #[arg(value_parser(|s: &str| ok(ChainId::new(s.to_owned()))))]

--- a/voyager/src/main.rs
+++ b/voyager/src/main.rs
@@ -579,6 +579,7 @@ async fn do_main(args: cli::AppArgs) -> anyhow::Result<()> {
                         client_type: client_info.client_type,
                         chain_id: client_meta.chain_id,
                         counterparty_chain_id: on.clone(),
+                        client_id: client_id.clone(),
                         update_from: client_meta.counterparty_height,
                         update_to,
                     })],


### PR DESCRIPTION
internal voyager change to add the client id of the client being updated to the update client request message, such that update plugins can inspect the client state for possible client-specific configuration options.