### PR TITLE
docs(integrations): fix broken links

### DIFF
--- a/docs/src/content/docs/integrations/api/graphql.mdx
+++ b/docs/src/content/docs/integrations/api/graphql.mdx
@@ -61,8 +61,8 @@ The following definitions are used across the schema and documentation:
 
 - `source`: The chain or rollup where the packet is sent from, often prefixed such as `source_timestamp` or `source_transaction_hash`.
 - `destination`: The chain or roll-up that receives the packet. 
-- `sender`: the contract or [EOA](https://ethereum.org/en/developers/accounts/) that made the transfer.
-- `receiver`: the contract or [EOA](https://ethereum.org/en/developers/accounts/) that received the transfer.
+- `sender`: the contract or [EOA](https://ethereum.org/en/developers/docs/accounts/) that made the transfer.
+- `receiver`: the contract or [EOA](https://ethereum.org/en/developers/docs/accounts/) that received the transfer.
 
 ## Queries
 


### PR DESCRIPTION
Fixed links to the [ethereum.org](https://ethereum.org) docs that weren't linking correctly!