### PR TITLE
refactor(voyager): support multiple IBC interfaces in ensure_ibc_interface

### DIFF
--- a/cosmwasm/ucs00-pingpong/src/ibc.rs
+++ b/cosmwasm/ucs00-pingpong/src/ibc.rs
@@ -1,7 +1,9 @@
+#[cfg(not(feature = "library"))]
+use cosmwasm_std::entry_point;
 use cosmwasm_std::{
-    attr, entry_point, DepsMut, Env, IbcBasicResponse, IbcChannel, IbcChannelCloseMsg,
-    IbcChannelConnectMsg, IbcChannelOpenMsg, IbcOrder, IbcPacket, IbcPacketAckMsg,
-    IbcPacketReceiveMsg, IbcPacketTimeoutMsg, IbcReceiveResponse, Reply, Response, StdError,
+    attr, DepsMut, Env, IbcBasicResponse, IbcChannel, IbcChannelCloseMsg, IbcChannelConnectMsg,
+    IbcChannelOpenMsg, IbcOrder, IbcPacket, IbcPacketAckMsg, IbcPacketReceiveMsg,
+    IbcPacketTimeoutMsg, IbcReceiveResponse, Reply, Response, StdError,
 };
 
 use crate::{msg::UCS00PingPong, state::CONFIG, ContractError};

--- a/lib/voyager-message/src/module.rs
+++ b/lib/voyager-message/src/module.rs
@@ -176,12 +176,18 @@ impl ClientModuleInfo {
 
     pub fn ensure_ibc_interface(
         &self,
-        ibc_interface: impl AsRef<str>,
+        expected_interfaces: Vec<impl AsRef<str>>,
     ) -> Result<(), UnexpectedIbcInterfaceError> {
-        if ibc_interface.as_ref() != self.ibc_interface.as_str() {
+        if !expected_interfaces
+            .iter()
+            .any(|expected| expected.as_ref() == self.ibc_interface.as_str())
+        {
             Err(UnexpectedIbcInterfaceError {
                 expected: self.ibc_interface.clone(),
-                found: ibc_interface.as_ref().to_owned(),
+                found: expected_interfaces
+                    .iter()
+                    .map(|s| s.as_ref().to_string())
+                    .collect(),
             })
         } else {
             Ok(())
@@ -272,7 +278,7 @@ pub struct UnexpectedClientTypeError {
 #[error("invalid IBC interface: this module provides functionality for IBC interface `{expected}`, but the config specifies `{found}`")]
 pub struct UnexpectedIbcInterfaceError {
     pub expected: IbcInterface,
-    pub found: String,
+    pub found: Vec<String>,
 }
 
 #[derive(Debug, Clone, thiserror::Error)]

--- a/voyager/modules/client/ethereum/src/main.rs
+++ b/voyager/modules/client/ethereum/src/main.rs
@@ -47,7 +47,7 @@ impl ClientModule for Module {
     async fn new(config: Self::Config, info: ClientModuleInfo) -> Result<Self, BoxDynError> {
         info.ensure_client_type(ClientType::ETHEREUM)?;
         info.ensure_consensus_type(ConsensusType::ETHEREUM)?;
-        info.ensure_ibc_interface(IbcInterface::IBC_COSMWASM)?;
+        info.ensure_ibc_interface(vec![IbcInterface::IBC_COSMWASM])?;
 
         Ok(Self {
             chain_spec: config.chain_spec,

--- a/voyager/modules/client/movement/src/main.rs
+++ b/voyager/modules/client/movement/src/main.rs
@@ -46,7 +46,7 @@ impl ClientModule for Module {
     async fn new(Config {}: Self::Config, info: ClientModuleInfo) -> Result<Self, BoxDynError> {
         info.ensure_client_type(ClientType::MOVEMENT)?;
         info.ensure_consensus_type(ConsensusType::MOVEMENT)?;
-        info.ensure_ibc_interface(IbcInterface::IBC_COSMWASM)?;
+        info.ensure_ibc_interface(vec![IbcInterface::IBC_COSMWASM])?;
 
         Ok(Module {})
     }

--- a/voyager/modules/client/state-lens/ics23-ics23/src/main.rs
+++ b/voyager/modules/client/state-lens/ics23-ics23/src/main.rs
@@ -46,7 +46,7 @@ impl ClientModule for Module {
     async fn new(_: Self::Config, info: ClientModuleInfo) -> Result<Self, BoxDynError> {
         info.ensure_client_type(ClientType::STATE_LENS_ICS23_ICS23)?;
         info.ensure_consensus_type(ConsensusType::TENDERMINT)?;
-        info.ensure_ibc_interface(IbcInterface::IBC_SOLIDITY)?;
+        info.ensure_ibc_interface(vec![IbcInterface::IBC_COSMWASM])?;
         Ok(Self {})
     }
 }

--- a/voyager/modules/client/state-lens/ics23-mpt/src/main.rs
+++ b/voyager/modules/client/state-lens/ics23-mpt/src/main.rs
@@ -81,8 +81,7 @@ impl ClientModule for Module {
     async fn new(_: Self::Config, info: ClientModuleInfo) -> Result<Self, BoxDynError> {
         info.ensure_client_type(ClientType::STATE_LENS_ICS23_MPT)?;
         info.ensure_consensus_type(ConsensusType::ETHEREUM)?;
-        info.ensure_ibc_interface(IbcInterface::IBC_SOLIDITY)
-            .or(info.ensure_ibc_interface(IbcInterface::IBC_COSMWASM))?;
+        info.ensure_ibc_interface(vec![IbcInterface::IBC_SOLIDITY, IbcInterface::IBC_COSMWASM])?;
 
         Ok(Self {
             ibc_interface: SupportedIbcInterface::try_from(info.ibc_interface.to_string())?,


### PR DESCRIPTION
Allow checking an interface against multiple expected values by taking a Vec of interfaces. 

Updates error type to show all valid interfaces in error message.
