### PR TITLE
docs: Fixed Typo in "Getting a Testnet Account" Section

### DIFF
--- a/docs/src/content/docs/joining-testnet/getting-tokens.mdx
+++ b/docs/src/content/docs/joining-testnet/getting-tokens.mdx
@@ -18,7 +18,7 @@ Once you can run `uniond`, you can either create a new account, or recover one f
 
 :::caution
 
-Regardless the method used to set up your Union Testnet account, we recommend **NOT** storing the account on the server running your node.
+Regardless of the method used to set up your Union Testnet account, we recommend **NOT** storing the account on the server running your node.
 
 :::
 


### PR DESCRIPTION
 I noticed a typo in the "Getting a Testnet Account" section.
The sentence "Regardless the method used to set up your Union Testnet account..." should include "**of**" to be grammatically correct: "Regardless of the method used to set up your Union Testnet account...".
I’ve made this correction.