### PR TITLE
feat: move Slot type into it's own library

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1391,6 +1391,7 @@ dependencies = [
  "evm-storage-verifier",
  "rlp",
  "sha3 0.10.8",
+ "slotlib",
  "thiserror",
  "unionlabs",
 ]
@@ -7041,6 +7042,7 @@ dependencies = [
  "linea-types",
  "linea-zktrie",
  "rlp",
+ "slotlib",
  "thiserror",
  "unionlabs",
 ]
@@ -10351,6 +10353,7 @@ dependencies = [
  "rlp",
  "scroll-codec",
  "scroll-light-client-types",
+ "slotlib",
  "thiserror",
  "unionlabs",
  "zktrie",
@@ -10900,6 +10903,29 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8f92a496fb766b417c996b9c5e57daf2f7ad3b0bebe1ccfca4856390e3d3bb67"
 dependencies = [
  "autocfg",
+]
+
+[[package]]
+name = "slot-calculator"
+version = "0.1.0"
+dependencies = [
+ "clap 4.5.4",
+ "hex-literal",
+ "sha2 0.10.8",
+ "sha3 0.10.8",
+ "slotlib",
+ "typed-arena",
+ "unionlabs",
+]
+
+[[package]]
+name = "slotlib"
+version = "0.1.0"
+dependencies = [
+ "hex-literal",
+ "sha2 0.10.8",
+ "sha3 0.10.8",
+ "unionlabs-primitives",
 ]
 
 [[package]]
@@ -12758,6 +12784,7 @@ dependencies = [
  "serde_json",
  "sha2 0.10.8",
  "sha3 0.10.8",
+ "slotlib",
  "ssz",
  "static_assertions 1.1.0 (git+https://github.com/nvzqz/static-assertions)",
  "subtle-encoding",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -96,6 +96,7 @@ members = [
 
   "tools/devnet-utils",
   "tools/parse-wasm-client-type",
+  "tools/slot-calculator",
   "tools/tidy",
   "tools/move-bindgen",
   "lib/move-bindgen-derive",
@@ -176,6 +177,7 @@ members = [
   "lib/state-lens-light-client-types",
   "lib/create3",
   "lib/linea-types",
+  "lib/slotlib",
 ]
 
 [workspace.package]
@@ -264,6 +266,7 @@ movement-light-client-types = { path = "lib/movement-light-client-types", defaul
 cosmos-sdk-event = { path = "lib/cosmos-sdk-event", default-features = false }
 
 serde-utils      = { path = "lib/serde-utils", default-features = false }
+slotlib          = { path = "lib/slotlib", default-features = false }
 ssz              = { path = "lib/ssz", default-features = false }
 ssz-derive       = { path = "lib/ssz-derive", default-features = false }
 subset-of        = { path = "lib/subset-of", default-features = false }

--- a/lib/arbitrum-verifier/Cargo.toml
+++ b/lib/arbitrum-verifier/Cargo.toml
@@ -19,6 +19,7 @@ arbitrum-light-client-types = { workspace = true }
 evm-storage-verifier        = { workspace = true }
 rlp                         = { workspace = true }
 sha3                        = { workspace = true }
+slotlib                     = { workspace = true }
 thiserror                   = { workspace = true }
 unionlabs                   = { workspace = true }
 

--- a/lib/arbitrum-verifier/src/lib.rs
+++ b/lib/arbitrum-verifier/src/lib.rs
@@ -3,10 +3,8 @@ use core::fmt::Debug;
 use arbitrum_light_client_types::{ClientState, Header};
 use evm_storage_verifier::{verify_account_storage_root, verify_storage_proof};
 use sha3::{Digest, Keccak256};
-use unionlabs::{
-    ethereum::slot::{MappingKey, Slot},
-    primitives::{H256, U256},
-};
+use slotlib::{MappingKey, Slot};
+use unionlabs::primitives::{H256, U256};
 
 #[derive(thiserror::Error, Debug, PartialEq, Clone)]
 pub enum Error {

--- a/lib/linea-verifier/Cargo.toml
+++ b/lib/linea-verifier/Cargo.toml
@@ -21,5 +21,6 @@ linea-light-client-types = { workspace = true }
 linea-types              = { workspace = true }
 linea-zktrie             = { workspace = true }
 rlp                      = { workspace = true }
+slotlib                  = { workspace = true }
 thiserror                = { workspace = true }
 unionlabs                = { workspace = true }

--- a/lib/linea-verifier/src/lib.rs
+++ b/lib/linea-verifier/src/lib.rs
@@ -4,10 +4,8 @@ use evm_storage_verifier::{verify_account_storage_root, verify_storage_proof};
 use gnark_mimc::new_mimc_constants_bls12_377;
 use linea_light_client_types::{ClientState, Header};
 use linea_types::account::ZkAccount;
-use unionlabs::{
-    ethereum::slot::{MappingKey, Slot},
-    primitives::{H256, U256},
-};
+use slotlib::{MappingKey, Slot};
+use unionlabs::primitives::{H256, U256};
 
 #[derive(Debug, Clone, PartialEq, thiserror::Error)]
 pub enum Error {

--- a/lib/scroll-verifier/Cargo.toml
+++ b/lib/scroll-verifier/Cargo.toml
@@ -19,6 +19,7 @@ evm-storage-verifier      = { workspace = true }
 rlp                       = { workspace = true }
 scroll-codec              = { workspace = true }
 scroll-light-client-types = { workspace = true }
+slotlib                   = { workspace = true }
 thiserror                 = { workspace = true }
 unionlabs                 = { workspace = true }
 zktrie                    = { workspace = true }

--- a/lib/scroll-verifier/src/lib.rs
+++ b/lib/scroll-verifier/src/lib.rs
@@ -3,8 +3,8 @@ use core::fmt::Debug;
 use evm_storage_verifier::{verify_account_storage_root, verify_storage_proof};
 use scroll_codec::{hash_batch, HashBatchError};
 use scroll_light_client_types::{ClientState, Header};
+use slotlib::{MappingKey, Slot};
 use unionlabs::{
-    ethereum::slot::{MappingKey, Slot},
     primitives::{H160, H256, U256},
     scroll::account::Account,
 };

--- a/lib/slotlib/Cargo.toml
+++ b/lib/slotlib/Cargo.toml
@@ -1,0 +1,15 @@
+[package]
+edition.workspace      = true
+license-file.workspace = true
+name                   = "slotlib"
+repository.workspace   = true
+version                = "0.1.0"
+
+[dependencies]
+hex-literal          = { workspace = true }
+sha2                 = { workspace = true }
+sha3                 = { workspace = true }
+unionlabs-primitives = { workspace = true }
+
+[lints]
+workspace = true

--- a/lib/slotlib/src/lib.rs
+++ b/lib/slotlib/src/lib.rs
@@ -1,0 +1,3 @@
+pub mod slot;
+
+pub use crate::slot::{MappingKey, Slot};

--- a/lib/slotlib/src/slot.rs
+++ b/lib/slotlib/src/slot.rs
@@ -1,0 +1,85 @@
+use sha2::Digest;
+use sha3::Keccak256;
+use unionlabs_primitives::{H256, U256};
+
+// Duplication of keccak256 function defined in /lib/unionlabs/ethereum.rs, otherwise it creates a dependency cycle.
+#[inline]
+#[must_use]
+pub fn keccak256(bytes: impl AsRef<[u8]>) -> H256 {
+    Keccak256::new().chain_update(bytes).finalize().into()
+}
+
+/// Solidity storage slot calculations. Note that this currently does not handle dynamic arrays with packed values; the index passed to [`Slot::Array`] will need to be calculated manually in this case.
+pub enum Slot<'a> {
+    /// (base slot, index)
+    Array(&'a Slot<'a>, U256),
+    /// (base slot, mapping key)
+    Mapping(&'a Slot<'a>, MappingKey<'a>),
+    Offset(U256),
+}
+
+impl Slot<'_> {
+    // https://docs.soliditylang.org/en/latest/internals/layout_in_storage.html#mappings-and-dynamic-arrays
+    #[inline]
+    #[must_use = "calculating the slot has no effect"]
+    // REVIEW: Make const? <https://crates.io/crates/keccak-const/0.2.0>
+    pub fn slot(&self) -> U256 {
+        match self {
+            // keccak256(p)
+            Slot::Array(p, idx) => {
+                U256::from_be_bytes(*keccak256(p.slot().to_be_bytes()).get()) + *idx
+            }
+            // keccak256(h(k) . p)
+            Slot::Mapping(p, k) => {
+                let mut hasher = Keccak256::new();
+                match &k {
+                    MappingKey::String(string) => hasher.update(string.as_bytes()),
+                    MappingKey::Uint256(k) => hasher.update(k.to_be_bytes()),
+                    MappingKey::Uint64(k) => hasher.update(U256::from(*k).to_be_bytes()),
+                    MappingKey::Bytes32(k) => hasher.update(k.get()),
+                };
+
+                U256::from_be_bytes(
+                    hasher
+                        .chain_update(p.slot().to_be_bytes())
+                        .finalize()
+                        .into(),
+                )
+            }
+            Slot::Offset(p) => *p,
+        }
+    }
+}
+
+#[derive(Debug)]
+pub enum MappingKey<'a> {
+    String(&'a str),
+    Uint256(U256),
+    Uint64(u64),
+    Bytes32(H256),
+}
+
+#[test]
+fn test() {
+    // Test contract uploaded here: https://sepolia.etherscan.io/address/0x6845dbaa9513d3d07737ea9f6e350011dcfeb9bd
+
+    // mapping(uint256 => mapping(uint256 => uint256)[])
+    let slot = Slot::Mapping(
+        &Slot::Array(
+            &Slot::Mapping(
+                &Slot::Offset(0u32.into()),
+                MappingKey::Uint256(123u32.into()),
+            ),
+            1u32.into(),
+        ),
+        MappingKey::Uint256(100u32.into()),
+    )
+    .slot();
+
+    assert_eq!(
+        <H256>::new(slot.to_be_bytes()),
+        <H256>::new(hex_literal::hex!(
+            "00a9b48fe93e5d10ebc2d9021d1477088c6292bf047876944343f57fdf3f0467"
+        ))
+    );
+}

--- a/lib/unionlabs/Cargo.toml
+++ b/lib/unionlabs/Cargo.toml
@@ -53,6 +53,7 @@ near-primitives-core = { version = "0.21", optional = true }
 near-sdk             = { workspace = true, optional = true }
 schemars             = { workspace = true, features = ["derive"], optional = true }
 serde_bytes          = "0.11.6"
+slotlib              = { workspace = true }
 unionlabs-primitives = { workspace = true, features = ["generic-array-compat", "serde", "base64"] }
 
 [dev-dependencies]

--- a/lib/unionlabs/src/ethereum.rs
+++ b/lib/unionlabs/src/ethereum.rs
@@ -1,10 +1,8 @@
 use sha2::Digest;
 use sha3::Keccak256;
+use slotlib::{MappingKey, Slot};
 
-use crate::{
-    ethereum::slot::{MappingKey, Slot},
-    primitives::{H256, U256},
-};
+use crate::primitives::{H256, U256};
 
 pub mod slot;
 

--- a/tools/slot-calculator/Cargo.toml
+++ b/tools/slot-calculator/Cargo.toml
@@ -1,0 +1,19 @@
+[package]
+edition      = { workspace = true }
+license-file = { workspace = true }
+name         = "slot-calculator"
+publish      = false
+repository   = { workspace = true }
+version      = "0.1.0"
+
+[lints]
+workspace = true
+
+[dependencies]
+clap        = { workspace = true, features = ["derive", "help"] }
+hex-literal = { workspace = true }
+sha2        = { workspace = true }
+sha3        = { workspace = true }
+slotlib     = { workspace = true }
+typed-arena = "2.0"
+unionlabs   = { workspace = true, features = ["rlp"] }

--- a/tools/slot-calculator/src/main.rs
+++ b/tools/slot-calculator/src/main.rs
@@ -1,0 +1,206 @@
+use std::{collections::VecDeque, str::FromStr, vec};
+
+use clap::{Arg, Command};
+use slotlib::{MappingKey, Slot};
+use typed_arena::Arena;
+use unionlabs::primitives::{H256, U256};
+
+// Examples:
+// mapping(uint256 => uint256) => ["uint256"]
+// mapping(uint256 => uint256[]) => ["uint256", "uint256[]"]
+// mapping(uint256 => mapping(uint256 => uint256)) => ["uint256", "uint256"]
+// mapping(uint256 => mapping(uint256 => mapping(uint256 => uint256)[])[]) => ["uint256", "mapping[]", "uint256", "mapping[]", "uint256"]
+// mapping(uint256 => mapping(uint256 => mapping(uint256 => mapping(uint256 => uint256)[]))[]) => ["uint256", "mapping[]", "uint256", "uint256", "mapping[]", "uint256"]
+// mapping(uint256 => mapping(uint256 => uint256)[]) => ["uint256", "mapping[]", "uint256"]
+fn parse_layout(layout: &str) -> Result<Vec<String>, String> {
+    // 1. Basic validation
+    if !layout.starts_with("mapping(") || !layout.ends_with(')') {
+        return Err("Invalid layout".to_string());
+    }
+
+    // 2. Remove all 'mapping', then strip the first '(' and last ')' character.
+    let mut sanitized = layout.replace("mapping", "");
+    sanitized = sanitized[1..sanitized.len() - 1].to_string();
+
+    // 3. Split by '=>', trim and remove any leftover '('
+    let mut split_by_arrow: Vec<String> = sanitized
+        .split("=>")
+        .map(|s| s.trim().replace("(", ""))
+        .collect();
+
+    // cloning the array so we can iterate indexes from the *original* split_by_arrow
+    // while we modify the *current* split_by_arrow in place.
+    let original_split = split_by_arrow.clone();
+
+    for (i, element) in original_split.iter().enumerate() {
+        let mapping_array_count = element.matches(")[]").count();
+        if mapping_array_count == 0 {
+            continue;
+        }
+
+        // 1) split element by ")[]"
+        // 2) skip the first chunk
+        // 3) in each chunk, count how many times ')' appears, subtract 1
+        // 4) reverse at the end
+        let mut skip_indexes: Vec<usize> = element
+            .split(")[]")
+            .skip(1)
+            .map(|chunk| chunk.matches(')').count())
+            .collect();
+        skip_indexes.reverse();
+
+        // For each occurrence, insert "mapping[]" at index (i - j - skipCount).
+        for j in 1..=mapping_array_count {
+            let skip_count = skip_indexes[j - 1];
+            let insert_index = (i as usize) - (j as usize) - (skip_count as usize);
+            split_by_arrow.insert(insert_index as usize, "mapping[]".to_string());
+        }
+    }
+
+    // 4. Final check on the last element:
+    // if it doesn't have "[]" or if it still contains ")[]", pop it
+    if let Some(last) = split_by_arrow.last() {
+        if !last.contains("[]") || last.contains(")[]") {
+            split_by_arrow.pop();
+        }
+    }
+
+    Ok(split_by_arrow)
+}
+
+// MappingKey + U32
+#[derive(Debug)]
+pub enum KeyTypes<'a> {
+    MappingIndex(MappingKey<'a>),
+    ArrayIndex(U256),
+}
+
+fn parse_keys<'a>(parsed_layout: &Vec<String>, keys: &'a str) -> Vec<KeyTypes<'a>> {
+    let split_keys: Vec<&str> = keys.split(" ").collect();
+    let mut final_keys: Vec<KeyTypes<'a>> = vec![];
+    for (i, parsed_layout_elem) in parsed_layout.iter().enumerate() {
+        if (*parsed_layout_elem).contains("[]") {
+            final_keys.push(KeyTypes::ArrayIndex(
+                split_keys[i].parse::<u32>().unwrap().into(),
+            ));
+        } else if *parsed_layout_elem == "uint256" {
+            final_keys.push(KeyTypes::MappingIndex(MappingKey::Uint256(
+                split_keys[i].parse::<u32>().unwrap().into(),
+            )));
+        } else if *parsed_layout_elem == "string" {
+            final_keys.push(KeyTypes::MappingIndex(MappingKey::String(split_keys[i])));
+        } else if *parsed_layout_elem == "uint64" {
+            final_keys.push(KeyTypes::MappingIndex(MappingKey::Uint64(
+                split_keys[i].parse::<u64>().unwrap(),
+            )));
+        } else if *parsed_layout_elem == "bytes32" {
+            final_keys.push(KeyTypes::MappingIndex(MappingKey::Bytes32(
+                H256::from_str(split_keys[i]).unwrap(),
+            )));
+        } else {
+            panic!("Unrecognized key!");
+        };
+    }
+
+    final_keys
+}
+
+// ["uint256", "mapping[]", "uint256"]
+fn build_slot<'a>(
+    parsed_layout: &mut VecDeque<String>,
+    parsed_keys: &mut VecDeque<KeyTypes<'a>>,
+    arena: &'a Arena<Slot<'a>>,
+) -> &'a Slot<'a> {
+    if parsed_layout.is_empty() {
+        return arena.alloc(Slot::Offset(U256::from(0u32)));
+    }
+
+    let layout_part = parsed_layout.pop_front().unwrap();
+
+    if layout_part.contains("[]") {
+        let KeyTypes::ArrayIndex(i) = parsed_keys.pop_front().unwrap() else {
+            panic!("Expected an array index but got a mapping key!");
+        };
+        arena.alloc(Slot::Array(
+            build_slot(parsed_layout, parsed_keys, arena),
+            i,
+        ))
+    } else {
+        let KeyTypes::MappingIndex(mk) = parsed_keys.pop_front().unwrap() else {
+            panic!("Expected a mapping key but got an array index!");
+        };
+        arena.alloc(Slot::Mapping(
+            build_slot(parsed_layout, parsed_keys, arena),
+            mk,
+        ))
+    }
+}
+
+fn calculate_slot(layout: &str, keys: &str) -> U256 {
+    let parsed_layout = parse_layout(layout).unwrap();
+    let parsed_keys = parse_keys(&parsed_layout, keys);
+
+    // we need a queue structure for popping first elements more efficiently, therefore we're using VecDeque
+    let mut parsed_layout = VecDeque::from(parsed_layout);
+    let mut parsed_keys = VecDeque::from(parsed_keys);
+
+    let arena = Arena::new();
+    let slot = build_slot(&mut parsed_layout, &mut parsed_keys, &arena);
+    slot.slot()
+}
+
+fn main() {
+    let matches = Command::new("Slot Calculator (post-order)")
+        .version("1.0")
+        .about("Calculates Solidity storage slots for various layouts in a post-order manner")
+        .arg(
+            Arg::new("layout")
+                .long("layout")
+                .value_name("LAYOUT")
+                .required(true)
+                .help("e.g. 'mapping(uint256 => mapping(uint256 => uint256)[])'"),
+        )
+        .arg(
+            Arg::new("keys")
+                .long("keys")
+                .value_name("KEYS")
+                .required(true)
+                .num_args(1..) // Accept one or more
+                .help("The keys in the order that matches your snippet, e.g. 123 1 100"),
+        )
+        .get_matches();
+
+    let layout = matches
+        .get_one::<String>("layout")
+        .expect("Missing --layout");
+    let keys_collected: Vec<String> = matches
+        .get_many::<String>("keys")
+        .expect("Missing --keys")
+        .map(|s| s.to_string())
+        .collect();
+
+    // Combine user-provided keys into "123 1 100" form:
+    let keys_str = keys_collected.join(" ");
+
+    let slot_hex = calculate_slot(layout, &keys_str);
+
+    println!(
+        "Calculated storage slot: {}",
+        <H256>::new(slot_hex.to_be_bytes())
+    );
+}
+
+#[test]
+fn test_calculate_slot() {
+    let layout = "mapping(uint256 => mapping(uint256 => uint256)[])";
+    let keys = "100 1 123";
+
+    let slot = calculate_slot(layout, keys);
+
+    assert_eq!(
+        <H256>::new(slot.to_be_bytes()),
+        <H256>::new(hex_literal::hex!(
+            "00a9b48fe93e5d10ebc2d9021d1477088c6292bf047876944343f57fdf3f0467"
+        ))
+    );
+}


### PR DESCRIPTION
Closes #3417 

Created a small binary for slot calculation as well. Usage:
`cargo run --bin slot-calculator --layout "mapping(uint256 => mapping(uint256 => uint256)[])" --keys 100 1 123`