### PR TITLE
fix: deprecated #[clap] attributes with #[arg] and #[command]

### DIFF
--- a/tools/devnet-utils/src/main.rs
+++ b/tools/devnet-utils/src/main.rs
@@ -4,15 +4,15 @@ use clap::{Parser, Subcommand};
 use unionlabs::primitives::{H160, H256};
 
 #[derive(Parser)]
-#[clap(arg_required_else_help = true)]
+#[command(arg_required_else_help = true)]
 struct App {
-    #[clap(subcommand)]
+    #[command(subcommand)]
     command: Cmd,
 }
 
 #[derive(Subcommand)]
 enum Cmd {
-    #[clap(subcommand)]
+    #[command(subcommand)]
     Keygen(KeygenCmd),
     #[command(subcommand)]
     Compute(ComputeCmd),


### PR DESCRIPTION
This PR updates deprecated `#[clap(...)]` attributes to their modern equivalents in `clap` 4.x.
The current codebase still uses outdated syntax that has been deprecated since version 4.0.
By making this update, we ensure compatibility with future versions and maintain code quality.