### PR TITLE
fix(zkgm): revert batch if any instruction require a market maker

### DIFF
--- a/cosmwasm/ibc-union/app/ucs03-zkgm/src/lib.rs
+++ b/cosmwasm/ibc-union/app/ucs03-zkgm/src/lib.rs
@@ -99,4 +99,6 @@ pub enum ContractError {
     InvalidForwardInstruction,
     #[error("invalid multiplex sender")]
     InvalidMultiplexSender,
+    #[error("async acknowledgements are not allowed in batches as they are atomic")]
+    BatchMustBeSync,
 }

--- a/cosmwasm/ibc-union/app/ucs03-zkgm/src/state.rs
+++ b/cosmwasm/ibc-union/app/ucs03-zkgm/src/state.rs
@@ -27,7 +27,7 @@ pub const EXECUTING_PACKET: Item<Packet> = Item::new("executing_packet");
 
 /// Flag to indicate that the currently executing packet is a batch.
 /// This is used to determine how to handle acknowledgements in the reply handler.
-pub const EXECUTING_PACKET_IS_BATCH: Item<()> = Item::new("executing_packet_is_batch");
+pub const EXECUTING_PACKET_IS_BATCH: Item<usize> = Item::new("executing_packet_is_batch");
 
 /// Temporarily stores the acknowledgement from packet execution.
 /// This is used to retrieve the acknowledgement in the reply handler.


### PR DESCRIPTION
Also add some assertions on the batch acknowledgements to make sure upgrades don't break the semantic.