### PR TITLE
3346 revamp release component workflow to remove nixbuildnet

### DIFF
--- a/.github/workflows/release-component.yml
+++ b/.github/workflows/release-component.yml
@@ -217,6 +217,9 @@ jobs:
           for arch in 'aarch64-linux' 'x86_64-linux'
           do
             echo "Tagging $COMPONENT for $arch"
+            echo "GITHUB_WORKSPACE ($GITHUB_WORKSPACE)"
+            ls -la $GITHUB_WORKSPACE
+            echo "wd: ($(pwd))"
             ls -la
             dockerstring=$(docker load < $arch.$COMPONENT-image)
             dockerstring=$(echo ${dockerstring##*':'})

--- a/.github/workflows/release-component.yml
+++ b/.github/workflows/release-component.yml
@@ -90,7 +90,7 @@ jobs:
         env:
           COMPONENT: ${{ needs.eval-tag.outputs.component }}
         run: |
-          nix build .#packages.x86_64-linux."$COMPONENT" --accept-flake-config 
+          nix build .#packages.x86_64-linux."$COMPONENT"-image --accept-flake-config 
           cp -Lr result x86_64-linux."$COMPONENT"-image
       - uses: actions/upload-artifact@v4
         with:
@@ -114,7 +114,7 @@ jobs:
         env:
           COMPONENT: ${{ needs.eval-tag.outputs.component }}
         run: |
-          nix build .#packages.aarch64-linux."$COMPONENT" --accept-flake-config
+          nix build .#packages.aarch64-linux."$COMPONENT"-image --accept-flake-config
           cp -Lr result aarch64-linux."$COMPONENT"-image
       - uses: actions/upload-artifact@v4
         with:

--- a/.github/workflows/release-component.yml
+++ b/.github/workflows/release-component.yml
@@ -184,7 +184,7 @@ jobs:
           path: ${{ needs.eval-tag.outputs.component }}-aarch64-linux
 
   release-images:
-    needs: [download-images-x86_64]
+    needs: [download-images-x86_64, eval-tag]
     if: ${{ needs.eval-tag.outputs.image-produced }}
     runs-on: ubuntu-24.04
     permissions:
@@ -276,7 +276,7 @@ jobs:
           echo "Copied $COMPONENT:$TAG multi-arch to GHCR"
 
   public-release:
-    needs: [download-binaries-x86_64]
+    needs: [download-binaries-x86_64, eval-tag]
     runs-on: ubuntu-latest
     steps:
       - uses: actions/download-artifact@v4

--- a/.github/workflows/release-component.yml
+++ b/.github/workflows/release-component.yml
@@ -187,7 +187,7 @@ jobs:
           path: ${{ needs.eval-tag.outputs.component }}-${{ matrix.system }}
 
   release-images:
-    needs: [download-images, eval-tag]
+    needs: [download-images-x86_64, eval-tag]
     if: ${{ needs.eval-tag.outputs.image-produced }}
     runs-on: ubuntu-latest
     permissions:
@@ -279,7 +279,7 @@ jobs:
           echo "Copied $COMPONENT:$TAG multi-arch to GHCR"
 
   public-release:
-    needs: [download-binaries, eval-tag]
+    needs: [download-binaries-x86_64, eval-tag]
     runs-on: ubuntu-latest
     steps:
       - uses: actions/download-artifact@v4

--- a/.github/workflows/release-component.yml
+++ b/.github/workflows/release-component.yml
@@ -93,14 +93,13 @@ jobs:
         run: |
           nix build .#packages.x86_64-linux."$COMPONENT"
           cp -Lr result x86_64-linux."$COMPONENT"-image
-          exit 1
       - uses: actions/upload-artifact@v4
         with:
           name: x86_64-linux.${{ needs.eval-tag.outputs.component }}-image
           path: x86_64-linux.${{ needs.eval-tag.outputs.component }}-image
 
   download-images-aarch64:
-    if: ${{ needs.eval-tag.outputs.image-produced }}
+    if: ${{ needs.eval-tag.outputs.image-produced && contains(needs.eval-tag.outputs.systems, 'aarch64-linux') }}
     needs: [eval-tag]
     runs-on: ubuntu-24.04-arm
     steps:
@@ -118,7 +117,6 @@ jobs:
         run: |
           nix build .#packages.aarch64-linux."$COMPONENT"
           cp -Lr result aarch64-linux."$COMPONENT"-image
-          exit 1
       - uses: actions/upload-artifact@v4
         with:
           name: aarch64-linux.${{ needs.eval-tag.outputs.component }}-image
@@ -127,59 +125,69 @@ jobs:
   download-binaries-x86_64:
     needs: [eval-tag]
     runs-on: ubuntu-24.04
-    strategy:
-      matrix:
-        system: ${{ fromJSON(needs.eval-tag.outputs.systems) }}
     steps:
-      - uses: actions/download-artifact@v4
+      - uses: actions/checkout@v4
         with:
-          name: packages.${{ matrix.system }}.${{ needs.eval-tag.outputs.component }}
-      - uses: nixbuild/nix-quick-install-action@v28
-      - uses: nixbuild/nixbuild-action@812f1ab2b51842b0d44b9b79574611502d6940a0
+          lfs: true
+      - uses: cachix/install-nix-action@v30
         with:
-          nixbuild_token: ${{ secrets.nixbuild_token }}
+          extra_nix_config: |
+            trusted-public-keys = cache.nixos.org-1:6NCHdD59X431o0gWypbMrAURkbJ16ZPMQFGspcDShjY= cache.garnix.io:CTFPyKSLcx5RMJKfLo5EEPUObbA78b0YQ2DTCJXqr9g= union.cachix.org-1:TV9o8jexzNVbM1VNBOq9fu8NK+hL6ZhOyOh0quATy+M=
+            trusted-substituters = https://cache.nixos.org https://cache.garnix.io https://union.cachix.org
       - env:
           ARCHIVE: ${{ needs.eval-tag.outputs.archive }}
           COMPONENT: ${{ needs.eval-tag.outputs.component }}
-          SYSTEM: ${{ matrix.system }}
         run: |
-          exit 1
-          mkdir "$SYSTEM"
-          echo "Getting OUTPUT and NARINFO_NAME"
-          OUTPUT=$(jq -r \
-            --arg component "$COMPONENT" \
-            --arg system "$SYSTEM" \
-            '.packages[$system][$component].outputs.out' result.json)
-          NARINFO_NAME=$(basename "$OUTPUT" | cut -d'-' -f1)
-
-          echo "Copying $OUTPUT from nixbuild.net"
-          nix copy --to "file://$(pwd)/$SYSTEM" --from ssh-ng://eu.nixbuild.net "$OUTPUT" --extra-experimental-features nix-command
-
-          echo "Get the NAR_URL"
-          nar_url_line=$(cat "./$SYSTEM/$NARINFO_NAME.narinfo" | grep "URL:")
-          NAR_URL=$(echo "$nar_url_line" | cut -d " " -f 2-)
-
-          echo "Restore the package from the NAR_URL archive"
-          cat "$SYSTEM/$NAR_URL" | xz -dc | nix-store --restore "$SYSTEM.$COMPONENT"
+          nix build .#packages.x86_64-linux."$COMPONENT"
           if [[ "$COMPONENT" =~ uniond-release ]]
           then
-            mv "$SYSTEM.$COMPONENT"/bin/uniond "$COMPONENT-$SYSTEM"
+            mv result/bin/uniond "$COMPONENT"-x86_64-linux
           elif [[ $ARCHIVE ]]
           then
-            ls -la
-            tar -zcf "$COMPONENT-$SYSTEM" "$SYSTEM.$COMPONENT"
+            tar -zcf "$COMPONENT"-x86_64-linux result
           else
-            mv "$SYSTEM.$COMPONENT/bin/$COMPONENT" "$COMPONENT-$SYSTEM"
+            mv result/bin/"$COMPONENT" "$COMPONENT"-x86_64-linux
           fi
       - uses: actions/upload-artifact@v4
         with:
-          name: ${{ needs.eval-tag.outputs.component }}-${{ matrix.system }}
-          path: ${{ needs.eval-tag.outputs.component }}-${{ matrix.system }}
+          name: ${{ needs.eval-tag.outputs.component }}-x86_64-linux
+          path: ${{ needs.eval-tag.outputs.component }}-x86_64-linux
+
+  download-binaries-aarch64:
+    needs: [eval-tag]
+    runs-on: ubuntu-24.04-arm
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          lfs: true
+      - uses: cachix/install-nix-action@v30
+        with:
+          extra_nix_config: |
+            trusted-public-keys = cache.nixos.org-1:6NCHdD59X431o0gWypbMrAURkbJ16ZPMQFGspcDShjY= cache.garnix.io:CTFPyKSLcx5RMJKfLo5EEPUObbA78b0YQ2DTCJXqr9g= union.cachix.org-1:TV9o8jexzNVbM1VNBOq9fu8NK+hL6ZhOyOh0quATy+M=
+            trusted-substituters = https://cache.nixos.org https://cache.garnix.io https://union.cachix.org
+      - env:
+          ARCHIVE: ${{ needs.eval-tag.outputs.archive }}
+          COMPONENT: ${{ needs.eval-tag.outputs.component }}
+        run: |
+          nix build .#packages.aarch64-linux."$COMPONENT"
+          if [[ "$COMPONENT" =~ uniond-release ]]
+          then
+            mv result/bin/uniond "$COMPONENT"-aarch64-linux
+          elif [[ $ARCHIVE ]]
+          then
+            tar -zcf "$COMPONENT"-aarch64-linux result
+          else
+            mv result/bin/"$COMPONENT" "$COMPONENT"-aarch64-linux
+          fi
+      - uses: actions/upload-artifact@v4
+        with:
+          name: ${{ needs.eval-tag.outputs.component }}-aarch64-linux
+          path: ${{ needs.eval-tag.outputs.component }}-aarch64-linux
 
   release-images:
-    needs: [download-images-x86_64, eval-tag]
+    needs: [download-images-x86_64]
     if: ${{ needs.eval-tag.outputs.image-produced }}
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     permissions:
       packages: write
     services:
@@ -262,6 +270,7 @@ jobs:
           COMPONENT: ${{ needs.eval-tag.outputs.component }}
           TAG: ${{ needs.eval-tag.outputs.version }}
         run: |
+          exit 1
           wget https://github.com/rapidsai/skopeo/releases/download/v1.12/skopeo-linux-amd64 -O ./skopeo
           chmod +x ./skopeo && sudo cp ./skopeo /usr/bin
           echo "downloaded & installed skopeo"
@@ -269,7 +278,7 @@ jobs:
           echo "Copied $COMPONENT:$TAG multi-arch to GHCR"
 
   public-release:
-    needs: [download-binaries-x86_64, eval-tag]
+    needs: [download-binaries-x86_64]
     runs-on: ubuntu-latest
     steps:
       - uses: actions/download-artifact@v4
@@ -279,6 +288,7 @@ jobs:
           ARCHIVE: ${{ needs.eval-tag.outputs.archive }}
           SYSTEMS: ${{ needs.eval-tag.outputs.systems }}
         run: |
+          exit 1
           echo "# sha256 Checksums" >> release.md
           x86_64=$(echo "$SYSTEMS" | jq 'contains(["x86_64-linux"])')
           aarch64=$(echo "$SYSTEMS" | jq 'contains(["aarch64-linux"])')

--- a/.github/workflows/release-component.yml
+++ b/.github/workflows/release-component.yml
@@ -74,16 +74,6 @@ jobs:
             and ([.attr] | inside($attrs))" >> $GITHUB_OUTPUT
           echo "VERSION=${TAG##*/}" >> $GITHUB_OUTPUT
 
-  build:
-    needs: eval-tag
-    uses: unionlabs/workflows/.github/workflows/build.yml@8fdbd5d131725a503e1e8c7a415edf6726da25c5
-    secrets:
-      nixbuild_token: ${{ secrets.nixbuild_token }}
-      access-tokens: github.com=${{ secrets.GITHUB_TOKEN }}
-      org_token: ${{ secrets.UNION_ORG_PAT }}
-    with:
-      filter_builds: ${{ needs.eval-tag.outputs.build }}
-
   download-images-x86_64:
     if: ${{ needs.eval-tag.outputs.image-produced }}
     needs: [build, eval-tag]

--- a/.github/workflows/release-component.yml
+++ b/.github/workflows/release-component.yml
@@ -2,7 +2,7 @@ name: Release Component
 
 on:
   push:
-    tags: ['*/v[0-9]+\.[0-9]+\.[0-9]+\-rc[0-9]+', '*/v[0-9]+\.[0-9]+\.[0-9]+']
+    # tags: ['*/v[0-9]+\.[0-9]+\.[0-9]+\-rc[0-9]+', '*/v[0-9]+\.[0-9]+\.[0-9]+']
 
 jobs:
   eval-tag:
@@ -17,12 +17,13 @@ jobs:
     steps:
       - id: eval
         env:
-          TAG: ${{github.ref_name}}
+          # TAG: ${{github.ref_name}}
+          TAG: bundle-testnet-9
         run: |
           component="${TAG%/*}"
           case $component in
-            bundle-testnet-8)
-              attrs="[\"bundle-testnet-8\", \"bundle-testnet-8-image\"]"
+            bundle-testnet-9)
+              attrs="[\"bundle-testnet-9\", \"bundle-testnet-9-image\"]"
               systems="[\"x86_64-linux\", \"aarch64-linux\"]"
               echo "COMPONENT=$component" >> $GITHUB_OUTPUT
               echo "IMAGE_PRODUCED=true" >> $GITHUB_OUTPUT

--- a/.github/workflows/release-component.yml
+++ b/.github/workflows/release-component.yml
@@ -2,7 +2,7 @@ name: Release Component
 
 on:
   push:
-    # tags: ['*/v[0-9]+\.[0-9]+\.[0-9]+\-rc[0-9]+', '*/v[0-9]+\.[0-9]+\.[0-9]+']
+    tags: ['*/v[0-9]+\.[0-9]+\.[0-9]+\-rc[0-9]+', '*/v[0-9]+\.[0-9]+\.[0-9]+']
 
 jobs:
   eval-tag:
@@ -17,7 +17,7 @@ jobs:
     steps:
       - id: eval
         env:
-          TAG: bundle-testnet-9/v0.25.0
+          TAG: ${{github.ref_name}}
         run: |
           component="${TAG%/*}"
           case $component in
@@ -90,8 +90,8 @@ jobs:
         env:
           COMPONENT: ${{ needs.eval-tag.outputs.component }}
         run: |
-          nix build .#packages.x86_64-linux."$COMPONENT"-image --accept-flake-config 
-          cp -Lr result x86_64-linux."$COMPONENT"-image
+          nix build .#packages.x86_64-linux.\"$COMPONENT\"-image --accept-flake-config
+          cp -Lr result x86_64-linux.\"$COMPONENT\"-image
       - uses: actions/upload-artifact@v4
         with:
           name: x86_64-linux.${{ needs.eval-tag.outputs.component }}-image

--- a/.github/workflows/release-component.yml
+++ b/.github/workflows/release-component.yml
@@ -82,9 +82,9 @@ jobs:
       - uses: actions/checkout@v4
         with:
           lfs: true
-      - uses: nixbuild/nix-quick-install-action@v28
+      - uses: cachix/install-nix-action@v30
         with:
-          nix_conf: |
+          extra_nix_config: |
             trusted-public-keys = cache.nixos.org-1:6NCHdD59X431o0gWypbMrAURkbJ16ZPMQFGspcDShjY= cache.garnix.io:CTFPyKSLcx5RMJKfLo5EEPUObbA78b0YQ2DTCJXqr9g= union.cachix.org-1:TV9o8jexzNVbM1VNBOq9fu8NK+hL6ZhOyOh0quATy+M=
             trusted-substituters = https://cache.nixos.org https://cache.garnix.io https://union.cachix.org
       - name: Fetch from Cache
@@ -92,7 +92,7 @@ jobs:
           COMPONENT: ${{ needs.eval-tag.outputs.component }}
         run: |
           nix build .#packages.x86_64-linux."$COMPONENT"
-          cp -Lr result x86_64-linux.${{ needs.eval-tag.outputs.component }}-image
+          cp -Lr result x86_64-linux."$COMPONENT"-image
           exit 1
       - uses: actions/upload-artifact@v4
         with:
@@ -107,9 +107,9 @@ jobs:
       - uses: actions/checkout@v4
         with:
           lfs: true
-      - uses: nixbuild/nix-quick-install-action@v28
+      - uses: cachix/install-nix-action@v30
         with:
-          nix_conf: |
+          extra_nix_config: |
             trusted-public-keys = cache.nixos.org-1:6NCHdD59X431o0gWypbMrAURkbJ16ZPMQFGspcDShjY= cache.garnix.io:CTFPyKSLcx5RMJKfLo5EEPUObbA78b0YQ2DTCJXqr9g= union.cachix.org-1:TV9o8jexzNVbM1VNBOq9fu8NK+hL6ZhOyOh0quATy+M=
             trusted-substituters = https://cache.nixos.org https://cache.garnix.io https://union.cachix.org
       - name: Fetch from Cache

--- a/.github/workflows/release-component.yml
+++ b/.github/workflows/release-component.yml
@@ -83,39 +83,59 @@ jobs:
     with:
       filter_builds: ${{ needs.eval-tag.outputs.build }}
 
-  download-images:
+  download-images-x86_64:
     if: ${{ needs.eval-tag.outputs.image-produced }}
     needs: [build, eval-tag]
-    runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        system: ${{ fromJSON(needs.eval-tag.outputs.systems) }}
+    runs-on: ubuntu-24.04
     steps:
-      - uses: actions/download-artifact@v4
+      - uses: actions/checkout@v4
         with:
-          name: packages.${{ matrix.system }}.${{ needs.eval-tag.outputs.component }}-image
+          lfs: true
       - uses: nixbuild/nix-quick-install-action@v28
-      - uses: nixbuild/nixbuild-action@812f1ab2b51842b0d44b9b79574611502d6940a0
         with:
-          nixbuild_token: ${{ secrets.nixbuild_token }}
-      - env:
+          nix_conf: |
+            trusted-public-keys = cache.nixos.org-1:6NCHdD59X431o0gWypbMrAURkbJ16ZPMQFGspcDShjY= cache.garnix.io:CTFPyKSLcx5RMJKfLo5EEPUObbA78b0YQ2DTCJXqr9g= union.cachix.org-1:TV9o8jexzNVbM1VNBOq9fu8NK+hL6ZhOyOh0quATy+M=
+            trusted-substituters = https://cache.nixos.org https://cache.garnix.io https://union.cachix.org
+      - name: Fetch from Cache
+        env:
           COMPONENT: ${{ needs.eval-tag.outputs.component }}
-          SYSTEM: ${{ matrix.system }}
         run: |
-          mkdir "$SYSTEM"
-          nix copy --to "file://$(pwd)/$SYSTEM" --from ssh-ng://eu.nixbuild.net "$(cat result.json | jq -r \
-            --arg component "$COMPONENT-image" \
-            --arg system "$SYSTEM" \
-            '.packages[$system][$component].outputs.out')" --extra-experimental-features nix-command
-          cat "$SYSTEM"/nar/*.nar.xz | xz -dc | nix-store --restore "$SYSTEM.$COMPONENT"-image
+          nix build .#packages.x86_64-linux."$COMPONENT"
+          cp -Lr result x86_64-linux.${{ needs.eval-tag.outputs.component }}-image
+          exit 1
       - uses: actions/upload-artifact@v4
         with:
-          name: ${{ matrix.system }}.${{ needs.eval-tag.outputs.component }}-image
-          path: ${{ matrix.system }}.${{ needs.eval-tag.outputs.component }}-image
+          name: x86_64-linux.${{ needs.eval-tag.outputs.component }}-image
+          path: x86_64-linux.${{ needs.eval-tag.outputs.component }}-image
 
-  download-binaries:
+  download-images-aarch64:
+    if: ${{ needs.eval-tag.outputs.image-produced }}
     needs: [build, eval-tag]
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04-arm
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          lfs: true
+      - uses: nixbuild/nix-quick-install-action@v28
+        with:
+          nix_conf: |
+            trusted-public-keys = cache.nixos.org-1:6NCHdD59X431o0gWypbMrAURkbJ16ZPMQFGspcDShjY= cache.garnix.io:CTFPyKSLcx5RMJKfLo5EEPUObbA78b0YQ2DTCJXqr9g= union.cachix.org-1:TV9o8jexzNVbM1VNBOq9fu8NK+hL6ZhOyOh0quATy+M=
+            trusted-substituters = https://cache.nixos.org https://cache.garnix.io https://union.cachix.org
+      - name: Fetch from Cache
+        env:
+          COMPONENT: ${{ needs.eval-tag.outputs.component }}
+        run: |
+          nix build .#packages.aarch64-linux."$COMPONENT"
+          cp -Lr result aarch64-linux."$COMPONENT"-image
+          exit 1
+      - uses: actions/upload-artifact@v4
+        with:
+          name: aarch64-linux.${{ needs.eval-tag.outputs.component }}-image
+          path: aarch64-linux.${{ needs.eval-tag.outputs.component }}-image
+
+  download-binaries-x86_64:
+    needs: [build, eval-tag]
+    runs-on: ubuntu-24.04
     strategy:
       matrix:
         system: ${{ fromJSON(needs.eval-tag.outputs.systems) }}
@@ -132,6 +152,7 @@ jobs:
           COMPONENT: ${{ needs.eval-tag.outputs.component }}
           SYSTEM: ${{ matrix.system }}
         run: |
+          exit 1
           mkdir "$SYSTEM"
           echo "Getting OUTPUT and NARINFO_NAME"
           OUTPUT=$(jq -r \

--- a/.github/workflows/release-component.yml
+++ b/.github/workflows/release-component.yml
@@ -204,10 +204,12 @@ jobs:
         uses: actions/download-artifact@v4
         with:
           name: aarch64-linux.${{ needs.eval-tag.outputs.component }}-image
+          path: .
       - name: Download x86_64-linux.${{ needs.eval-tag.outputs.component }}-image
         uses: actions/download-artifact@v4
         with:
           name: x86_64-linux.${{ needs.eval-tag.outputs.component }}-image
+          path: .
       - name: Tag Docker Images
         env:
           COMPONENT: ${{ needs.eval-tag.outputs.component }}

--- a/.github/workflows/release-component.yml
+++ b/.github/workflows/release-component.yml
@@ -76,7 +76,7 @@ jobs:
 
   download-images-x86_64:
     if: ${{ needs.eval-tag.outputs.image-produced }}
-    needs: [build, eval-tag]
+    needs: [eval-tag]
     runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v4
@@ -101,7 +101,7 @@ jobs:
 
   download-images-aarch64:
     if: ${{ needs.eval-tag.outputs.image-produced }}
-    needs: [build, eval-tag]
+    needs: [eval-tag]
     runs-on: ubuntu-24.04-arm
     steps:
       - uses: actions/checkout@v4
@@ -125,7 +125,7 @@ jobs:
           path: aarch64-linux.${{ needs.eval-tag.outputs.component }}-image
 
   download-binaries-x86_64:
-    needs: [build, eval-tag]
+    needs: [eval-tag]
     runs-on: ubuntu-24.04
     strategy:
       matrix:

--- a/.github/workflows/release-component.yml
+++ b/.github/workflows/release-component.yml
@@ -90,7 +90,7 @@ jobs:
         env:
           COMPONENT: ${{ needs.eval-tag.outputs.component }}
         run: |
-          nix build .#packages.x86_64-linux."$COMPONENT"
+          nix build .#packages.x86_64-linux."$COMPONENT" --accept-flake-config 
           cp -Lr result x86_64-linux."$COMPONENT"-image
       - uses: actions/upload-artifact@v4
         with:
@@ -114,7 +114,7 @@ jobs:
         env:
           COMPONENT: ${{ needs.eval-tag.outputs.component }}
         run: |
-          nix build .#packages.aarch64-linux."$COMPONENT"
+          nix build .#packages.aarch64-linux."$COMPONENT" --accept-flake-config
           cp -Lr result aarch64-linux."$COMPONENT"-image
       - uses: actions/upload-artifact@v4
         with:
@@ -137,7 +137,7 @@ jobs:
           ARCHIVE: ${{ needs.eval-tag.outputs.archive }}
           COMPONENT: ${{ needs.eval-tag.outputs.component }}
         run: |
-          nix build .#packages.x86_64-linux."$COMPONENT"
+          nix build .#packages.x86_64-linux."$COMPONENT" --accept-flake-config
           if [[ "$COMPONENT" =~ uniond-release ]]
           then
             mv result/bin/uniond "$COMPONENT"-x86_64-linux
@@ -168,7 +168,7 @@ jobs:
           ARCHIVE: ${{ needs.eval-tag.outputs.archive }}
           COMPONENT: ${{ needs.eval-tag.outputs.component }}
         run: |
-          nix build .#packages.aarch64-linux."$COMPONENT"
+          nix build .#packages.aarch64-linux."$COMPONENT" --accept-flake-config
           if [[ "$COMPONENT" =~ uniond-release ]]
           then
             mv result/bin/uniond "$COMPONENT"-aarch64-linux

--- a/.github/workflows/release-component.yml
+++ b/.github/workflows/release-component.yml
@@ -184,7 +184,7 @@ jobs:
           path: ${{ needs.eval-tag.outputs.component }}-aarch64-linux
 
   release-images:
-    needs: [download-images-x86_64, eval-tag]
+    needs: [download-images-x86_64, download-images-aarch64, eval-tag]
     if: ${{ needs.eval-tag.outputs.image-produced }}
     runs-on: ubuntu-24.04
     permissions:
@@ -282,7 +282,7 @@ jobs:
           echo "Copied $COMPONENT:$TAG multi-arch to GHCR"
 
   public-release:
-    needs: [download-binaries-x86_64, eval-tag]
+    needs: [download-binaries-x86_64, download-binaries-aarch64, eval-tag]
     runs-on: ubuntu-latest
     steps:
       - uses: actions/download-artifact@v4

--- a/.github/workflows/release-component.yml
+++ b/.github/workflows/release-component.yml
@@ -17,8 +17,7 @@ jobs:
     steps:
       - id: eval
         env:
-          # TAG: ${{github.ref_name}}
-          TAG: bundle-testnet-9
+          TAG: bundle-testnet-9/v0.25.0
         run: |
           component="${TAG%/*}"
           case $component in
@@ -270,7 +269,6 @@ jobs:
           COMPONENT: ${{ needs.eval-tag.outputs.component }}
           TAG: ${{ needs.eval-tag.outputs.version }}
         run: |
-          exit 1
           wget https://github.com/rapidsai/skopeo/releases/download/v1.12/skopeo-linux-amd64 -O ./skopeo
           chmod +x ./skopeo && sudo cp ./skopeo /usr/bin
           echo "downloaded & installed skopeo"
@@ -288,7 +286,6 @@ jobs:
           ARCHIVE: ${{ needs.eval-tag.outputs.archive }}
           SYSTEMS: ${{ needs.eval-tag.outputs.systems }}
         run: |
-          exit 1
           echo "# sha256 Checksums" >> release.md
           x86_64=$(echo "$SYSTEMS" | jq 'contains(["x86_64-linux"])')
           aarch64=$(echo "$SYSTEMS" | jq 'contains(["aarch64-linux"])')

--- a/.github/workflows/release-component.yml
+++ b/.github/workflows/release-component.yml
@@ -217,6 +217,7 @@ jobs:
           for arch in 'aarch64-linux' 'x86_64-linux'
           do
             echo "Tagging $COMPONENT for $arch"
+            ls -la
             dockerstring=$(docker load < $arch.$COMPONENT-image)
             dockerstring=$(echo ${dockerstring##*':'})
             echo "Getting image ID for $dockerstring"


### PR DESCRIPTION
Sample release: https://github.com/unionlabs/union/releases/tag/v0.25.0
Docker images: https://github.com/unionlabs/union/pkgs/container/bundle-testnet-9