### PR TITLE
chore(app2,ts-sdk): cleanup static analysis #1

### DIFF
--- a/app2/src/lib/components/model/TransferListItemComponent.svelte
+++ b/app2/src/lib/components/model/TransferListItemComponent.svelte
@@ -38,7 +38,7 @@ const handleClick = () => {
     onclick={handleClick}
   >
     <div>
-      {#if Option.isSome(sourceChain)}
+      {#if Option.isSome(sourceChain) && Option.isSome(destinationChain)}
         <TokenComponent
           showWrapping={false}
           chain={destinationChain.value}

--- a/app2/src/lib/services/aptos/balances.ts
+++ b/app2/src/lib/services/aptos/balances.ts
@@ -57,7 +57,7 @@ export const fetchAptosBalance = ({
   tokenAddress: TokenRawDenom
   walletAddress: string
 }) => {
-  return Effect.gen(function* (_) {
+  return Effect.gen(function* () {
     const aptosClient = yield* getPublicClient(chain)
 
     yield* Effect.log(

--- a/app2/src/lib/services/aptos/clients.ts
+++ b/app2/src/lib/services/aptos/clients.ts
@@ -27,12 +27,12 @@ export const getPublicClient = (chain: Chain) =>
     if (chain.rpc_type !== "aptos") {
       throw new NoAptosChainError({ chain })
     }
-    const rpcUrl = chain.getRpcUrl("rpc")
+    const rpcUrl = yield* chain.getRpcUrl("rpc")
     yield* Effect.log("rpcUrl", rpcUrl)
     const aptosClient = yield* Effect.try({
       try: () => {
         const config = new AptosConfig({
-          fullnode: `${rpcUrl.value}/v1`, // TODO: there is not v1 in the url
+          fullnode: `${rpcUrl}/v1`, // TODO: there is not v1 in the url
           network: Network.TESTNET
         })
         return new Aptos(config)
@@ -49,12 +49,12 @@ export const getWalletClient = (chain: Chain) =>
       throw new NoAptosChainError({ chain })
     }
 
-    const rpcUrl = chain.getRpcUrl("rpc")
+    const rpcUrl = yield* chain.getRpcUrl("rpc")
 
     const aptosClient = yield* Effect.try({
       try: () => {
         const config = new AptosConfig({
-          fullnode: `${rpcUrl.value}/v1`, // TODO: there is not v1 in the url
+          fullnode: `${rpcUrl}/v1`, // TODO: there is not v1 in the url
           network: Network.TESTNET
         })
         const aptos = new Aptos(config)

--- a/app2/src/lib/services/cosmos/balances.ts
+++ b/app2/src/lib/services/cosmos/balances.ts
@@ -49,7 +49,7 @@ const fetchCosmosCw20Balance = ({
   walletAddress: AddressCosmosDisplay
   contractAddress: AddressCosmosDisplay
 }) =>
-  Effect.gen(function* (_) {
+  Effect.gen(function* () {
     const queryJson = { balance: { address: walletAddress } }
 
     const base64Query = yield* toBase64(queryJson)

--- a/app2/src/lib/services/evm/balances.ts
+++ b/app2/src/lib/services/evm/balances.ts
@@ -74,7 +74,7 @@ export const fetchEvmBalance = ({
   tokenAddress: TokenRawDenom
   walletAddress: AddressEvmCanonical
 }) => {
-  return Effect.gen(function* (_) {
+  return Effect.gen(function* () {
     const client = yield* getPublicClient(chain)
     const decodedDenom = yield* fromHexString(tokenAddress)
 

--- a/app2/src/lib/stores/app-errors.svelte.ts
+++ b/app2/src/lib/stores/app-errors.svelte.ts
@@ -1,15 +1,17 @@
-import { Option } from "effect"
+import { Array as A, Option, pipe } from "effect"
 import { chains } from "$lib/stores/chains.svelte"
 import { tokensStore } from "$lib/stores/tokens.svelte"
 
 // Get all token errors from the store
 const _tokenErrors = $derived(
-  Array.from(tokensStore.error.entries())
-    .filter(([_, error]) => Option.isSome(error))
-    .map(([chainId, error]) => ({
+  pipe(
+    A.fromIterable(tokensStore.error),
+    A.filterMap(([a, b]) => Option.all([Option.some(a), b])),
+    A.map(([chainId, error]) => ({
       chainId,
-      error: error.value // valid given prior filter
+      error
     }))
+  )
 )
 export const tokenErrors = () => _tokenErrors
 

--- a/app2/src/lib/stores/balances.svelte.ts
+++ b/app2/src/lib/stores/balances.svelte.ts
@@ -101,7 +101,7 @@ export class BalancesStore {
     }
 
     // Create a queue for processing balance requests
-    const batchProcessor = Effect.gen(function* (_) {
+    const batchProcessor = Effect.gen(function* () {
       // Create a queue for balance requests
       const queue = yield* Queue.unbounded<BalanceFetchRequest>()
 
@@ -111,13 +111,13 @@ export class BalancesStore {
       }
 
       yield* Effect.forever(
-        Effect.gen(function* (_) {
+        Effect.gen(function* () {
           // Take the next request from the queue
           const request = yield* Queue.take(queue)
           const { chain, address, denom } = request
 
           // Process the balance request
-          yield* Effect.gen(function* (_) {
+          yield* Effect.gen(function* () {
             let balance: RawTokenBalance
             if (chain.rpc_type === "evm") {
               balance = yield* fetchEvmBalance({

--- a/app2/src/lib/transfer/normal/steps/ApprovalStep.svelte
+++ b/app2/src/lib/transfer/normal/steps/ApprovalStep.svelte
@@ -276,7 +276,7 @@ function handleCustomInput(event: Event) {
 
 function isValidCustomAmount(amount: string): boolean {
   return Effect.runSync(
-    Effect.gen(function* (_) {
+    Effect.gen(function* () {
       // Handle empty or invalid input
       if (!amount || amount === "." || amount === ",") return false
 
@@ -301,7 +301,7 @@ function isValidCustomAmount(amount: string): boolean {
 
 function handleBeforeInput(event: InputEvent) {
   return Effect.runSync(
-    Effect.gen(function* (_) {
+    Effect.gen(function* () {
       const { inputType, data } = event
       const { value } = event.currentTarget as HTMLInputElement
       const proposed = value + (data ?? "")

--- a/app2/src/lib/transfer/normal/steps/SubmitStep.svelte
+++ b/app2/src/lib/transfer/normal/steps/SubmitStep.svelte
@@ -173,11 +173,10 @@ export const submit = Effect.gen(function* () {
             step.intent.sourceChain,
             cosmosStore.connectedWallet
           )
+          const walletCosmosAddress = yield* wallets.cosmosAddress
 
           console.log("here stop", step.intent.baseToken)
-          const sender = yield* step.intent.sourceChain.getDisplayAddress(
-            wallets.cosmosAddress.value
-          )
+          const sender = yield* step.intent.sourceChain.getDisplayAddress(walletCosmosAddress)
           const isNative = !isValidBech32ContractAddress(step.intent.baseToken)
 
           console.log({ isNative })

--- a/app2/src/lib/transfer/shared/components/ChainAsset/ChainAssetButton.svelte
+++ b/app2/src/lib/transfer/shared/components/ChainAsset/ChainAssetButton.svelte
@@ -153,7 +153,7 @@ const isChainLoading: boolean = $derived(
                 {transferData.baseToken.value.representations[0]?.symbol ?? transferData.baseToken.value.denom}
               </p>
               {#if Option.isSome(transferData.sourceChain)}
-                <p class="text-xs text-zinc-400">{ type === "source" ? transferData.sourceChain.value.display_name : transferData.destinationChain.value.display_name }</p>
+                <p class="text-xs text-zinc-400">{ type === "source" ? transferData.sourceChain.value.display_name : Option.getOrUndefined(transferData.destinationChain)?.display_name }</p>
               {/if}
 
             </div>

--- a/app2/src/routes/explorer/transfers/[packet_hash]/+page.svelte
+++ b/app2/src/routes/explorer/transfers/[packet_hash]/+page.svelte
@@ -101,11 +101,13 @@ const suggestTokenToWallet = async (chain_id: string, denom: TokenRawDenom) => {
           <div class="flex flex-col gap-6">
             <div class="flex flex-1 items-center justify-between pt-6 px-4">
               <div class="text-2xl">
+                {#if Option.isSome(destChain)}
                 <TokenComponent
                   chain={destChain.value}
                   denom={transfer.quote_token}
                   amount={transfer.quote_amount}
                 />
+                {/if}
               </div>
               {#if !inProgress}
                 <div class="flex items-center gap-2">

--- a/app2/src/routes/explorer/transfers/[packet_hash]/+page.svelte
+++ b/app2/src/routes/explorer/transfers/[packet_hash]/+page.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
 import { page } from "$app/state"
 import { onMount } from "svelte"
-import { Effect, Fiber, Option, Struct } from "effect"
+import { Effect, Fiber, Option, pipe, Schema, Struct } from "effect"
 import { transferByPacketHashQuery } from "$lib/queries/transfer-by-hash.svelte"
 import Card from "$lib/components/ui/Card.svelte"
 import Sections from "$lib/components/ui/Sections.svelte"
@@ -13,7 +13,7 @@ import AddressComponent from "$lib/components/model/AddressComponent.svelte"
 import DateTimeComponent from "$lib/components/ui/DateTimeComponent.svelte"
 import { chains } from "$lib/stores/chains.svelte"
 import { settingsStore } from "$lib/stores/settings.svelte"
-import { getChain, TokenRawDenom } from "@unionlabs/sdk/schema"
+import { getChain, PacketHash, TokenRawDenom } from "@unionlabs/sdk/schema"
 import PacketComponent from "$lib/components/model/PacketComponent.svelte"
 import { packetDetailsQuery } from "$lib/queries/packet-details.svelte"
 import { packetDetails } from "$lib/stores/packets.svelte"
@@ -34,7 +34,7 @@ import Button from "$lib/components/ui/Button.svelte"
 let showPacketDetails = $state(false)
 
 let fiber: Fiber.Fiber<any, any>
-const packetHash = page.params.packet_hash
+const packetHash = $derived(pipe(page.params.packet_hash, Schema.decodeSync(PacketHash)))
 
 onMount(() => {
   fiber = Effect.runFork(transferByPacketHashQuery(packetHash))

--- a/app2/src/routes/transfers/+page.svelte
+++ b/app2/src/routes/transfers/+page.svelte
@@ -97,7 +97,8 @@ const onNextPage = async () => {
   }
 }
 
-const transferCountForAddressesQuery = () => Effect.void
+// TODO: reimplement
+const transferCountForAddressesQuery = (_: unknown) => Effect.void
 </script>
 
 <Sections>

--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
     "@effect/language-service": "~0.5.1",
     "@effect/vitest": "~0.20.14",
     "typescript": "~5.8.2",
+    "viem": "^2.26.2",
     "vite": "~6.3.1",
     "vitest": "~3.1.2"
   },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -25,6 +25,9 @@ importers:
       typescript:
         specifier: ~5.8.2
         version: 5.8.2
+      viem:
+        specifier: ^2.26.2
+        version: 2.27.2(bufferutil@4.0.9)(typescript@5.8.2)(utf-8-validate@5.0.10)(zod@3.22.4)
       vite:
         specifier: ~6.3.1
         version: 6.3.1(@types/node@22.13.14)(jiti@2.4.2)(lightningcss@1.29.2)(tsx@4.19.3)(yaml@2.7.0)
@@ -175,6 +178,9 @@ importers:
       crc:
         specifier: ^4.3.2
         version: 4.3.2(buffer@6.0.3)
+      viem:
+        specifier: ^2
+        version: 2.27.2(bufferutil@4.0.9)(typescript@5.8.2)(utf-8-validate@5.0.10)(zod@3.22.4)
     devDependencies:
       '@babel/cli':
         specifier: ^7.24.8
@@ -215,9 +221,6 @@ importers:
       graphql-request:
         specifier: ^7.1.2
         version: 7.1.2(graphql@16.10.0)
-      viem:
-        specifier: ^2.23.12
-        version: 2.24.1(bufferutil@4.0.9)(typescript@5.8.2)(utf-8-validate@5.0.10)(zod@3.22.4)
 
   typescript-sdk:
     dependencies:

--- a/ts-sdk/package.json
+++ b/ts-sdk/package.json
@@ -76,8 +76,7 @@
     "dpdm": "^3.14.0",
     "effect": "3.14.14",
     "gql.tada": "^1.8.10",
-    "graphql-request": "^7.1.2",
-    "viem": "^2.23.12"
+    "graphql-request": "^7.1.2"
   },
   "dependencies": {
     "@aptos-labs/ts-sdk": "1.34.0",

--- a/ts-sdk/src/schema/chain.ts
+++ b/ts-sdk/src/schema/chain.ts
@@ -1,8 +1,9 @@
 import { VIEM_CHAINS } from "../constants/viem-chains.js"
-import { Data, Effect, Option, Schema as S } from "effect"
+import { Array as Arr, Data, Effect, Option, Schema as S } from "effect"
 import type { Chain as ViemChain } from "viem"
 import type { AddressCosmosCanonical, AddressCosmosDisplay } from "./address.ts"
 import { bech32, bytes } from "@scure/base"
+import { dual } from "effect/Function"
 
 export const ChainId = S.String.pipe(S.brand("ChainId"))
 // e.g. union.union-testnet-9
@@ -157,8 +158,11 @@ export class Chain extends S.Class<Chain>("Chain")({
 export const Chains = S.Array(Chain)
 export type Chains = typeof Chains.Type
 
-export const getChain = (
-  chains: typeof Chains.Type,
-  universalChainId: UniversalChainId
-): Option.Option<Chain> =>
-  Option.fromNullable(chains.find(chain => chain.universal_chain_id === universalChainId))
+export const getChain: {
+  (universalChainId: UniversalChainId): (chains: Chains) => Option.Option<Chain>
+  (chains: Chains, universalChainId: UniversalChainId): Option.Option<Chain>
+} = dual(
+  2,
+  (chains: Chains, universalChainId: UniversalChainId): Option.Option<Chain> =>
+    Arr.findFirst(chains, chain => chain.universal_chain_id === universalChainId)
+)

--- a/ts-sdk/ts-sdk.nix
+++ b/ts-sdk/ts-sdk.nix
@@ -28,7 +28,7 @@ _: {
           packageJsonPath = ./package.json;
           extraSrcs = [ ../ts-sdk ];
           pnpmWorkspaces = [ "@unionlabs/sdk" ];
-          hash = "sha256-eIND4fPDsSzHmnN/S2HcH8I4MTCVTNu4JLcQ4j9n5HA=";
+          hash = "sha256-bOMVsDDMym0px9AIWBJB/JjvyFxedEHg2Xv+ExOoxlA=";
           doCheck = true;
           buildPhase = ''
             runHook preBuild


### PR DESCRIPTION
Fixes the following classifications of static analysis errors:
- Direct `value` property access of `Option<T>` types which have not been narrowed to `Some<T>`