### PR TITLE
Hubble prevent restart on error

### DIFF
--- a/hubble/src/indexer/fetcher.rs
+++ b/hubble/src/indexer/fetcher.rs
@@ -14,6 +14,16 @@ use crate::indexer::{
     HappyRangeFetcher,
 };
 
+enum RunToFinalizedLoopResult {
+    RunAgain,
+    Finished,
+}
+
+enum RunToTipLoopResult {
+    RunAgain,
+    TryAgainLater,
+}
+
 impl<T: FetcherClient> Indexer<T> {
     pub async fn run_fetcher(&self, fetcher_client: T) -> Result<(), IndexerError> {
         self.run_to_finalized(&fetcher_client)
@@ -25,48 +35,65 @@ impl<T: FetcherClient> Indexer<T> {
     }
 
     async fn run_to_finalized(&self, fetcher_client: &T) -> Result<(), IndexerError> {
-        let chunk_size: u64 = self.chunk_size.try_into().unwrap();
-        let delay_blocks: u64 = self.finalizer_config.delay_blocks.try_into().unwrap();
-
         loop {
-            debug!("fetching last finalized block");
-            match fetcher_client
-                .fetch_single(BlockSelection::LastFinalized, FetchMode::Lazy)
-                .await
-            {
-                Ok(last_finalized) => {
-                    let next_height = self.next_height().await?;
-                    if next_height + chunk_size + delay_blocks > last_finalized.reference().height {
-                        info!("near finalized height (current: {} + chunk: {} + delay: {} > finalized: {}) => start 'run to tip'", next_height, self.chunk_size, self.finalizer_config.delay_blocks, last_finalized.reference());
-                        return Ok(());
-                    }
-
-                    let catch_up_range: BlockRange =
-                        (next_height..last_finalized.reference().height).into();
-                    info!("missing blocks: {}", catch_up_range);
-
-                    for slice in catch_up_range.range_chunks(self.chunk_size) {
-                        info!("{}: handling chunk", slice);
-
-                        last_finalized
-                            .fetch_range_expect_all(slice.clone(), FetchMode::Eager, |block| {
-                                self.store_block(block)
-                            })
-                            .instrument(info_span!("store"))
-                            .await?;
-
-                        info!("{}: handled chunk", &slice);
-                    }
+            match self.run_to_finalized_loop(fetcher_client).await {
+                Ok(RunToFinalizedLoopResult::RunAgain) => {
+                    debug!("run again");
                 }
-                Err(IndexerError::NoBlock(_)) => {
-                    info!("no finalized block => start 'run to tip'");
+                Ok(RunToFinalizedLoopResult::Finished) => {
+                    debug!("finished");
                     return Ok(());
                 }
                 Err(error) => {
-                    info!("error reading: {}", error);
-                    return Err(error);
+                    warn!("error in finalized loop: {error} => try again later (sleep 1s)");
+                    sleep(Duration::from_secs(1)).await;
                 }
             };
+        }
+    }
+
+    async fn run_to_finalized_loop(
+        &self,
+        fetcher_client: &T,
+    ) -> Result<RunToFinalizedLoopResult, IndexerError> {
+        let chunk_size: u64 = self.chunk_size.try_into().unwrap();
+        let delay_blocks: u64 = self.finalizer_config.delay_blocks.try_into().unwrap();
+
+        debug!("fetching last finalized block");
+        match fetcher_client
+            .fetch_single(BlockSelection::LastFinalized, FetchMode::Lazy)
+            .await
+        {
+            Ok(last_finalized) => {
+                let next_height = self.next_height().await?;
+                if next_height + chunk_size + delay_blocks > last_finalized.reference().height {
+                    info!("near finalized height (current: {} + chunk: {} + delay: {} > finalized: {}) => start 'run to tip'", next_height, self.chunk_size, self.finalizer_config.delay_blocks, last_finalized.reference());
+                    return Ok(RunToFinalizedLoopResult::Finished);
+                }
+
+                let catch_up_range: BlockRange =
+                    (next_height..last_finalized.reference().height).into();
+                info!("missing blocks: {catch_up_range}");
+
+                for slice in catch_up_range.range_chunks(self.chunk_size) {
+                    info!("{slice}: handling chunk");
+
+                    last_finalized
+                        .fetch_range_expect_all(slice.clone(), FetchMode::Eager, |block| {
+                            self.store_block(block)
+                        })
+                        .instrument(info_span!("store"))
+                        .await?;
+
+                    info!("{slice}: handled chunk");
+                }
+                Ok(RunToFinalizedLoopResult::RunAgain)
+            }
+            Err(IndexerError::NoBlock(_)) => {
+                info!("no finalized block => start 'run to tip'");
+                Ok(RunToFinalizedLoopResult::Finished)
+            }
+            Err(error) => Err(error),
         }
     }
 
@@ -93,64 +120,84 @@ impl<T: FetcherClient> Indexer<T> {
 
     async fn run_to_tip(&self, fetcher_client: &T) -> Result<(), IndexerError> {
         loop {
-            let next_height = self.next_height().await?;
-            info!("{}: fetching", next_height);
+            match self.run_to_tip_loop(fetcher_client).await {
+                Ok(RunToTipLoopResult::RunAgain) => {
+                    debug!("run again");
+                }
+                Ok(RunToTipLoopResult::TryAgainLater) => {
+                    debug!("try again later (sleep 1s)");
+                    sleep(Duration::from_secs(1)).await;
+                }
+                Err(error) => {
+                    warn!("error in run to tip loop: {error} => try again later (sleep 1s)");
+                    sleep(Duration::from_secs(1)).await;
+                }
+            }
+        }
+    }
 
-            match fetcher_client
-                .fetch_single(BlockSelection::Height(next_height), FetchMode::Eager)
-                .await
-            {
-                Ok(block_handle) => {
-                    let reference = &block_handle.reference();
-                    debug!("{}: handling", reference);
+    async fn run_to_tip_loop(
+        &self,
+        fetcher_client: &T,
+    ) -> Result<RunToTipLoopResult, IndexerError> {
+        let next_height = self.next_height().await?;
+        info!("{}: fetching", next_height);
 
-                    if next_height != reference.height {
-                        error!(
-                            "{}: unexpected height (actual {}, expecting {})",
-                            reference.height, reference.height, next_height
-                        );
-                        return Err(IndexerError::UnexpectedHeightSingle(
-                            next_height,
-                            reference.height,
-                        ));
-                    }
+        match fetcher_client
+            .fetch_single(BlockSelection::Height(next_height), FetchMode::Eager)
+            .await
+        {
+            Ok(block_handle) => {
+                let reference = &block_handle.reference();
+                debug!("{}: handling", reference);
 
-                    let mut tx = self.pg_pool.begin().await?;
-                    block_handle
-                        .insert(&mut tx)
-                        .instrument(info_span!("insert"))
-                        .await?;
-
-                    debug!("{}: update height", reference);
-                    update_current_height(
-                        &mut tx,
-                        self.indexer_id.clone(),
+                if next_height != reference.height {
+                    error!(
+                        "{}: unexpected height (actual {}, expecting {})",
+                        reference.height, reference.height, next_height
+                    );
+                    return Err(IndexerError::UnexpectedHeightSingle(
+                        next_height,
                         reference.height,
-                        reference.timestamp,
-                    )
+                    ));
+                }
+
+                let mut tx = self.pg_pool.begin().await?;
+                block_handle
+                    .insert(&mut tx)
+                    .instrument(info_span!("insert"))
                     .await?;
 
-                    debug!("{}: update status", reference);
-                    update_block_status(
-                        &mut tx,
-                        self.indexer_id.clone(),
-                        reference.height,
-                        reference.hash.clone(),
-                        reference.timestamp,
-                    )
-                    .await?;
+                debug!("{}: update height", reference);
+                update_current_height(
+                    &mut tx,
+                    self.indexer_id.clone(),
+                    reference.height,
+                    reference.timestamp,
+                )
+                .await?;
 
-                    tx.commit().await?;
-                    debug!("{}: handled", reference);
-                }
-                Err(IndexerError::NoBlock(_)) => {
-                    debug!("{}: no block yet => sleep", next_height);
-                    sleep(Duration::from_millis(1000)).await;
-                }
-                Err(err) => {
-                    warn!("{}: error reading block => sleep : {:?}", next_height, err);
-                    sleep(Duration::from_millis(1000)).await;
-                }
+                debug!("{}: update status", reference);
+                update_block_status(
+                    &mut tx,
+                    self.indexer_id.clone(),
+                    reference.height,
+                    reference.hash.clone(),
+                    reference.timestamp,
+                )
+                .await?;
+
+                tx.commit().await?;
+                debug!("{}: handled", reference);
+                Ok(RunToTipLoopResult::RunAgain)
+            }
+            Err(IndexerError::NoBlock(_)) => {
+                debug!("{}: no block yet => sleep", next_height);
+                Ok(RunToTipLoopResult::TryAgainLater)
+            }
+            Err(err) => {
+                warn!("{}: error reading block => sleep : {:?}", next_height, err);
+                Err(err)
             }
         }
     }

--- a/hubble/src/indexer/fixer.rs
+++ b/hubble/src/indexer/fixer.rs
@@ -1,4 +1,4 @@
-use std::{cmp::min, time::Duration};
+use std::cmp::min;
 
 use color_eyre::eyre::Report;
 use tokio::time::sleep;
@@ -14,66 +14,90 @@ use crate::indexer::{
     HappyRangeFetcher,
 };
 
+enum FixerLoopResult {
+    RunAgain,
+    TryAgainLater,
+}
+
 impl<T: FetcherClient> Indexer<T> {
     pub async fn run_fixer(&self, fetcher_client: T) -> Result<(), IndexerError> {
+        loop {
+            match self.run_fixer_loop(&fetcher_client).await {
+                Ok(FixerLoopResult::RunAgain) => {
+                    debug!("run again");
+                }
+                Ok(FixerLoopResult::TryAgainLater) => {
+                    debug!(
+                        "try again later (sleep {}s)",
+                        self.finalizer_config.retry_later_sleep.as_secs()
+                    );
+                    sleep(self.finalizer_config.retry_later_sleep).await;
+                }
+                Err(error) => {
+                    warn!(
+                        "error in finalizer loop: {error} => try again later (sleep {}s)",
+                        self.finalizer_config.retry_later_sleep.as_secs()
+                    );
+                    sleep(self.finalizer_config.retry_later_sleep).await;
+                }
+            }
+        }
+    }
+
+    async fn run_fixer_loop(&self, fetcher_client: &T) -> Result<FixerLoopResult, IndexerError> {
         let chunk_size: u64 = self.chunk_size.try_into().unwrap();
 
-        loop {
-            if let Some(block_range_to_fix) = self.block_range_to_fix().await? {
-                info!("{}: begin", block_range_to_fix);
+        if let Some(block_range_to_fix) = self.block_range_to_fix().await? {
+            info!("{block_range_to_fix}: begin");
 
-                match fetcher_client
-                    .fetch_single(BlockSelection::LastFinalized, FetchMode::Lazy)
-                    .await
-                {
-                    Ok(last_finalized) => {
-                        let last_finalized_reference = last_finalized.reference();
+            match fetcher_client
+                .fetch_single(BlockSelection::LastFinalized, FetchMode::Lazy)
+                .await
+            {
+                Ok(last_finalized) => {
+                    let last_finalized_reference = last_finalized.reference();
 
-                        trace!(
-                            "{}: current finalized: {}",
-                            block_range_to_fix,
-                            last_finalized_reference,
+                    trace!("{block_range_to_fix}: current finalized: {last_finalized_reference}");
+
+                    if block_range_to_fix.start_inclusive <= last_finalized_reference.height {
+                        // find the end of the range to fix
+                        let end_of_chunk_exclusive =
+                            block_range_to_fix.start_inclusive + chunk_size;
+                        let end_until_finalized = last_finalized_reference.height + 1;
+                        let end_until_last_block_to_fix = block_range_to_fix.end_exclusive;
+
+                        let range_to_fix_end = min(
+                            end_of_chunk_exclusive,
+                            min(end_until_finalized, end_until_last_block_to_fix),
                         );
 
-                        if block_range_to_fix.start_inclusive <= last_finalized_reference.height {
-                            // find the end of the range to fix
-                            let end_of_chunk_exclusive =
-                                block_range_to_fix.start_inclusive + chunk_size;
-                            let end_until_finalized = last_finalized_reference.height + 1;
-                            let end_until_last_block_to_fix = block_range_to_fix.end_exclusive;
+                        let range_to_fix: BlockRange =
+                            (block_range_to_fix.start_inclusive..range_to_fix_end).into();
+                        debug!("{block_range_to_fix}: fixing: {range_to_fix}");
 
-                            let range_to_fix_end = min(
-                                end_of_chunk_exclusive,
-                                min(end_until_finalized, end_until_last_block_to_fix),
-                            );
+                        self.fix_blocks(&last_finalized, range_to_fix.clone())
+                            .instrument(info_span!("fix"))
+                            .await?;
 
-                            let range_to_fix: BlockRange =
-                                (block_range_to_fix.start_inclusive..range_to_fix_end).into();
-                            debug!("{}: fixing: {}", block_range_to_fix, range_to_fix);
-
-                            self.fix_blocks(&last_finalized, range_to_fix.clone())
-                                .instrument(info_span!("fix"))
-                                .await?;
-
-                            self.remove_blocks_to_fix(range_to_fix).await?
-                        }
+                        self.remove_blocks_to_fix(range_to_fix.clone()).await?;
                     }
-                    Err(IndexerError::NoBlock(_)) => {
-                        info!("{}: no finalized block => retry later", block_range_to_fix);
-                        sleep(Duration::from_millis(1000)).await;
-                    }
-                    Err(error) => {
-                        warn!(
-                            "{}: error finding finalized block ({}) => retry later",
-                            block_range_to_fix, error,
-                        );
-                        sleep(Duration::from_millis(1000)).await;
-                    }
+
+                    Ok(FixerLoopResult::RunAgain)
                 }
-            } else {
-                info!("nothing scheduled to fix => retry later");
-                sleep(Duration::from_millis(1000)).await;
+                Err(IndexerError::NoBlock(_)) => {
+                    info!("{block_range_to_fix}: no block to fix => retry later");
+                    Ok(FixerLoopResult::TryAgainLater)
+                }
+                Err(error) => {
+                    warn!(
+                        "{block_range_to_fix}: error finding block to fix ({error}) => retry later"
+                    );
+                    Err(error)
+                }
             }
+        } else {
+            info!("nothing scheduled to fix => retry later");
+            Ok(FixerLoopResult::TryAgainLater)
         }
     }
 
@@ -89,14 +113,14 @@ impl<T: FetcherClient> Indexer<T> {
             .instrument(info_span!("fix"))
             .await?;
 
-        info!("{}: done", &block_range);
+        info!("{block_range}: done");
 
         Ok(())
     }
 
     async fn fix_block(&self, block: T::BlockHandle) -> Result<(), Report> {
         let reference = block.reference();
-        debug!("{}: fixing", reference);
+        debug!("{reference}: fixing");
 
         let mut tx = self.pg_pool.begin().await?;
 
@@ -107,7 +131,7 @@ impl<T: FetcherClient> Indexer<T> {
 
         tx.commit().await?;
 
-        debug!("{}: fixed", reference);
+        debug!("{reference}: fixed");
 
         Ok(())
     }


### PR DESCRIPTION
there are three indexing flows (for each chain): fetching, finalizing and fixing. The indexer (for a chain) is restarted in case of an error. This is a problem if a chain has rpcs with a high error rate, because the restart kills all transactions.

This PR changes this, so errors in each flow are handled individually.