### PR TITLE
fix: correct condition in Tendermint's query_latest_timestamp

### DIFF
--- a/voyager/modules/consensus/tendermint/src/main.rs
+++ b/voyager/modules/consensus/tendermint/src/main.rs
@@ -130,7 +130,7 @@ impl ConsensusModuleServer for Module {
             .await
             .map_err(json_rpc_error_to_error_object)?;
 
-        if finalized && commit_response.canonical {
+        if finalized && !commit_response.canonical {
             trace!(
                 "commit is not canonical and finalized timestamp was \
                 requested, fetching commit at previous block"


### PR DESCRIPTION
## Title

Fix logical discrepancy in Tendermint consensus module's timestamp query

## Description
While studying the Union project's implementation of various consensus modules, I noticed a logical discrepancy in the Tendermint module's implementation of `query_latest_timestamp`.

The current implementation has a condition that contradicts the log message and the intended behavior. The code currently reads:

```rust
if finalized && commit_response.canonical {
    trace!(
        "commit is not canonical and finalized timestamp was \\
        requested, fetching commit at previous block"
    );
    // ... fetch previous block logic ...
}

```

This is inconsistent with the log message which states "commit is not canonical" while the condition checks if it IS canonical. This also contradicts the implementation of `latest_height` which correctly uses:

```rust
if finalized && !commit_response.canonical {
    trace!(
        "commit is not canonical and finalized height was requested, \\
        latest finalized height is the previous block"
    );
    height -= 1;
}

```

This PR fixes the condition to match the intended behavior by changing to `!commit_response.canonical` in the timestamp query method.

### Impact

The current implementation would fetch the previous block when:

1. The user requests a finalized timestamp (`finalized=true`)
2. The current block IS canonical (`commit_response.canonical=true`)

This is incorrect because when a block is already canonical, there's no need to fetch the previous block. The fix ensures we only fetch the previous block when the current block is NOT canonical, which aligns with the behavior of `latest_height`.

BTW I'd like to mention that this is my first contribution to the Union project. I'm excited to help improve the codebase and would appreciate any feedback or guidance on this PR.