### PR TITLE
Disable external faucets

### DIFF
--- a/app/src/routes/faucet/+page.svelte
+++ b/app/src/routes/faucet/+page.svelte
@@ -276,7 +276,9 @@ const requestUnoFromFaucet = async () => {
   <!-- dydx faucet -->
   <DydxFaucet />
   <StrideFaucet />
+  <!--
   <ChainsGate let:chains>
     <ExternalFaucets {chains} />
   </ChainsGate>
+  !-->
 </main>


### PR DESCRIPTION
they relied on a deprecated assets table
