### PR TITLE
 Add missing schedule trigger to Nightly workflow

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -1,8 +1,11 @@
 name: Nightly
 
 on:
+  schedule:
+    - cron: '0 2 * * *'  # Her gece 02:00 UTC'de çalışır
   workflow_dispatch:
   workflow_call:
+
 
 jobs:
   build:


### PR DESCRIPTION
This PR adds a schedule trigger to the Nightly workflow. The workflow contains a job (create-issue) that runs only when the event is schedule and the build fails. However, without defining a schedule trigger, this condition can never be met.