### PR TITLE
fix(zkgm): better zkgm forward salt tinting

### DIFF
--- a/evm/tests/src/05-app/Zkgm.t.sol
+++ b/evm/tests/src/05-app/Zkgm.t.sol
@@ -613,12 +613,15 @@ contract ZkgmTests is Test {
     function test_tintForwardSalt_ok(
         bytes32 salt
     ) public {
-        vm.assume(
-            salt
-                < 0xffff000000000000000000000000000000000000000000000000000000000000
-        );
+        salt = bytes32(salt >> 8);
         assertFalse(ZkgmLib.isForwardedPacket(salt));
         assertTrue(ZkgmLib.isForwardedPacket(ZkgmLib.tintForwardSalt(salt)));
+    }
+
+    function test_tintForwardSalt_ok_2() public {
+        test_tintForwardSalt_ok(
+            0xdefe464db3fcf737aba09147ad0258e1f0913e3633c065053e744057b42dfefe
+        );
     }
 
     function test_onChanOpenInit_ok(


### PR DESCRIPTION
Due to hash properties, the forward tinting mechanism has false positive but no false negative. Avoid the false positive by forcing the salt to be not tinted in tests.