### PR TITLE
Smooth paginated transfers UI

### DIFF
--- a/app2/src/app.html
+++ b/app2/src/app.html
@@ -1,5 +1,5 @@
 <!doctype html>
-<html lang="en" class="dark dark:bg-zinc-900 dark:text-white">
+<html lang="en" class="dark dark:bg-zinc-950 dark:text-white">
 
 <head>
 	<meta charset="utf-8" />

--- a/app2/src/lib/components/ChainList.svelte
+++ b/app2/src/lib/components/ChainList.svelte
@@ -2,14 +2,19 @@
 import { chains } from "$lib/stores/chains.svelte"
 import { Option } from "effect"
 import ChainComponent from "$lib/components/model/ChainComponent.svelte"
+import Card from "./ui/Card.svelte"
 </script>
 
-{#if Option.isSome(chains.data)}
-  <ul>
-  {#each chains.data.value as chain}
-    <li><ChainComponent {chain}/></li>
-  {/each}
-  </ul>
-{:else}
-  Loading...
-{/if}
+<section class="p-4">
+  <Card>
+    {#if Option.isSome(chains.data)}
+      <ul class="flex flex-col gap-4">
+      {#each chains.data.value as chain}
+        <li><ChainComponent {chain}/></li>
+      {/each}
+      </ul>
+    {:else}
+      Loading...
+    {/if}
+  </Card>
+</section>

--- a/app2/src/lib/components/layout/AppErrors/index.svelte
+++ b/app2/src/lib/components/layout/AppErrors/index.svelte
@@ -8,9 +8,5 @@ import ErrorComponent from "$lib/components/model/ErrorComponent.svelte"
 <div class="max-w-full overflow-auto">
   {#if Option.isSome(chains.error)}
     <ErrorComponent error={chains.error.value}/>
-  {:else}
-    <div class="bg-emerald-500 font-bold m-4 p-4 rounded">
-      Chains data is fresh
-    </div>
   {/if}
 </div>

--- a/app2/src/lib/components/layout/Sidebar/index.svelte
+++ b/app2/src/lib/components/layout/Sidebar/index.svelte
@@ -1,11 +1,13 @@
 <script>
 import ChainList from "$lib/components/ChainList.svelte"
+import Sections from "$lib/components/ui/Sections.svelte"
 import { wallets } from "$lib/stores/wallets.svelte"
 </script>
 
-<div class="p-4 flex flex-col gap-4">
+<Sections>
+  <h1 class="font-extrabold text-3xl uppercase">Union</h1>
   <section>
-    <h2 class="font-bold text-xl m2-4">Transfer</h2>
+    <h2 class="font-bold text-xl">Transfer</h2>
     <ul>
       <li>Transfer</li>
       <li>Swap</li>
@@ -13,23 +15,17 @@ import { wallets } from "$lib/stores/wallets.svelte"
     </ul>
   </section>
   <section>
-    <h2 class="font-bold text-xl m2-4">Explorer</h2>
+    <h2 class="font-bold text-xl">Explorer</h2>
     <ul>
       <li><a href="/" class="underline">Home</a></li>
       <li><a href="/explorer/transfers" class="underline">Transfers</a></li>
-      <li>Packets</li>
-      <li>Connections</li>
-      <li>Channels</li>
+      <li><a href="/explorer/packets" class="underline">Packets</a></li>
+      <li><a href="/explorer/connections" class="underline">Connections</a></li>
+      <li><a href="/explorer/channels" class="underline">Channels</a></li>
     </ul>
   </section>
 
   <section>
-    <h2 class="font-bold text-xl m2-4">Explorer</h2>
-    <ul>
-      <li>Transfers</li>
-      <li>Connections</li>
-      <li>Channels</li>
-    </ul>
-  </section>
   {wallets.evmAddress}
-</div>
+  </section>
+</Sections>

--- a/app2/src/lib/components/layout/Sidebar/index.svelte
+++ b/app2/src/lib/components/layout/Sidebar/index.svelte
@@ -19,9 +19,9 @@ import { wallets } from "$lib/stores/wallets.svelte"
     <ul>
       <li><a href="/" class="underline">Home</a></li>
       <li><a href="/explorer/transfers" class="underline">Transfers</a></li>
-      <li><a href="/explorer/packets" class="underline">Packets</a></li>
-      <li><a href="/explorer/connections" class="underline">Connections</a></li>
-      <li><a href="/explorer/channels" class="underline">Channels</a></li>
+      <!--<li><a href="/explorer/packets" class="underline">Packets</a></li>!-->
+      <!--<li><a href="/explorer/connections" class="underline">Connections</a></li>!-->
+      <!--<li><a href="/explorer/channels" class="underline">Channels</a></li>!-->
     </ul>
   </section>
 

--- a/app2/src/lib/components/model/ChainComponent.svelte
+++ b/app2/src/lib/components/model/ChainComponent.svelte
@@ -8,9 +8,11 @@ let { chain }: Props = $props()
 </script>
 
 <div>
-	<h2 class="text-lg font-bold">{chain.display_name}</h2>
+	<p class="text-md font-bold">{chain.display_name}</p>
+	<!--
 	<div>{chain.chain_id}</div>
 	<div>{chain.testnet}</div>
 	<div>{chain.rpc_type}</div>
 	<div>{JSON.stringify(chain.features)}</div>
+	!-->
 </div>

--- a/app2/src/lib/components/model/ChainComponent.svelte
+++ b/app2/src/lib/components/model/ChainComponent.svelte
@@ -7,7 +7,7 @@ interface Props {
 let { chain }: Props = $props()
 </script>
 
-<div class="p-4">
+<div>
 	<h2 class="text-lg font-bold">{chain.display_name}</h2>
 	<div>{chain.chain_id}</div>
 	<div>{chain.testnet}</div>

--- a/app2/src/lib/components/model/ErrorComponent.svelte
+++ b/app2/src/lib/components/model/ErrorComponent.svelte
@@ -10,7 +10,7 @@ interface Props {
 let { error }: Props = $props()
 </script>
 
-<div class="p-4 rounded m-4 bg-red-500 overflow-auto flex flex-col gap-4">
+<div class="p-4 rounded bg-red-500 overflow-auto flex flex-col gap-4">
   <section>
     <h3 class="text-xl font-bold">{error._tag}</h3>
     <pre>{error.message}</pre>

--- a/app2/src/lib/components/ui/Card.svelte
+++ b/app2/src/lib/components/ui/Card.svelte
@@ -1,0 +1,16 @@
+<script lang="ts">
+import type { Snippet } from "svelte"
+
+// Card.svelte
+type Props = {
+  children: Snippet
+  class?: string
+}
+
+// Define props with default
+const { children, class: className = "" }: Props = $props()
+</script>
+
+<div class="rounded border dark:border-zinc-700 dark:bg-zinc-900 shadow-sm p-4 {className}">
+    {@render children()}
+</div>

--- a/app2/src/lib/components/ui/Card.svelte
+++ b/app2/src/lib/components/ui/Card.svelte
@@ -11,6 +11,6 @@ type Props = {
 const { children, class: className = "" }: Props = $props()
 </script>
 
-<div class="rounded border dark:border-zinc-700 dark:bg-zinc-900 shadow-sm p-4 {className}">
+<div class="rounded border dark:border-zinc-700 dark:bg-zinc-900 shadow-sm {className}">
   {@render children()}
 </div>

--- a/app2/src/lib/components/ui/Label.svelte
+++ b/app2/src/lib/components/ui/Label.svelte
@@ -10,7 +10,4 @@ type Props = {
 // Define props with default
 const { children, class: className = "" }: Props = $props()
 </script>
-
-<div class="flex flex-col gap-4 p-4 md:gap-6 md:p-6 {className}">
-  {@render children()}
-</div>
+<label class="uppercase text-zinc-500 text-xs font-semibold block {className}">{@render children()}</label>

--- a/app2/src/lib/components/ui/Sections.svelte
+++ b/app2/src/lib/components/ui/Sections.svelte
@@ -11,6 +11,6 @@ type Props = {
 const { children, class: className = "" }: Props = $props()
 </script>
 
-<div class="flex felx-col gap-4 p-4 {className}">
+<div class="flex flex-col gap-4 p-4 {className}">
     {@render children()}
 </div>

--- a/app2/src/lib/components/ui/Sections.svelte
+++ b/app2/src/lib/components/ui/Sections.svelte
@@ -11,6 +11,6 @@ type Props = {
 const { children, class: className = "" }: Props = $props()
 </script>
 
-<div class="rounded border dark:border-zinc-700 dark:bg-zinc-900 shadow-sm p-4 {className}">
-  {@render children()}
+<div class="flex felx-col gap-4 p-4 {className}">
+    {@render children()}
 </div>

--- a/app2/src/lib/components/ui/Sections.svelte
+++ b/app2/src/lib/components/ui/Sections.svelte
@@ -11,6 +11,6 @@ type Props = {
 const { children, class: className = "" }: Props = $props()
 </script>
 
-<div class="flex flex-col gap-4 p-4 {className}">
+<div class="flex flex-col gap-4 p-4 md:gap-6 md:p-6 {className}">
     {@render children()}
 </div>

--- a/app2/src/lib/queries/chains.svelte.ts
+++ b/app2/src/lib/queries/chains.svelte.ts
@@ -28,7 +28,7 @@ export let chainsQuery = (environment: Environment) =>
     }
   `),
     variables: { environment },
-    refetchInterval: "5 seconds",
+    refetchInterval: "60 seconds",
     writeData: data => {
       chains.data = data.pipe(Option.map(d => d.v1_ibc_union_chains))
     },

--- a/app2/src/lib/queries/transfer-list.svelte.ts
+++ b/app2/src/lib/queries/transfer-list.svelte.ts
@@ -10,7 +10,7 @@ export let transferListLatestQuery = createQueryGraphql({
   schema: Schema.Struct({ v1_ibc_union_fungible_asset_orders: TransferList }),
   document: graphql(
     `
-    query TransferListLatest @cached(ttl: 1) {
+    query TransferListLatest {
       v1_ibc_union_fungible_asset_orders(
         limit: 20,
         distinct_on: sort_order
@@ -22,7 +22,7 @@ export let transferListLatestQuery = createQueryGraphql({
     [transferListItemFragment]
   ),
   variables: {},
-  refetchInterval: "1 second",
+  refetchInterval: "200 millis",
   writeData: data => {
     transferList.data = data.pipe(Option.map(d => d.v1_ibc_union_fungible_asset_orders))
   },
@@ -31,7 +31,7 @@ export let transferListLatestQuery = createQueryGraphql({
   }
 })
 
-export let transferListPageQuery = (page: typeof SortOrder.Type) =>
+export let transferListPageLtQuery = (page: typeof SortOrder.Type) =>
   createQueryGraphql({
     schema: Schema.Struct({ v1_ibc_union_fungible_asset_orders: TransferList }),
     document: graphql(

--- a/app2/src/lib/queries/transfer-list.svelte.ts
+++ b/app2/src/lib/queries/transfer-list.svelte.ts
@@ -4,7 +4,7 @@ import { graphql } from "gql.tada"
 import { transferList } from "$lib/stores/transfers.svelte"
 import { transferListItemFragment } from "$lib/queries/fragments/transfer-list-item"
 import { TransferList } from "$lib/schema/transfer-list"
-import { SortOrder } from "$lib/schema/sort-order"
+import type { SortOrder } from "$lib/schema/sort-order"
 
 export let transferListLatestQuery = createQueryGraphql({
   schema: Schema.Struct({ v1_ibc_union_fungible_asset_orders: TransferList }),
@@ -13,6 +13,7 @@ export let transferListLatestQuery = createQueryGraphql({
     query TransferListLatest @cached(ttl: 1) {
       v1_ibc_union_fungible_asset_orders(
         limit: 20,
+        distinct_on: sort_order
         order_by: { sort_order: desc_nulls_last}) {
       ...TransferListItem
       }
@@ -38,8 +39,10 @@ export let transferListPageQuery = (page: typeof SortOrder.Type) =>
     query TransferListPage($page: String!) @cached(ttl: 30) {
       v1_ibc_union_fungible_asset_orders(
         limit: 20,
-        where: {sort_order: {_lt: $page}}
-        order_by: { sort_order: desc_nulls_last}) {
+        distinct_on: sort_order
+        where: {sort_order: {_lt: $page}},
+        order_by: {sort_order: desc_nulls_last}
+      ) {
       ...TransferListItem
       }
     }
@@ -50,6 +53,36 @@ export let transferListPageQuery = (page: typeof SortOrder.Type) =>
     refetchInterval: "30 seconds",
     writeData: data => {
       transferList.data = data.pipe(Option.map(d => d.v1_ibc_union_fungible_asset_orders))
+    },
+    writeError: error => {
+      transferList.error = error
+    }
+  })
+
+export let transferListPageGtQuery = (page: typeof SortOrder.Type) =>
+  createQueryGraphql({
+    schema: Schema.Struct({ v1_ibc_union_fungible_asset_orders: TransferList }),
+    document: graphql(
+      `
+    query TransferListPage($page: String!) @cached(ttl: 30) {
+      v1_ibc_union_fungible_asset_orders(
+        limit: 20,
+        distinct_on: sort_order
+        where: {sort_order: {_gt: $page}},
+        order_by: {sort_order: asc_nulls_last}
+      ) {
+      ...TransferListItem
+      }
+    }
+  `,
+      [transferListItemFragment]
+    ),
+    variables: { page },
+    refetchInterval: "30 seconds",
+    writeData: data => {
+      transferList.data = data.pipe(
+        Option.map(d => d.v1_ibc_union_fungible_asset_orders.toReversed())
+      )
     },
     writeError: error => {
       transferList.error = error

--- a/app2/src/lib/queries/transfer-list.svelte.ts
+++ b/app2/src/lib/queries/transfer-list.svelte.ts
@@ -4,12 +4,13 @@ import { graphql } from "gql.tada"
 import { transferList } from "$lib/stores/transfers.svelte"
 import { transferListItemFragment } from "$lib/queries/fragments/transfer-list-item"
 import { TransferList } from "$lib/schema/transfer-list"
+import { SortOrder } from "$lib/schema/sort-order"
 
 export let transferListLatestQuery = createQueryGraphql({
   schema: Schema.Struct({ v1_ibc_union_fungible_asset_orders: TransferList }),
   document: graphql(
     `
-    query TransferList @cached(ttl: 1) {
+    query TransferListLatest @cached(ttl: 1) {
       v1_ibc_union_fungible_asset_orders(
         limit: 20,
         order_by: { sort_order: desc_nulls_last}) {
@@ -28,3 +29,29 @@ export let transferListLatestQuery = createQueryGraphql({
     transferList.error = error
   }
 })
+
+export let transferListPageQuery = (page: typeof SortOrder.Type) =>
+  createQueryGraphql({
+    schema: Schema.Struct({ v1_ibc_union_fungible_asset_orders: TransferList }),
+    document: graphql(
+      `
+    query TransferListPage($page: String!) @cached(ttl: 30) {
+      v1_ibc_union_fungible_asset_orders(
+        limit: 20,
+        where: {sort_order: {_lt: $page}}
+        order_by: { sort_order: desc_nulls_last}) {
+      ...TransferListItem
+      }
+    }
+  `,
+      [transferListItemFragment]
+    ),
+    variables: { page },
+    refetchInterval: "30 seconds",
+    writeData: data => {
+      transferList.data = data.pipe(Option.map(d => d.v1_ibc_union_fungible_asset_orders))
+    },
+    writeError: error => {
+      transferList.error = error
+    }
+  })

--- a/app2/src/lib/schema/chain.ts
+++ b/app2/src/lib/schema/chain.ts
@@ -1,4 +1,4 @@
-import { Schema } from "effect"
+import { Option, Schema } from "effect"
 
 export const ChainId = Schema.String.pipe(Schema.brand("ChainId"))
 export const ChainDisplayName = Schema.String.pipe(Schema.brand("ChainDisplayName"))
@@ -28,3 +28,8 @@ export class Chain extends Schema.Class<Chain>("Chain")({
 }) {}
 
 export const Chains = Schema.Array(Chain)
+
+export const getChain = (
+  chains: typeof Chains.Type,
+  chainId: typeof ChainId.Type
+): Option.Option<Chain> => Option.fromNullable(chains.find(chain => chain.chain_id === chainId))

--- a/app2/src/routes/+layout.svelte
+++ b/app2/src/routes/+layout.svelte
@@ -21,7 +21,7 @@ onMount(() => {
   </aside>
   
   <!-- Main content area: Has margin to clear fixed sidebar -->
-  <main class="col-start-2 ml-64 max-w-[calc(100vw - calc(var(--spacing)*64))] overflow-hidden">
+  <main class="col-start-2 ml-64 max-w-[calc(100vw-calc(var(--spacing)*64))]">
     <AppErrors/>
     {@render children()}
   </main>

--- a/app2/src/routes/+layout.svelte
+++ b/app2/src/routes/+layout.svelte
@@ -16,7 +16,7 @@ onMount(() => {
 </script>
 
 <div class="grid grid-cols-[auto_1fr] min-h-[100svh] w-screen">
-  <aside class="fixed top-0 left-0 bottom-0 w-64 dark:bg-zinc-800 shadow overflow-auto">
+  <aside class="fixed top-0 left-0 bottom-0 w-64 dark:bg-zinc-900 shadow overflow-auto">
     <Sidebar/>
   </aside>
   

--- a/app2/src/routes/explorer/transfers/+page.svelte
+++ b/app2/src/routes/explorer/transfers/+page.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
 import { transferListLatestQuery } from "$lib/queries/transfer-list.svelte"
-import { Effect, Fiber, Option } from "effect"
+import { DateTime, Effect, Fiber, Option } from "effect"
 import { onMount } from "svelte"
 import { transferList } from "$lib/stores/transfers.svelte"
 import ErrorComponent from "$lib/components/model/ErrorComponent.svelte"
@@ -9,6 +9,7 @@ import Sections from "$lib/components/ui/Sections.svelte"
 import { chains } from "$lib/stores/chains.svelte"
 import { getChain } from "$lib/schema/chain"
 import ChainComponent from "$lib/components/model/ChainComponent.svelte"
+import Label from "$lib/components/ui/Label.svelte"
 
 onMount(() => {
   const fiber = Effect.runFork(transferListLatestQuery)
@@ -27,19 +28,20 @@ onMount(() => {
         {@const destinationChain = getChain(chainss, transfer.destination_chain_id)}
         <div class="flex gap-8 px-4 py-2 flex-cols-3">
           <div class="flex-1">
-            <p class="uppercase text-zinc-500 text-xs font-semibold">from</p>
+            <Label>from</Label>
             {#if Option.isSome(sourceChain)}
               <ChainComponent chain={sourceChain.value}/>
             {/if}
           </div>
           <div class="flex-1">
-            <p class="uppercase text-zinc-500 text-xs font-semibold">to</p>
+            <Label>to</Label>
             {#if Option.isSome(destinationChain)}
               <ChainComponent chain={destinationChain.value}/>
             {/if}
           </div>
           <div class="flex-1">
-            yeah
+            <Label>Time</Label>
+            {DateTime.formatIso(transfer.packet_send_timestamp)}
           </div>
         </div>
       {/each}

--- a/app2/src/routes/explorer/transfers/+page.svelte
+++ b/app2/src/routes/explorer/transfers/+page.svelte
@@ -4,6 +4,8 @@ import { Effect, Fiber, Option } from "effect"
 import { onMount } from "svelte"
 import { transferList } from "$lib/stores/transfers.svelte"
 import ErrorComponent from "$lib/components/model/ErrorComponent.svelte"
+import Card from "$lib/components/ui/Card.svelte"
+import Sections from "$lib/components/ui/Sections.svelte"
 
 onMount(() => {
   const fiber = Effect.runFork(transferListLatestQuery)
@@ -12,17 +14,18 @@ onMount(() => {
 </script>
 
 
-{#if Option.isSome(transferList.data)}
-  <pre>{JSON.stringify(transferList.data.value, null,2)}</pre>
-  {#if Option.isSome(transferList.error)}
-    <ErrorComponent error={transferList.error.value}/>
-  {/if}
-{:else}
-  Loading...
-  {#if Option.isSome(transferList.error)}
-    <ErrorComponent error={transferList.error.value}/>
-  {/if}
-{/if}
-
-
-
+<Sections>
+  <Card class="overflow-auto">
+    {#if Option.isSome(transferList.data)}
+      <pre>{JSON.stringify(transferList.data.value, null,2)}</pre>
+      {#if Option.isSome(transferList.error)}
+        <ErrorComponent error={transferList.error.value}/>
+      {/if}
+    {:else}
+      Loading...
+      {#if Option.isSome(transferList.error)}
+        <ErrorComponent error={transferList.error.value}/>
+      {/if}
+    {/if}
+  </Card>
+</Sections>

--- a/app2/src/routes/explorer/transfers/+page.svelte
+++ b/app2/src/routes/explorer/transfers/+page.svelte
@@ -58,4 +58,15 @@ onMount(() => {
       {/if}
     {/if}
   </Card>
+  <div class="flex rounded overflow-clip">
+    <button class="border-l border-t border-b bg-zinc-700 border-zinc-600 h-10 w-10 rounded-tl rounded-bl">
+      ←
+    </button>
+    <div class="bg-zinc-900 border-t border-b border-zinc-800 flex items-center px-4">
+      Current
+    </div>
+    <button class="border-r border-t border-b bg-zinc-700 border-zinc-600 h-10 w-10 rounded-tr rounded-br">
+      →
+    </button>
+  </div>
 </Sections>

--- a/app2/src/routes/explorer/transfers/+page.svelte
+++ b/app2/src/routes/explorer/transfers/+page.svelte
@@ -6,6 +6,9 @@ import { transferList } from "$lib/stores/transfers.svelte"
 import ErrorComponent from "$lib/components/model/ErrorComponent.svelte"
 import Card from "$lib/components/ui/Card.svelte"
 import Sections from "$lib/components/ui/Sections.svelte"
+import { chains } from "$lib/stores/chains.svelte"
+import { getChain } from "$lib/schema/chain"
+import ChainComponent from "$lib/components/model/ChainComponent.svelte"
 
 onMount(() => {
   const fiber = Effect.runFork(transferListLatestQuery)
@@ -15,9 +18,27 @@ onMount(() => {
 
 
 <Sections>
-  <Card class="overflow-auto">
-    {#if Option.isSome(transferList.data)}
-      <pre>{JSON.stringify(transferList.data.value, null,2)}</pre>
+  <Card class="overflow-auto p-0 divide-y divide-zinc-800">
+    {#if Option.isSome(transferList.data) && Option.isSome(chains.data)}
+      {@const chainss = chains.data.value}
+      {#each transferList.data.value as transfer}
+        {@const sourceChain = getChain(chainss, transfer.source_chain_id)}
+        {@const destinationChain = getChain(chainss, transfer.destination_chain_id)}
+        <div class="flex gap-8 px-4 py-2">
+          <div>
+            <p class="uppercase text-zinc-500 text-xs font-semibold">from</p>
+            {#if Option.isSome(sourceChain)}
+              <ChainComponent chain={sourceChain.value}/>
+            {/if}
+          </div>
+          <div>
+            <p class="uppercase text-zinc-500 text-xs font-semibold">to</p>
+            {#if Option.isSome(destinationChain)}
+              <ChainComponent chain={destinationChain.value}/>
+            {/if}
+          </div>
+        </div>
+      {/each}
       {#if Option.isSome(transferList.error)}
         <ErrorComponent error={transferList.error.value}/>
       {/if}

--- a/app2/src/routes/explorer/transfers/+page.svelte
+++ b/app2/src/routes/explorer/transfers/+page.svelte
@@ -50,8 +50,7 @@ onMount(() => {
       {/if}
     {:else}
       {#each [1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20]}
-        <div class="h-[57px] p-4">
-        </div>
+        <div class="h-[57px] last:h-[56px]"></div>
       {/each}
       {#if Option.isSome(transferList.error)}
         <ErrorComponent error={transferList.error.value}/>

--- a/app2/src/routes/explorer/transfers/+page.svelte
+++ b/app2/src/routes/explorer/transfers/+page.svelte
@@ -18,24 +18,28 @@ onMount(() => {
 
 
 <Sections>
+  <h1 class="font-bold text-4xl">Transfers</h1>
   <Card class="overflow-auto p-0 divide-y divide-zinc-800">
     {#if Option.isSome(transferList.data) && Option.isSome(chains.data)}
       {@const chainss = chains.data.value}
       {#each transferList.data.value as transfer}
         {@const sourceChain = getChain(chainss, transfer.source_chain_id)}
         {@const destinationChain = getChain(chainss, transfer.destination_chain_id)}
-        <div class="flex gap-8 px-4 py-2">
-          <div>
+        <div class="flex gap-8 px-4 py-2 flex-cols-3">
+          <div class="flex-1">
             <p class="uppercase text-zinc-500 text-xs font-semibold">from</p>
             {#if Option.isSome(sourceChain)}
               <ChainComponent chain={sourceChain.value}/>
             {/if}
           </div>
-          <div>
+          <div class="flex-1">
             <p class="uppercase text-zinc-500 text-xs font-semibold">to</p>
             {#if Option.isSome(destinationChain)}
               <ChainComponent chain={destinationChain.value}/>
             {/if}
+          </div>
+          <div class="flex-1">
+            yeah
           </div>
         </div>
       {/each}
@@ -43,7 +47,10 @@ onMount(() => {
         <ErrorComponent error={transferList.error.value}/>
       {/if}
     {:else}
-      Loading...
+      {#each [1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20]}
+        <div class="h-[57px] p-4">
+        </div>
+      {/each}
       {#if Option.isSome(transferList.error)}
         <ErrorComponent error={transferList.error.value}/>
       {/if}

--- a/app2/src/routes/explorer/transfers/+page.svelte
+++ b/app2/src/routes/explorer/transfers/+page.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-import { transferListLatestQuery } from "$lib/queries/transfer-list.svelte"
+import { transferListLatestQuery, transferListPageQuery } from "$lib/queries/transfer-list.svelte"
 import { DateTime, Effect, Fiber, Option } from "effect"
 import { onMount } from "svelte"
 import { transferList } from "$lib/stores/transfers.svelte"
@@ -11,10 +11,21 @@ import { getChain } from "$lib/schema/chain"
 import ChainComponent from "$lib/components/model/ChainComponent.svelte"
 import Label from "$lib/components/ui/Label.svelte"
 
+let fiber: Fiber.Fiber
+
 onMount(() => {
-  const fiber = Effect.runFork(transferListLatestQuery)
+  fiber = Effect.runFork(transferListLatestQuery)
   return () => Effect.runPromise(Fiber.interrupt(fiber))
 })
+
+const onNextPage = async () => {
+  if (Option.isSome(transferList.data)) {
+    let lastSortOrder = transferList.data.value.at(-1)?.sort_order
+    if (!lastSortOrder) return
+    await Effect.runPromise(Fiber.interrupt(fiber))
+    fiber = Effect.runFork(transferListPageQuery(lastSortOrder))
+  }
+}
 </script>
 
 
@@ -23,10 +34,10 @@ onMount(() => {
   <Card class="overflow-auto p-0 divide-y divide-zinc-800">
     {#if Option.isSome(transferList.data) && Option.isSome(chains.data)}
       {@const chainss = chains.data.value}
-      {#each transferList.data.value as transfer}
+      {#each transferList.data.value as transfer, index (transfer)}
         {@const sourceChain = getChain(chainss, transfer.source_chain_id)}
         {@const destinationChain = getChain(chainss, transfer.destination_chain_id)}
-        <div class="flex gap-8 px-4 py-2 flex-cols-3">
+        <div class="flex gap-8 px-4 py-2 flex-cols-3" animate:flip>
           <div class="flex-1">
             <Label>from</Label>
             {#if Option.isSome(sourceChain)}
@@ -57,15 +68,17 @@ onMount(() => {
       {/if}
     {/if}
   </Card>
-  <div class="flex rounded overflow-clip">
-    <button class="border-l border-t border-b bg-zinc-700 border-zinc-600 h-10 w-10 rounded-tl rounded-bl">
-      ←
-    </button>
-    <div class="bg-zinc-900 border-t border-b border-zinc-800 flex items-center px-4">
-      Current
+  <div class="flex">
+    <div class="rounded shadow flex">
+      <button class="cursor-pointer border-l border-t border-b bg-zinc-700 border-zinc-600 h-10 w-10 rounded-tl rounded-bl">
+        ←
+      </button>
+      <div class="bg-zinc-900 border-t border-b border-zinc-800 flex items-center px-4">
+        Current
+      </div>
+      <button onclick={onNextPage} class="cursor-pointer border-r border-t border-b bg-zinc-700 border-zinc-600 h-10 w-10 rounded-tr rounded-br">
+        →
+      </button>
     </div>
-    <button class="border-r border-t border-b bg-zinc-700 border-zinc-600 h-10 w-10 rounded-tr rounded-br">
-      →
-    </button>
   </div>
 </Sections>


### PR DESCRIPTION
I'll have to think of how to make the pagination more generic and DRY, but getting this merged so that we have a transfers list to experiment with.

- **feat(app2): introduce card component**
- **fix(app): layout overflow issue, introduce sections**
- **feat(app): fetch transfer and show details**
- **feat(app2): load transfers with skeletons**
- **feat(app): better transfers layout**
- **feat(app2): pagination controler**
- **fix(app2): transfers layout shift**
- **feat(app): implement pagination**
- **feat(app): paginate forwards and backwards**
- **feat(app): live, next, prev pages**
