### PR TITLE
zkgm: better name and symbol handling, and handle decimals

### DIFF
--- a/aptos/ibc/sources/cometbls_lc.move
+++ b/aptos/ibc/sources/cometbls_lc.move
@@ -707,7 +707,7 @@ module ibc::cometbls_lc {
             next_validators_hash: x"0000000000000000000000000000000000000000000000000000000000000000"
         };
 
-        let (cs, cons, _counterparty_channel_id) =
+        let (cs, cons, _counterparty_channel_id, _) =
             create_client(
                 ibc_signer,
                 0,
@@ -734,7 +734,7 @@ module ibc::cometbls_lc {
         client_state.trusting_period = 2;
         consensus_state.timestamp = 20000;
 
-        let (cs, cons, _counterparty_channel_id) =
+        let (cs, cons, _counterparty_channel_id, _) =
             create_client(
                 ibc_signer,
                 2,

--- a/aptos/ucs03-zkgm/sources/fungible_asset_order.move
+++ b/aptos/ucs03-zkgm/sources/fungible_asset_order.move
@@ -73,7 +73,8 @@ module zkgm::fungible_asset_order {
         base_token_name: String,
         base_token_path: u256,
         quote_token: vector<u8>,
-        quote_amount: u256
+        quote_amount: u256,
+        decimals: u8
     }
 
     public fun new(
@@ -85,7 +86,8 @@ module zkgm::fungible_asset_order {
         base_token_name: String,
         base_token_path: u256,
         quote_token: vector<u8>,
-        quote_amount: u256
+        quote_amount: u256,
+        decimals: u8
     ): FungibleAssetOrder {
         FungibleAssetOrder {
             sender,
@@ -96,7 +98,8 @@ module zkgm::fungible_asset_order {
             base_token_name,
             base_token_path,
             quote_token,
-            quote_amount
+            quote_amount,
+            decimals
         }
     }
 
@@ -136,6 +139,10 @@ module zkgm::fungible_asset_order {
         order.quote_amount
     }
 
+    public fun decimals(order: &FungibleAssetOrder): u8 {
+        order.decimals
+    }
+
     public fun encode(order: &FungibleAssetOrder): vector<u8> {
         let buf = vector::empty();
 
@@ -173,6 +180,7 @@ module zkgm::fungible_asset_order {
         // quote_token offset
         zkgm_ethabi::encode_uint<u64>(&mut buf, dyn_offset);
         zkgm_ethabi::encode_uint<u256>(&mut buf, order.quote_amount);
+        zkgm_ethabi::encode_uint<u8>(&mut buf, order.decimals);
 
         vector::append(&mut buf, sender);
         vector::append(&mut buf, receiver);
@@ -195,7 +203,8 @@ module zkgm::fungible_asset_order {
             base_token_name: zkgm_ethabi::decode_string_from_offset(buf, &mut index),
             base_token_path: zkgm_ethabi::decode_uint(buf, &mut index),
             quote_token: zkgm_ethabi::decode_bytes_from_offset(buf, &mut index),
-            quote_amount: zkgm_ethabi::decode_uint(buf, &mut index)
+            quote_amount: zkgm_ethabi::decode_uint(buf, &mut index),
+            decimals: (zkgm_ethabi::decode_uint(buf, &mut index) as u8)
         }
     }
 

--- a/aptos/ucs03-zkgm/sources/token_denom.move
+++ b/aptos/ucs03-zkgm/sources/token_denom.move
@@ -73,8 +73,9 @@ module zkgm::fa_coin {
     use aptos_framework::primary_fungible_store;
     use std::error;
     use std::signer;
-    use std::string::{Self};
+    use std::string::{Self, String};
     use std::option;
+    use std::vector;
 
     /// Only fungible asset metadata owner can make changes.
     const E_NOT_OWNER: u64 = 1;
@@ -112,8 +113,8 @@ module zkgm::fa_coin {
         primary_fungible_store::create_primary_store_enabled_fungible_asset(
             constructor_ref,
             option::none(),
-            name,
-            symbol,
+            sanitize_token_name(name),
+            sanitize_token_symbol(symbol),
             decimals,
             icon,
             project
@@ -179,6 +180,11 @@ module zkgm::fa_coin {
     #[view]
     public fun symbol_with_metadata(asset: Object<Metadata>): string::String {
         fungible_asset::symbol<Metadata>(asset)
+    }
+
+    #[view]
+    public fun decimals_with_metadata(asset: Object<Metadata>): u8 {
+        fungible_asset::decimals<Metadata>(asset)
     }
 
     /// Deposit function override to ensure that the account is not denylisted and the FA coin is not paused.
@@ -317,11 +323,50 @@ module zkgm::fa_coin {
         borrow_global<ManagedFungibleAsset>(object::object_address(&asset))
     }
 
+    public fun sanitize_token_str(name: String, max_len: u64): String {
+        let len = string::length(&name);
+        if (len > max_len) {
+            let token_name = string::sub_string(&name, len - max_len, len);
+            let i = max_len - 1;
+            let bytes = string::bytes(&token_name);
+            while (i > 0) {
+                if (*vector::borrow(bytes, i) == 47 /* '/' */ && i != max_len - 1) {
+                    return string::sub_string(&token_name, i + 1, max_len)
+                };
+                i = i - 1;
+            };
+            token_name
+        } else {
+            name
+        }
+    }
+
+    public fun sanitize_token_name(name: String): String {
+        sanitize_token_str(name, 32)
+    }
+
+    public fun sanitize_token_symbol(symbol: String): String {
+        sanitize_token_str(symbol, 10)
+    }
+
     const TEST_NAME: vector<u8> = b"Test Coin";
     const TEST_SYMBOL: vector<u8> = b"TST";
     const TEST_DECIMALS: u8 = 8;
     const TEST_ICON: vector<u8> = b"https://example.com/icon.png";
     const TEST_PROJECT: vector<u8> = b"Test Project";
+
+    #[test]
+    fun test_sanitize_token_works() {
+        use std::string::utf8;
+        assert!(sanitize_token_name(utf8(b"alesdnleansdf")) == utf8(b"alesdnleansdf"), 1);
+        assert!(sanitize_token_name(utf8(b"verylongverylongverylongverylongverylongverylongverylongverylong")) == utf8(b"verylongverylongverylongverylong"), 2);
+        assert!(sanitize_token_name(utf8(b"factory/union12qdvmw22n72mem0ysff3nlyj2c76cuy4x60lua/clown")) == utf8(b"clown"), 3);
+        assert!(sanitize_token_name(utf8(b"factory/union12qdvmw22n72mem0ysff3nlyj2c76cuy4x60lua/clown/")) == utf8(b"clown/"), 4);
+
+        assert!(sanitize_token_symbol(utf8(b"verylongverylongverylongverylongverylongverylongverylongverylong")) == utf8(b"ngverylong"), 5);
+        assert!(sanitize_token_symbol(utf8(b"factory/union12qdvmw22n72mem0ysff3nlyj2c76cuy4x60lua/clown")) == utf8(b"clown"), 6);
+    }
+
 
     #[test(creator = @0x28873b2d4265e6e14bc0739ef876dce858f06380905279ed090b82d0c75f6e57)]
     public fun test_burn_with_metadata(creator: &signer) acquires ManagedFungibleAsset {

--- a/aptos/ucs03-zkgm/sources/zkgm.move
+++ b/aptos/ucs03-zkgm/sources/zkgm.move
@@ -452,7 +452,8 @@ module zkgm::ibc_app {
                 name,
                 origin,
                 quote_token,
-                quote_amount
+                quote_amount,
+                zkgm::fa_coin::decimals_with_metadata(asset)
             );
         let operand = fungible_asset_order::encode(&fungible_asset_order);
         let zkgm_pack =
@@ -901,24 +902,11 @@ module zkgm::ibc_app {
         let fee =
             fungible_asset_order::base_amount(&order)
                 - fungible_asset_order::quote_amount(&order);
-        // ------------------------------------------------------------------
-        // TODO: no idea if the code below will work lol, it looks promising though
-        // ------------------------------------------------------------------
         if (quote_token == wrapped_address) {
             if (!is_deployed(wrapped_address)) {
                 let token_name = *fungible_asset_order::base_token_name(&order);
                 let token_symbol = *fungible_asset_order::base_token_symbol(&order);
-                // Truncate the name to max 32 characters
-                if (string::length(&token_name) > 32) {
-                    token_name = string::sub_string(&token_name, 0, 32);
-                };
-
-                // Truncate the symbol to max 10 characters
-                if (string::length(&token_symbol) > 10) {
-                    token_symbol = string::sub_string(&token_symbol, 0, 10);
-                };
-
-                deploy_token(salt, token_name, token_symbol, 18);
+                deploy_token(salt, token_name, token_symbol, fungible_asset_order::decimals(&order));
                 let value =
                     update_channel_path(
                         path, ibc::packet::destination_channel_id(&ibc_packet)
@@ -1410,7 +1398,7 @@ module zkgm::ibc_app {
     }
 
     #[test]
-    public fun test_fls() {
+    fun test_fls() {
         assert!(fls(0) == 256, 1);
         assert!(fls(22) == 4, 23);
         assert!(fls(32) == 5, 33);

--- a/cosmwasm/cw20-token-minter/src/contract.rs
+++ b/cosmwasm/cw20-token-minter/src/contract.rs
@@ -286,7 +286,7 @@ pub fn query(deps: Deps, env: Env, msg: QueryMsg) -> Result<Binary, Error> {
 
                 let (name, symbol, decimals) = match denom_metadata {
                     Ok(DenomMetadataResponse { metadata, .. }) => {
-                        let decimals = match metadata.denom_units.get(0) {
+                        let decimals = match metadata.denom_units.first() {
                             Some(unit) => unit.exponent.try_into().unwrap_or(0),
                             None => 0,
                         };

--- a/cosmwasm/ibc-union/app/ucs03-zkgm/src/com.rs
+++ b/cosmwasm/ibc-union/app/ucs03-zkgm/src/com.rs
@@ -1,7 +1,7 @@
 use alloy::{primitives::U256, sol_types::SolValue};
 
-pub const ZKGM_VERSION_0: u8 = 0x00;
-pub const ZKGM_VERSION_1: u8 = 0x01;
+pub const INSTR_VERSION_0: u8 = 0x00;
+pub const INSTR_VERSION_1: u8 = 0x01;
 
 pub const OP_FORWARD: u8 = 0x00;
 pub const OP_MULTIPLEX: u8 = 0x01;
@@ -112,10 +112,10 @@ pub fn decode_fungible_asset(
     instruction: &Instruction,
 ) -> Result<FungibleAssetOrder, alloy::sol_types::Error> {
     match instruction.version {
-        ZKGM_VERSION_0 => {
+        INSTR_VERSION_0 => {
             FungibleAssetOrderV0::abi_decode_params(&instruction.operand, true).map(Into::into)
         }
-        ZKGM_VERSION_1 => FungibleAssetOrder::abi_decode_params(&instruction.operand, true),
+        INSTR_VERSION_1 => FungibleAssetOrder::abi_decode_params(&instruction.operand, true),
         _ => panic!("the protocol must handle an incorrect version"),
     }
 }

--- a/cosmwasm/ucs03-zkgm-token-minter-api/src/lib.rs
+++ b/cosmwasm/ucs03-zkgm-token-minter-api/src/lib.rs
@@ -31,6 +31,7 @@ pub struct Metadata {
     /// symbol is the token symbol usually shown on exchanges (eg: ATOM). This can
     /// be the same as the display.
     pub symbol: String,
+    pub decimals: u8,
 }
 
 #[cw_serde]
@@ -81,6 +82,7 @@ pub enum QueryMsg {
 pub struct MetadataResponse {
     pub name: String,
     pub symbol: String,
+    pub decimals: u8,
 }
 
 #[cw_serde]

--- a/evm/contracts/apps/ucs/03-zkgm/ZkgmERC20.sol
+++ b/evm/contracts/apps/ucs/03-zkgm/ZkgmERC20.sol
@@ -9,9 +9,14 @@ contract ZkgmERC20 is ERC20, IZkgmERC20 {
     address public admin;
     uint8 private _decimals;
 
-    constructor(string memory n, string memory s, address a) ERC20(n, s) {
+    constructor(
+        string memory n,
+        string memory s,
+        address a,
+        uint8 d
+    ) ERC20(n, s) {
         admin = a;
-        _decimals = 18;
+        _decimals = d;
     }
 
     function decimals()


### PR DESCRIPTION
## Decimal
- Add decimals to `FungibleAssetOrder` and make it V1.
- `move` implementation dropped support for `FungibleAssetOrderV0`.
- `cosmwasm` and `evm` implementations are backwards compatible with `FungibleAssetOrderV0`.
- All implementations now default to `FungibleAssetOrderV1` in their `transfer` function.
  
## Token name and symbol
- Fixed a bug where we don't handle minimum lengths in symbols and names in `cw20`.
- Added names and symbols to the `move` impl.