### PR TITLE
chore: fix semantic expression of BLS cryptography

### DIFF
--- a/docs/src/content/docs/architecture/cometbls.mdx
+++ b/docs/src/content/docs/architecture/cometbls.mdx
@@ -19,7 +19,7 @@ These improvements will decrease proving times even further, leading to faster b
 
 Boneh–Lynn–Shacham (BLS) signatures form the foundation of CometBLS.
 They are cheaper to verify for both regular IBC and zero-knowledge proof (zkp) based IBC.
-With BLS signatures, we can aggregate the public keys and the signatures, and verify the aggregated signature with the aggregated private key.
+With BLS signatures, we can aggregate the public keys and the signatures, and verify the aggregated signature with the aggregated public key.
 This has a few advantages:
 
 - Transaction size decreases compared to ECDSA verification. We do not need to transfer all signatures, just the aggregate.

--- a/docs/src/content/docs/concepts/bls-signatures.mdx
+++ b/docs/src/content/docs/concepts/bls-signatures.mdx
@@ -4,7 +4,7 @@ title: BLS Signatures
 
 Boneh–Lynn–Shacham (BLS) signatures form the foundation of [CometBLS](/architecture/cometbls).
 They are cheaper to verify for both regular [IBC](/concepts/ibc) and zero-knowledge proof (ZKP) based IBC.
-With BLS signatures, we can aggregate the public keys and the signatures and verify the aggregated signature with the aggregated private key.
+With BLS signatures, we can aggregate the public keys and the signatures and verify the aggregated signature with the aggregated public key.
 BLS signature aggregation has a few advantages:
 
 - Transaction size decreases compared to ECDSA verification. We do not need to transfer all signatures, just the aggregate.


### PR DESCRIPTION
The expression of BLS signatures and verifications is wrong and make them correct.