### PR TITLE
zkgm improvements / ibc-union upgrade

### DIFF
--- a/cosmwasm/ibc-union/core/src/lib.rs
+++ b/cosmwasm/ibc-union/core/src/lib.rs
@@ -87,6 +87,11 @@ pub enum ContractError {
     TimeoutHeightNotReached,
     #[error("{} channel ({0}) does not exist", ContractErrorKind::from(self))]
     ChannelNotExist(u32),
+    #[error(
+        "{} packet has been already acknowledged",
+        ContractErrorKind::from(self)
+    )]
+    PacketAlreadyAcknowledged,
     #[error("{} packet commitment not found", ContractErrorKind::from(self))]
     PacketCommitmentNotFound,
     #[error(

--- a/cosmwasm/ibc-union/core/src/tests/client/ibc.rs
+++ b/cosmwasm/ibc-union/core/src/tests/client/ibc.rs
@@ -150,6 +150,7 @@ fn update_client_ok() {
                     client_state: vec![3, 2, 1].into(),
                 })
             }
+            LightClientQueryMsg::GetStatus { .. } => to_json_binary(&Status::Active),
             msg => panic!("should not be called: {:?}", msg),
         }));
 
@@ -195,6 +196,7 @@ fn update_client_ko() {
                 events: None,
             }),
             LightClientQueryMsg::VerifyClientMessage { .. } => to_json_binary(&0),
+            LightClientQueryMsg::GetStatus { .. } => to_json_binary(&Status::Active),
             msg => panic!("should not be called: {:?}", msg),
         }));
 
@@ -246,6 +248,7 @@ fn update_client_commitments_saved() {
                     client_state: vec![3, 2, 1].into(),
                 })
             }
+            LightClientQueryMsg::GetStatus { .. } => to_json_binary(&Status::Active),
             msg => panic!("should not be called: {:?}", msg),
         }));
 

--- a/evm/contracts/apps/ucs/00-pingpong/PingPong.sol
+++ b/evm/contracts/apps/ucs/00-pingpong/PingPong.sol
@@ -26,7 +26,13 @@ library PingPongLib {
     event Ring(bool ping);
     event TimedOut();
     event Acknowledged();
-    event Zkgoblim(uint32 channelId, bytes sender, bytes message);
+    event Zkgoblim(
+        uint256 path,
+        uint32 sourceChannelId,
+        uint32 destinationChannelId,
+        bytes sender,
+        bytes message
+    );
 
     function encode(
         PingPongPacket memory packet
@@ -204,13 +210,17 @@ contract PingPong is
     }
 
     function onZkgm(
-        uint32 channelId,
+        uint256 path,
+        uint32 sourceChannelId,
+        uint32 destinationChannelId,
         bytes calldata sender,
         bytes calldata message
     ) public {
         if (msg.sender != zkgmProtocol) {
             revert PingPongLib.ErrOnlyZKGM();
         }
-        emit PingPongLib.Zkgoblim(channelId, sender, message);
+        emit PingPongLib.Zkgoblim(
+            path, sourceChannelId, destinationChannelId, sender, message
+        );
     }
 }

--- a/evm/contracts/apps/ucs/03-zkgm/IEurekaModule.sol
+++ b/evm/contracts/apps/ucs/03-zkgm/IEurekaModule.sol
@@ -2,7 +2,9 @@ pragma solidity ^0.8.27;
 
 interface IEurekaModule {
     function onZkgm(
-        uint32 channelId,
+        uint256 path,
+        uint32 sourceChannelId,
+        uint32 destinationChannelId,
         bytes calldata sender,
         bytes calldata message
     ) external;

--- a/evm/contracts/core/Types.sol
+++ b/evm/contracts/core/Types.sol
@@ -53,6 +53,7 @@ library IBCErrors {
     error ErrPacketNotReceived();
     error ErrAcknowledgementAlreadyExists();
     error ErrPacketCommitmentNotFound();
+    error ErrPacketAlreadyAcknowledged();
     error ErrTimeoutHeightNotReached();
     error ErrTimeoutTimestampNotReached();
     error ErrNotEnoughPackets();

--- a/evm/tests/src/04-channel/IBCPacket.t.sol
+++ b/evm/tests/src/04-channel/IBCPacket.t.sol
@@ -669,7 +669,7 @@ contract IBCPacketTests is Test {
         handler.acknowledgePacket(msg_);
     }
 
-    function test_acknowledgePacket_commitmentRemoved(
+    function test_acknowledgePacket_commitmentMarked(
         uint32 destinationChannel,
         bytes calldata message,
         uint8 nbPackets
@@ -690,7 +690,7 @@ contract IBCPacketTests is Test {
                         IBCPacketLib.commitPacketMemory(msg_.packets[i])
                     )
                 ),
-                IBCPacketLib.COMMITMENT_NULL
+                IBCPacketLib.COMMITMENT_MAGIC_ACK
             );
         }
     }
@@ -755,7 +755,7 @@ contract IBCPacketTests is Test {
         return msg_;
     }
 
-    function test_timeoutPacket_timestamp_commitmentRemoved(
+    function test_timeoutPacket_timestamp_commitmentMarked(
         uint32 destinationChannel,
         bytes calldata message,
         uint32 timestamp,
@@ -770,7 +770,7 @@ contract IBCPacketTests is Test {
                     channelId, IBCPacketLib.commitPacketMemory(msg_.packet)
                 )
             ),
-            IBCPacketLib.COMMITMENT_NULL
+            IBCPacketLib.COMMITMENT_MAGIC_ACK
         );
     }
 
@@ -853,7 +853,7 @@ contract IBCPacketTests is Test {
                     channelId, IBCPacketLib.commitPacketMemory(msg_.packet)
                 )
             ),
-            IBCPacketLib.COMMITMENT_NULL
+            IBCPacketLib.COMMITMENT_MAGIC_ACK
         );
     }
 

--- a/lib/ibc-union-spec/src/path.rs
+++ b/lib/ibc-union-spec/src/path.rs
@@ -16,6 +16,13 @@ pub const COMMITMENT_MAGIC: H256 = {
     H256::new(bz)
 };
 
+/// 0x0200000000000000000000000000000000000000000000000000000000000000
+pub const COMMITMENT_MAGIC_ACK: H256 = {
+    let mut bz = [0; 32];
+    bz[0] = 2;
+    H256::new(bz)
+};
+
 pub const COMMITMENT_NULL: H256 = H256::new([0; 32]);
 
 pub const CLIENT_STATE: U256 = U256::from_limbs([0, 0, 0, 0]);


### PR DESCRIPTION
Improve zkgm handling of forward in-flight packet check by masking the forwarded salt and checking it (avoids 2 sload in ack/timeout if the packet isn't a forward (100% of current packets).

Introduce the `path` and `source`/`destination` channel on multiplexed calls for the target protocol to have the full packet context when being executed.

Upgrade IBC-Union to prevent ack replay (fixes #3794).