### PR TITLE
chore: disable garnix cache

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -568,9 +568,11 @@
   nixConfig = {
     extra-substituters = [
       "https://union.cachix.org/"
+      "https://cache.garnix.io"
     ];
     extra-trusted-public-keys = [
       "union.cachix.org-1:TV9o8jexzNVbM1VNBOq9fu8NK+hL6ZhOyOh0quATy+M="
+      "cache.garnix.io:CTFPyKSLcx5RMJKfLo5EEPUObbA78b0YQ2DTCJXqr9g="
     ];
   };
 }

--- a/flake.nix
+++ b/flake.nix
@@ -568,11 +568,9 @@
   nixConfig = {
     extra-substituters = [
       "https://union.cachix.org/"
-      "https://cache.garnix.io"
     ];
     extra-trusted-public-keys = [
       "union.cachix.org-1:TV9o8jexzNVbM1VNBOq9fu8NK+hL6ZhOyOh0quATy+M="
-      "cache.garnix.io:CTFPyKSLcx5RMJKfLo5EEPUObbA78b0YQ2DTCJXqr9g="
     ];
   };
 }

--- a/flake.nix
+++ b/flake.nix
@@ -565,14 +565,14 @@
         };
     };
 
-  nixConfig = {
-    extra-substituters = [
-      "https://union.cachix.org/"
-      "https://cache.garnix.io"
-    ];
-    extra-trusted-public-keys = [
-      "union.cachix.org-1:TV9o8jexzNVbM1VNBOq9fu8NK+hL6ZhOyOh0quATy+M="
-      "cache.garnix.io:CTFPyKSLcx5RMJKfLo5EEPUObbA78b0YQ2DTCJXqr9g="
-    ];
-  };
+  # nixConfig = {
+  #   extra-substituters = [
+  #     "https://union.cachix.org/"
+  #     "https://cache.garnix.io"
+  #   ];
+  #   extra-trusted-public-keys = [
+  #     "union.cachix.org-1:TV9o8jexzNVbM1VNBOq9fu8NK+hL6ZhOyOh0quATy+M="
+  #     "cache.garnix.io:CTFPyKSLcx5RMJKfLo5EEPUObbA78b0YQ2DTCJXqr9g="
+  #   ];
+  # };
 }


### PR DESCRIPTION
Removes garnix cache from the flake/devshell. Be sure to also remove it from your system flake configured substitutes 