### PR TITLE
fix(ibc-union): ensure batches share the same channel

### DIFF
--- a/evm/tests/src/core/IBCHandler.sol
+++ b/evm/tests/src/core/IBCHandler.sol
@@ -4,7 +4,6 @@ import "../../../contracts/core/25-handler/IBCHandler.sol";
 
 contract TestIBCHandler is IBCHandler {
     function assumePacketSent(
-        uint32 channel,
         IBCPacket calldata packet
     ) public {
         commitments[IBCCommitment.batchPacketsCommitmentKey(


### PR DESCRIPTION
- ensure that the batched packets share the same channel, avoiding a malicious client from accepting a batch that would result in arbitrary packets indexed at i+1 to be accepted by the protocol