### PR TITLE
feat(app2): improve user-facing errors

### DIFF
--- a/app2/src/lib/components/model/ErrorComponent.svelte
+++ b/app2/src/lib/components/model/ErrorComponent.svelte
@@ -100,21 +100,21 @@ const getUserFriendlyMessage = pipe(
       `Cosmos wallet not connected. Please check wallet connection.`,
     CosmosWalletNotOnWindowError: (x) => `${x.kind} not found on window. Please check wallet.`,
     CreatePublicClientError: () => "Failed to create network connection.",
-    CreateViemPublicClientError: (x) => `Could not create the viem public client: ${x.message}`,
-    CreateViemWalletClientError: (x) => ``,
+    CreateViemPublicClientError: (x) => `Could not create the EVM public client: ${x.message}`,
+    CreateViemWalletClientError: (x) => `Could not create the EVM wallet client: ${x.message}.`,
     CreateWalletClientError: (x) => `Could not create the wallet client: ${x.message}.`,
-    CryptoError: (x) => ``,
+    CryptoError: (x) => `Browser does not support cryptography functions.`,
     EvmSwitchChainError: (x) => `Failed to switch chain. Please switch manually within wallet.`,
     ExecuteContractError: (x) => `Failed to execute contract: ${x.cause.message}`,
     FetchNativeBalanceError: () => "Failed to fetch native token balance.",
-    GasPriceError: (x) => ``,
-    GetChainInfoError: (x) => ``,
-    NoCosmosChainInfoError: (x) => ``,
+    GasPriceError: (x) => `Incorrect gas price configuration.`,
+    GetChainInfoError: (x) => `No info for EVM chain ${x.chainId}.`, // TODO: rename to EVM
+    NoCosmosChainInfoError: (x) => `No info for Cosmos chain ${x.chain.display_name}.`,
     NoRpcError: (error) => `No ${error.type} endpoint available for ${error.chain.display_name}.`,
-    NoSuchElementException: () => "No such element was found.", // TODO: remove me for more explicit errors
+    NoSuchElementException: () => "An unexpected error occurred.", // TODO: remove me for more explicit errors
     NoViemChain: () => "Chain configuration not found for the selected network.",
     NotACosmosChainError: () => "The selected chain is not a Cosmos chain.",
-    OfflineSignerError: (x) => ``,
+    OfflineSignerError: (x) => `Wallet failed to provide offline signer for ${x.chain_id}.`,
     ParseError: () => "There was an error processing the data from the server.",
     QueryBankBalanceError: () => "Failed to query bank balance from the network.",
     ReadContractError: () => "Failed to read contract data from the network.",
@@ -124,7 +124,7 @@ const getUserFriendlyMessage = pipe(
     UnknownException: () => "An unexpected error occurred.",
     WaitForTransactionReceiptError: (x) =>
       `Waiting for the transaction receipt failed: ${x.message}`,
-    WriteContractError: (e) => `Failed to write to the contract: ${e.cause.cause.shortMessage}`,
+    WriteContractError: (e) => `Failed to write to the contract: ${e.cause.cause.shortMessage}`, // TODO: needs types
   }),
   Match.orElse((x) => `Unexpected error: ${x?.["_tag"]}`),
 )

--- a/app2/src/lib/components/model/ErrorComponent.svelte
+++ b/app2/src/lib/components/model/ErrorComponent.svelte
@@ -3,12 +3,39 @@ import Button from "$lib/components/ui/Button.svelte"
 import type { QueryBankBalanceError } from "$lib/services/cosmos/balances"
 import type { FetchNativeBalanceError, ReadContractError } from "$lib/services/evm/balances"
 import type { NoViemChainError } from "$lib/services/evm/clients"
-import type { CreatePublicClientError } from "$lib/services/transfer/errors"
+import type {
+  CosmosWalletNotConnectedError,
+  CosmosWalletNotOnWindowError,
+  CosmWasmError,
+  GasPriceError,
+  GetChainInfoError,
+  NoCosmosChainInfoError,
+  OfflineSignerError,
+} from "$lib/services/transfer-ucs03-cosmos"
+import type { WaitForTransactionReceiptError } from "$lib/services/transfer-ucs03-evm"
+import type {
+  AmountError,
+  ConnectorClientError,
+  CreatePublicClientError,
+  CreateWalletClientError,
+  SwitchChainError,
+} from "$lib/services/transfer/errors"
 import type { Base64EncodeError } from "$lib/utils/base64"
 import type { HttpClientError } from "@effect/platform/HttpClientError"
-import type { NoRpcError } from "@unionlabs/sdk/schema"
-import { extractErrorDetails } from "@unionlabs/sdk/utils"
-import type { TimeoutException, UnknownException } from "effect/Cause"
+import type { ExecuteContractError } from "@unionlabs/sdk/cosmos"
+import {
+  CreateViemPublicClientError,
+  CreateViemWalletClientError,
+  WriteContractError,
+} from "@unionlabs/sdk/evm"
+import type {
+  CosmosAddressEncodeError,
+  NoRpcError,
+  NotACosmosChainError,
+} from "@unionlabs/sdk/schema"
+import { CryptoError, extractErrorDetails } from "@unionlabs/sdk/utils"
+import { Match, pipe } from "effect"
+import type { NoSuchElementException, TimeoutException, UnknownException } from "effect/Cause"
 import type { ParseError } from "effect/ParseResult"
 import { slide } from "svelte/transition"
 import BaselineCloseIcon from "../icons/BaselineCloseIcon.svelte"
@@ -20,55 +47,87 @@ import Tooltip from "../ui/Tooltip.svelte"
 
 interface Props {
   error:
-    | UnknownException
-    | HttpClientError
-    | ParseError
-    | TimeoutException
-    | NoViemChainError
-    | ReadContractError
-    | FetchNativeBalanceError
-    | CreatePublicClientError
-    | QueryBankBalanceError
+    | AmountError
     | Base64EncodeError
+    | ConnectorClientError
+    | CosmWasmError
+    | CosmosAddressEncodeError
+    | CosmosWalletNotConnectedError
+    | CosmosWalletNotOnWindowError
+    | CreatePublicClientError
+    | CreateViemPublicClientError
+    | CreateViemWalletClientError
+    | CreateWalletClientError
+    | CryptoError
+    | ExecuteContractError
+    | FetchNativeBalanceError
+    | GasPriceError
+    | GetChainInfoError
+    | HttpClientError
+    | NoCosmosChainInfoError
     | NoRpcError
+    | NoSuchElementException
+    | NoViemChainError
+    | NotACosmosChainError
+    | OfflineSignerError
+    | ParseError
+    | QueryBankBalanceError
+    | ReadContractError
+    | SwitchChainError
+    | TimeoutException
+    | UnknownException
+    | WaitForTransactionReceiptError
+    | WriteContractError
+  onOpen?: () => void | undefined
   onClose?: (() => void) | undefined
 }
 
-let { error, onClose }: Props = $props()
+let { error, onClose, onOpen }: Props = $props()
 let showDetails = $state(false)
 let visible = $state(true)
 
-// TODO: replace me with an exhaustive matcher :)
-function getUserFriendlyMessage(error: Props["error"]): string {
-  switch (error._tag) {
-    case "RequestError":
-      return "Unable to connect to the server. Please check your internet connection."
-    case "ResponseError":
-      return "The server encountered an error processing your request."
-    case "ParseError":
-      return "There was an error processing the data from the server."
-    case "TimeoutException":
-      return "The request timed out because it took too long. Please try again."
-    case "UnknownException":
-      return "An unexpected error occurred."
-    case "NoViemChain":
-      return "Chain configuration not found for the selected network."
-    case "ReadContractError":
-      return "Failed to read contract data from the network."
-    case "FetchNativeBalanceError":
-      return "Failed to fetch native token balance."
-    case "CreatePublicClientError":
-      return "Failed to create network connection."
-    case "QueryBankBalanceError":
-      return "Failed to query bank balance from the network."
-    case "Base64EncodeError":
-      return "Failed to encode query parameters."
-    case "NoRpcError":
-      return `No ${error.type} endpoint available for ${error.chain.display_name}.`
-    default:
-      return "Something went wrong. Please try again later."
-  }
-}
+const getUserFriendlyMessage = pipe(
+  Match.type<Props["error"]>(),
+  Match.tags({
+    AmountError: () => "Amount invalid.",
+    Base64EncodeError: () => "Failed to encode query parameters.",
+    ConnectorClientError: (x) => `A connector client error occurred: ${x.message}`,
+    CosmWasmError: (x) => `CosmWasm failure: ${x.message}`,
+    CosmosAddressEncodeError: (x) => `Failed to encode the Cosmos address ${x.address}.`,
+    CosmosSwitchChainError: (x) =>
+      `Failed to switch to chain ${x.chainInfo?.chainName}. Please switch manually within wallet.`,
+    CosmosWalletNotConnectedError: (x) =>
+      `Cosmos wallet not connected. Please check wallet connection.`,
+    CosmosWalletNotOnWindowError: (x) => `${x.kind} not found on window. Please check wallet.`,
+    CreatePublicClientError: () => "Failed to create network connection.",
+    CreateViemPublicClientError: (x) => `Could not create the viem public client: ${x.message}`,
+    CreateViemWalletClientError: (x) => ``,
+    CreateWalletClientError: (x) => `Could not create the wallet client: ${x.message}.`,
+    CryptoError: (x) => ``,
+    EvmSwitchChainError: (x) => `Failed to switch chain. Please switch manually within wallet.`,
+    ExecuteContractError: (x) => `Failed to execute contract: ${x.cause.message}`,
+    FetchNativeBalanceError: () => "Failed to fetch native token balance.",
+    GasPriceError: (x) => ``,
+    GetChainInfoError: (x) => ``,
+    NoCosmosChainInfoError: (x) => ``,
+    NoRpcError: (error) => `No ${error.type} endpoint available for ${error.chain.display_name}.`,
+    NoSuchElementException: () => "No such element was found.", // TODO: remove me for more explicit errors
+    NoViemChain: () => "Chain configuration not found for the selected network.",
+    NotACosmosChainError: () => "The selected chain is not a Cosmos chain.",
+    OfflineSignerError: (x) => ``,
+    ParseError: () => "There was an error processing the data from the server.",
+    QueryBankBalanceError: () => "Failed to query bank balance from the network.",
+    ReadContractError: () => "Failed to read contract data from the network.",
+    RequestError: () => "Unable to connect to the server. Please check your internet connection.",
+    ResponseError: () => "The server encountered an error processing your request.",
+    TimeoutException: () => "The request timed out because it took too long. Please try again.",
+    UnknownException: () => "An unexpected error occurred.",
+    WaitForTransactionReceiptError: (x) =>
+      `Waiting for the transaction receipt failed: ${x.message}`,
+    WriteContractError: (e) => `Failed to write to the contract: ${e.cause.cause.shortMessage}`,
+  }),
+  Match.orElse((x) => `Unexpected error: ${x?.["_tag"]}`),
+)
 
 const writeToClipboard = () => {
   navigator.clipboard.writeText(JSON.stringify(extractErrorDetails(error), null, 2))
@@ -84,6 +143,14 @@ const exportData = () => {
   anchor.download = `union-log-${datetime}.json`
   anchor.click()
   window.URL.revokeObjectURL(anchor.href)
+}
+
+const onShowDetails = () => {
+  if (onOpen) {
+    onOpen()
+  } else {
+    showDetails = !showDetails
+  }
 }
 </script>
 
@@ -115,7 +182,7 @@ const exportData = () => {
         {#snippet trigger()}
           <Button
             variant="secondary"
-            onclick={() => (showDetails = !showDetails)}
+            onclick={onShowDetails}
           >
             <SharpOpenInBrowserIcon class="size-4" />
           </Button>
@@ -135,19 +202,21 @@ const exportData = () => {
         Copy to Clipboard
       {/snippet}
     </Tooltip> -->
-      <Tooltip delay={"quick"}>
-        {#snippet trigger()}
-          <Button
-            variant="primary"
-            onclick={exportData}
-          >
-            <SharpDownloadIcon class="size-4" />
-          </Button>
-        {/snippet}
-        {#snippet content()}
-          Download Log
-        {/snippet}
-      </Tooltip>
+      {#if !onOpen}
+        <Tooltip delay={"quick"}>
+          {#snippet trigger()}
+            <Button
+              variant="primary"
+              onclick={exportData}
+            >
+              <SharpDownloadIcon class="size-4" />
+            </Button>
+          {/snippet}
+          {#snippet content()}
+            Download Log
+          {/snippet}
+        </Tooltip>
+      {/if}
     </div>
 
     <Modal

--- a/app2/src/lib/components/model/InsetError.svelte
+++ b/app2/src/lib/components/model/InsetError.svelte
@@ -45,6 +45,9 @@ const exportData = () => {
       class="absolute inset-0 flex flex-col bg-zinc-925"
       transition:fly={{ y: 30, duration: 300, opacity: 0 }}
     >
+      {#if errorDetails?.message}
+        <div>Message: {errorDetails.message}</div>
+      {/if}
       <div class="p-4 overflow-y-auto flex-1">
         {#if errorDetails}
           <pre

--- a/app2/src/lib/components/model/InsetError.svelte
+++ b/app2/src/lib/components/model/InsetError.svelte
@@ -3,6 +3,7 @@ import SharpContentCopyIcon from "$lib/components/icons/SharpContentCopyIcon.sve
 import SharpDownloadIcon from "$lib/components/icons/SharpDownloadIcon.svelte"
 import Button from "$lib/components/ui/Button.svelte"
 import { extractErrorDetails } from "@unionlabs/sdk/utils"
+import { String as Str } from "effect"
 import { fade, fly } from "svelte/transition"
 
 type Props = {
@@ -45,15 +46,12 @@ const exportData = () => {
       class="absolute inset-0 flex flex-col bg-zinc-925"
       transition:fly={{ y: 30, duration: 300, opacity: 0 }}
     >
-      {#if errorDetails?.message}
-        <div>Message: {errorDetails.message}</div>
-      {/if}
       <div class="p-4 overflow-y-auto flex-1">
         {#if errorDetails}
           <pre
             class="text-xs whitespace-pre-wrap break-all"
           >
-            {JSON.stringify(errorDetails, null, 2)}
+{Str.trim(JSON.stringify(errorDetails, null, 2))}
           </pre>
         {:else}
           <p class="text-zinc-300">No error info available.</p>

--- a/app2/src/lib/copy.ts
+++ b/app2/src/lib/copy.ts
@@ -1,0 +1,18 @@
+import { interpolate } from "$lib/utils/interpolate.js"
+import { NotACosmosChainError } from "@unionlabs/sdk/schema"
+
+export const OfflineSignerCopy = interpolate(
+  "Something went wrong signing the {{step}}",
+)
+export const NoCosmosChainInfoCopy = interpolate(
+  "Could not find chain {{sourceChain}}. Please check wallet configuration.",
+)
+export const CosmosWalletNotOnWindowCopy = interpolate(
+  "Cosmos wallet not available on `window.{{wallet}}`. Please check wallet connection.",
+)
+export const SwitchChainCopy = interpolate(
+  "Could not switch {{wallet}} wallet from chain {{from}} to chain {{to}}. Please switch manually.",
+)
+export const ContractErrorCopy = interpolate(
+  "Error executing contract",
+)

--- a/app2/src/lib/services/cosmos/chain-info/index.ts
+++ b/app2/src/lib/services/cosmos/chain-info/index.ts
@@ -66,6 +66,8 @@ export const getHighGasPriceStep = (
     if (!feeCurrency.gasPriceStep) {
       yield* Effect.fail(
         new GasPriceError({
+          // TODO: change to `message`
+          // TODO: reserve `cause` for originally thrown error
           cause: "Gas price step not defined for fee currency",
           chainId: chainInfo.chainId,
         }),

--- a/app2/src/lib/services/evm/clients.ts
+++ b/app2/src/lib/services/evm/clients.ts
@@ -23,6 +23,7 @@ export class PublicSourceViemClient extends Context.Tag("PublicSourceViemClient"
   { readonly client: PublicClient }
 >() {}
 
+// XXX: change tag to NoViemChainError
 export class NoViemChainError extends Data.TaggedError("NoViemChain")<{
   chain: Chain
 }> {}

--- a/app2/src/lib/services/transfer-ucs03-cosmos/chain.ts
+++ b/app2/src/lib/services/transfer-ucs03-cosmos/chain.ts
@@ -6,9 +6,9 @@ import type { Chain } from "@unionlabs/sdk/schema"
 import { extractErrorDetails } from "@unionlabs/sdk/utils/extract-error-details.ts"
 import { Effect } from "effect"
 import {
+  CosmosSwitchChainError,
   CosmosWalletNotConnectedError,
   NoCosmosChainInfoError,
-  SwitchChainError,
 } from "./errors.ts"
 
 type SwitchChainSuccess = {
@@ -23,6 +23,7 @@ export const switchChain = (chain: Chain) =>
     const { connectedWallet, connectionStatus } = cosmosStore
     if (connectionStatus !== "connected" || !connectedWallet) {
       return yield* new CosmosWalletNotConnectedError({
+        // TODO: move to `message`
         cause: "wallet not connected according to cosmosStore",
       })
     }
@@ -39,7 +40,7 @@ export const switchChain = (chain: Chain) =>
     yield* Effect.tryPromise({
       try: () => wallet.experimentalSuggestChain(chainInfo),
       catch: err =>
-        new SwitchChainError({
+        new CosmosSwitchChainError({
           cause: extractErrorDetails(err as Error),
           chainId: chain.universal_chain_id,
           phase: "suggest",
@@ -50,7 +51,7 @@ export const switchChain = (chain: Chain) =>
     yield* Effect.tryPromise({
       try: () => wallet.enable([chain.chain_id]),
       catch: err =>
-        new SwitchChainError({
+        new CosmosSwitchChainError({
           cause: extractErrorDetails(err as Error),
           chainId: chain.universal_chain_id,
           phase: "enable",

--- a/app2/src/lib/services/transfer-ucs03-cosmos/errors.ts
+++ b/app2/src/lib/services/transfer-ucs03-cosmos/errors.ts
@@ -2,7 +2,7 @@ import type { getCosmosChainInfo } from "$lib/wallet/cosmos/chain-info.ts"
 import type { Chain } from "@unionlabs/sdk/schema/chain"
 import { Data } from "effect"
 
-export class SwitchChainError extends Data.TaggedError("SwitchChainError")<{
+export class CosmosSwitchChainError extends Data.TaggedError("CosmosSwitchChainError")<{
   cause: unknown
   chainId: string
   phase: "enable" | "suggest"

--- a/app2/src/lib/services/transfer-ucs03-evm/chain.ts
+++ b/app2/src/lib/services/transfer-ucs03-evm/chain.ts
@@ -2,13 +2,13 @@ import { type ConfiguredChainId, getWagmiConfig } from "$lib/wallet/evm/wagmi-co
 import { switchChain as wagmiSwitchChain } from "@wagmi/core"
 import { Effect } from "effect"
 import type { Chain as ViemChain, SwitchChainErrorType } from "viem"
-import { SwitchChainError } from "./errors.ts"
+import { EvmSwitchChainError } from "./errors.ts"
 
 export const switchChain = (chain: ViemChain) =>
   Effect.gen(function*() {
     const res = yield* Effect.tryPromise({
       try: () => wagmiSwitchChain(getWagmiConfig(), { chainId: chain.id as ConfiguredChainId }),
-      catch: err => new SwitchChainError({ cause: err as SwitchChainErrorType }),
+      catch: err => new EvmSwitchChainError({ cause: err as SwitchChainErrorType }),
     })
 
     // Some wallets, like metamask, fulfill the promise before they are actually done with switching.

--- a/app2/src/lib/services/transfer-ucs03-evm/errors.ts
+++ b/app2/src/lib/services/transfer-ucs03-evm/errors.ts
@@ -26,7 +26,7 @@ export class WriteContractError extends Data.TaggedError("WriteContractError")<{
   cause: WriteContractErrorType
 }> {}
 
-export class SwitchChainError extends Data.TaggedError("SwitchChainError")<{
+export class EvmSwitchChainError extends Data.TaggedError("EvmSwitchChainError")<{
   cause: SwitchChainErrorType
 }> {}
 

--- a/app2/src/lib/services/transfer-ucs03-evm/machine.ts
+++ b/app2/src/lib/services/transfer-ucs03-evm/machine.ts
@@ -1,5 +1,5 @@
 import { approveTransfer, waitForApprovalReceipt } from "$lib/services/transfer-ucs03-evm/approval"
-import { SwitchChainError } from "$lib/services/transfer-ucs03-evm/errors.ts"
+import { EvmSwitchChainError } from "$lib/services/transfer-ucs03-evm/errors.ts"
 import type { ValidTransfer } from "@unionlabs/sdk/schema"
 import { Effect, Option } from "effect"
 import type { SwitchChainErrorType } from "viem"
@@ -31,7 +31,7 @@ export async function nextState(
             Option.match(viemChainOption, {
               onNone: () =>
                 Effect.fail(
-                  new SwitchChainError({
+                  new EvmSwitchChainError({
                     cause: {
                       name: "UserRejectedRequestError",
                       message: "Could not convert to viem chain for chain switch.",

--- a/app2/src/lib/services/transfer/chain.ts
+++ b/app2/src/lib/services/transfer/chain.ts
@@ -2,10 +2,10 @@ import { type ConfiguredChainId, getWagmiConfig } from "$lib/wallet/evm/wagmi-co
 import { switchChain as wagmiSwitchChain } from "@wagmi/core"
 import { Effect } from "effect"
 import type { SwitchChainErrorType } from "viem"
-import { SwitchChainError } from "./errors.ts"
+import { EvmSwitchChainError } from "../transfer-ucs03-evm/errors"
 
 export const switchChain = (chainId: ConfiguredChainId) =>
   Effect.tryPromise({
     try: () => wagmiSwitchChain(getWagmiConfig(), { chainId }),
-    catch: err => new SwitchChainError({ cause: err as SwitchChainErrorType }),
+    catch: err => new EvmSwitchChainError({ cause: err as SwitchChainErrorType }),
   })

--- a/app2/src/lib/services/transfer/errors.ts
+++ b/app2/src/lib/services/transfer/errors.ts
@@ -7,6 +7,8 @@ import type {
   SwitchChainErrorType,
   WaitForTransactionReceiptErrorType,
 } from "viem"
+import { CosmosSwitchChainError } from "../transfer-ucs03-cosmos"
+import { EvmSwitchChainError } from "../transfer-ucs03-evm"
 
 export class CreateWalletClientError extends Data.TaggedError("CreateWalletClientError")<{
   cause: CreateWalletClientErrorType
@@ -26,13 +28,14 @@ export class SendTransactionError extends Data.TaggedError("SendTransactionError
   cause: SendTransactionErrorType
 }> {}
 
-export class SwitchChainError extends Data.TaggedError("SwitchChainError")<{
-  cause: SwitchChainErrorType
-}> {}
+export type SwitchChainError = EvmSwitchChainError | CosmosSwitchChainError
 
 export class ConnectorClientError extends Data.TaggedError("ConnectorClientError")<{
   wagmiConfig: unknown
   cause: GetConnectorClientErrorType
+}> {}
+export class AmountError extends Data.TaggedError("AmountError")<{
+  message: string
 }> {}
 
 export type SubmitTransferError = SendTransactionError | CreateWalletClientError

--- a/app2/src/lib/transfer/normal/steps/FillingStep.svelte
+++ b/app2/src/lib/transfer/normal/steps/FillingStep.svelte
@@ -38,8 +38,8 @@ const uiStatus = $derived.by(() => {
           text: "Failed checking balance",
           error,
         })),
-        Match.tag("AllowanceCheckError", () => ({
-          text: "Failed checking allowance",
+        Match.tag("AllowanceCheckError", (err) => ({
+          text: `Failed checking allowance: ${err.message}`,
           error,
         })),
         Match.tag("OrderCreationError", () => ({

--- a/app2/src/lib/transfer/normal/steps/SubmitStep.svelte
+++ b/app2/src/lib/transfer/normal/steps/SubmitStep.svelte
@@ -242,7 +242,7 @@ export const submit = Effect.gen(function*() {
       Effect.repeat({ until: WriteCosmos.is("WriteContractComplete") }),
       Effect.andThen(({ exit }) =>
         // TODO: remove cast
-        startPolling(exit.transactionHash as TransactionHash)
+        startPolling(`0x${exit.transactionHash}` as TransactionHash)
       ),
     )
   })

--- a/app2/src/lib/transfer/normal/steps/SubmitStep.svelte
+++ b/app2/src/lib/transfer/normal/steps/SubmitStep.svelte
@@ -1,34 +1,54 @@
 <script lang="ts">
 import { ucs03ZkgmAbi } from "$lib/abi/ucs03.ts"
 import ChainComponent from "$lib/components/model/ChainComponent.svelte"
+import ErrorComponent from "$lib/components/model/ErrorComponent.svelte"
 import InsetError from "$lib/components/model/InsetError.svelte"
 import Button from "$lib/components/ui/Button.svelte"
 import Label from "$lib/components/ui/Label.svelte"
 import { getWagmiConnectorClient } from "$lib/services/evm/clients.ts"
+import type {
+  CosmosSwitchChainError,
+  CosmosWalletNotConnectedError,
+  CosmosWalletNotOnWindowError,
+  CosmWasmError,
+  GasPriceError,
+  GetChainInfoError,
+  NoCosmosChainInfoError,
+  OfflineSignerError,
+} from "$lib/services/transfer-ucs03-cosmos"
+import type {
+  ConnectorClientError,
+  SwitchChainError,
+  WaitForTransactionReceiptError,
+} from "$lib/services/transfer/errors"
 import { transferHashStore } from "$lib/stores/transfer-hash.svelte.ts"
 import { wallets } from "$lib/stores/wallets.svelte.ts"
 import type { SubmitInstruction } from "$lib/transfer/normal/steps/steps.ts"
-import {
-  hasFailedExit as cosmosHasFailedExit,
-  isComplete as cosmosIsComplete,
-  nextStateCosmos,
-  TransactionSubmissionCosmos,
-} from "$lib/transfer/shared/services/write-cosmos.ts"
-import {
-  hasFailedExit as evmHasFailedExit,
-  isComplete as evmIsComplete,
-  nextStateEvm,
-  TransactionSubmissionEvm,
-} from "$lib/transfer/shared/services/write-evm.ts"
+import * as WriteCosmos from "$lib/transfer/shared/services/write-cosmos.ts"
+import * as WriteEvm from "$lib/transfer/shared/services/write-evm.ts"
 import { isValidBech32ContractAddress } from "$lib/utils"
-import { createViemPublicClient, createViemWalletClient } from "@unionlabs/sdk/evm"
+import type { ExecuteContractError } from "@unionlabs/sdk/cosmos"
+import {
+  createViemPublicClient,
+  CreateViemPublicClientError,
+  createViemWalletClient,
+  CreateViemWalletClientError,
+  WriteContractError,
+} from "@unionlabs/sdk/evm"
 import { instructionAbi } from "@unionlabs/sdk/evm/abi"
+import type {
+  CosmosAddressEncodeError,
+  NotACosmosChainError,
+  TransactionHash,
+} from "@unionlabs/sdk/schema"
 import { encodeAbi } from "@unionlabs/sdk/ucs03/instruction.ts"
-import { extractErrorDetails, generateSalt } from "@unionlabs/sdk/utils"
+import { CryptoError, extractErrorDetails, generateSalt } from "@unionlabs/sdk/utils"
 import { getTimeoutInNanoseconds24HoursFromNow } from "@unionlabs/sdk/utils/timeout.ts"
 import { http } from "@wagmi/core"
-import { Cause, Effect, Exit, Match, Option } from "effect"
-import { constVoid } from "effect/Function"
+import { Array as Arr, Cause, Effect, Exit, Match, Option, Predicate, Unify } from "effect"
+import { not } from "effect/Boolean"
+import type { NoSuchElementException } from "effect/Cause"
+import { compose, constVoid, flow, pipe } from "effect/Function"
 import { custom, encodeAbiParameters, fromHex } from "viem"
 
 type Props = {
@@ -42,37 +62,60 @@ type Props = {
 const { stepIndex, step, onSubmit, cancel, actionButtonText }: Props = $props()
 
 let showError = $state(false)
-
-let ets = $state<TransactionSubmissionEvm>(TransactionSubmissionEvm.Filling())
-let cts = $state<TransactionSubmissionCosmos>(TransactionSubmissionCosmos.Filling())
-let error = $state<Option.Option<unknown>>(Option.none())
+let ets = $state<WriteEvm.TransactionState>(WriteEvm.TransactionState.Filling())
+let cts = $state<WriteCosmos.TransactionState>(WriteCosmos.TransactionState.Filling())
+let error = $state<
+  Option.Option<
+    | ConnectorClientError
+    | CosmWasmError
+    | CosmosAddressEncodeError
+    | CosmosSwitchChainError
+    | CosmosWalletNotConnectedError
+    | CosmosWalletNotOnWindowError
+    | CreateViemPublicClientError
+    | CreateViemWalletClientError
+    | CryptoError
+    | ExecuteContractError
+    | GasPriceError
+    | GetChainInfoError
+    | NoCosmosChainInfoError
+    | NoSuchElementException
+    | NotACosmosChainError
+    | OfflineSignerError
+    | SwitchChainError
+    | WaitForTransactionReceiptError
+    | WriteContractError
+  >
+>(Option.none())
 let isSubmitting = $state(false)
 
-const needsRetry = $derived(evmHasFailedExit(ets) || cosmosHasFailedExit(cts))
+const needsRetry = $derived(Option.isSome(error))
 
-const isButtonEnabled = $derived(
-  !isSubmitting && ((ets._tag === "Filling" && cts._tag === "Filling") || needsRetry),
-)
+const isButtonEnabled = $derived.by(() => {
+  const isFilling = WriteEvm.is("Filling")(ets) || WriteCosmos.is("Filling")(cts)
+  const hasError = Option.isSome(error)
+  return !isSubmitting && isFilling || hasError
+})
 
-const getSubmitButtonText = $derived(
-  ets._tag === "SwitchChainInProgress"
-    ? "Switching Chain..."
-    : ets._tag === "WriteContractInProgress"
-    ? "Confirming Transaction..."
-    : ets._tag === "TransactionReceiptInProgress"
-    ? "Waiting for Receipt..."
-    : cts._tag === "SwitchChainInProgress"
-    ? "Switching Chain..."
-    : cts._tag === "WriteContractInProgress"
-    ? "Confirming Transaction..."
-    : needsRetry
-    ? "Try Again"
-    : actionButtonText,
-)
+const submitButtonText = $derived.by(() => {
+  if (Option.isSome(error)) {
+    return "Try Again"
+  }
+
+  if (!WriteEvm.is("Filling")(ets)) {
+    return WriteEvm.toCtaText(actionButtonText)(ets)
+  }
+
+  if (!WriteCosmos.is("Filling")(cts)) {
+    return WriteCosmos.toCtaText(actionButtonText)(cts)
+  }
+
+  return actionButtonText
+})
 
 const resetState = () => {
-  ets = TransactionSubmissionEvm.Filling()
-  cts = TransactionSubmissionCosmos.Filling()
+  ets = WriteEvm.TransactionState.Filling()
+  cts = WriteCosmos.TransactionState.Filling()
   error = Option.none()
   isSubmitting = false
 }
@@ -87,158 +130,139 @@ export const submit = Effect.gen(function*() {
   isSubmitting = true
   error = Option.none()
 
-  try {
-    const sourceChainRpcType = step.intent.sourceChain.rpc_type
+  const startPolling = (transactionHash: TransactionHash) =>
+    Effect.sync(() => {
+      console.log("GOT TRANSACTION HASH:", transactionHash)
+      transferHashStore.startPolling(transactionHash)
+      onSubmit()
+    })
 
-    yield* Match.value(sourceChainRpcType).pipe(
-      Match.when("evm", () =>
-        Effect.gen(function*() {
-          const viemChain = step.intent.sourceChain.toViemChain()
-          if (Option.isNone(viemChain)) {
-            return Effect.succeed(null)
-          }
+  const doEvm = Effect.gen(function*() {
+    const viemChain = yield* step.intent.sourceChain.toViemChain()
+    const publicClient = yield* createViemPublicClient({
+      chain: viemChain,
+      transport: http(),
+    })
+    const connectorClient = yield* getWagmiConnectorClient
+    const walletClient = yield* createViemWalletClient({
+      account: connectorClient.account,
+      chain: viemChain,
+      transport: custom(connectorClient),
+    })
+    const timeoutTimestamp = getTimeoutInNanoseconds24HoursFromNow()
+    const salt = yield* generateSalt("evm")
 
-          const publicClient = yield* createViemPublicClient({
-            chain: viemChain.value,
-            transport: http(),
-          })
+    const setEts = (nextEts: typeof ets) =>
+      Effect.sync(() => {
+        console.log(`ETS transitioning: ${ets._tag} -> ${nextEts._tag}`)
+        ets = nextEts
+      })
 
-          const connectorClient = yield* getWagmiConnectorClient
-
-          const walletClient = yield* createViemWalletClient({
-            account: connectorClient.account,
-            chain: viemChain.value,
-            transport: custom(connectorClient),
-          })
-
-          do {
-            const timeoutTimestamp = getTimeoutInNanoseconds24HoursFromNow()
-            const salt = yield* generateSalt("evm")
-            ets = yield* Effect.promise(() =>
-              nextStateEvm(ets, viemChain.value, publicClient, walletClient, {
-                chain: viemChain.value,
-                account: connectorClient.account,
-                address: step.intent.channel.source_port_id,
-                abi: ucs03ZkgmAbi,
-                functionName: "send",
-                args: [
-                  step.intent.channel.source_channel_id,
-                  0n,
-                  timeoutTimestamp,
-                  salt,
-                  {
-                    opcode: step.instruction.opcode,
-                    version: step.instruction.version,
-                    operand: encodeAbi(step.instruction),
-                  },
-                ],
-              })
-            )
-
-            if (ets._tag === "SwitchChainComplete" || ets._tag === "WriteContractComplete") {
-              yield* Exit.matchEffect(ets.exit, {
-                onFailure: cause =>
-                  Effect.sync(() => {
-                    error = Option.some(Cause.squash(cause))
-                    console.log(error)
-                  }),
-                onSuccess: () =>
-                  Effect.sync(() => {
-                    error = Option.none()
-                  }),
-              })
-            }
-
-            const result = evmIsComplete(ets)
-            if (result) {
-              transferHashStore.startPolling(result)
-              onSubmit()
-              break
-            }
-          } while (!evmHasFailedExit(ets))
-
-          return Effect.succeed(ets)
-        })),
-      Match.when("cosmos", () =>
-        Effect.gen(function*() {
-          const walletCosmosAddress = yield* wallets.cosmosAddress
-
-          const sender = yield* step.intent.sourceChain.getDisplayAddress(walletCosmosAddress)
-          const isNative = !isValidBech32ContractAddress(step.intent.baseToken)
-
-          const baseToken = step.intent.baseToken === "xion" ? "uxion" : step.intent.baseToken
-
-          do {
-            const timeout_timestamp = getTimeoutInNanoseconds24HoursFromNow().toString()
-            const salt = yield* generateSalt("cosmos")
-            cts = yield* Effect.promise(() =>
-              nextStateCosmos(
-                cts,
-                step.intent.sourceChain,
-                sender,
-                fromHex(step.intent.channel.source_port_id, "string"),
-                {
-                  send: {
-                    channel_id: step.intent.channel.source_channel_id,
-                    timeout_height: "0",
-                    timeout_timestamp,
-                    salt,
-                    instruction: encodeAbiParameters(instructionAbi, [
-                      step.instruction.version,
-                      step.instruction.opcode,
-                      encodeAbi(step.instruction),
-                    ]),
-                  },
-                },
-                isNative
-                  ? [
-                    {
-                      denom: baseToken,
-                      amount: step.intent.baseAmount.toString(),
-                    },
-                  ]
-                  : undefined,
-              )
-            )
-
-            if (cts._tag === "SwitchChainComplete" || cts._tag === "WriteContractComplete") {
-              yield* Exit.matchEffect(cts.exit, {
-                onFailure: cause =>
-                  Effect.sync(() => {
-                    error = Option.some(Cause.squash(cause))
-                  }),
-                onSuccess: () =>
-                  Effect.sync(() => {
-                    error = Option.none()
-                  }),
-              })
-            }
-
-            const result = cosmosIsComplete(cts)
-            if (result) {
-              transferHashStore.startPolling(`0x${result}`)
-              onSubmit()
-              break
-            }
-          } while (!cosmosHasFailedExit(cts))
-
-          return Effect.succeed(cts)
-        })),
-      Match.orElse(() =>
-        Effect.gen(function*() {
-          yield* Effect.log("Unknown chain type")
-          error = Option.some({
-            _tag: "UnknownError",
-            cause: "Unsupported chain type",
-          })
-          return Effect.succeed("unknown chain type")
+    const nextState = Effect.tap(
+      Effect.suspend(() =>
+        WriteEvm.nextState(ets, viemChain, publicClient, walletClient, {
+          chain: viemChain,
+          account: connectorClient.account,
+          address: step.intent.channel.source_port_id,
+          abi: ucs03ZkgmAbi,
+          functionName: "send",
+          args: [
+            step.intent.channel.source_channel_id,
+            0n,
+            timeoutTimestamp,
+            salt,
+            {
+              opcode: step.instruction.opcode,
+              version: step.instruction.version,
+              operand: encodeAbi(step.instruction),
+            },
+          ],
         })
       ),
+      setEts,
     )
-  } finally {
-    // Reset submitting state when done, regardless of success/failure
+
+    yield* pipe(
+      nextState,
+      Effect.repeat({ until: WriteEvm.is("TransactionReceiptComplete") }),
+      // TODO: remove cast
+      Effect.andThen(({ exit }) => startPolling(exit.transactionHash as TransactionHash)),
+    )
+  })
+
+  const doCosmos = Effect.gen(function*() {
+    const walletCosmosAddress = yield* wallets.cosmosAddress
+    const sender = yield* step.intent.sourceChain.getDisplayAddress(walletCosmosAddress)
+    const isNative = !isValidBech32ContractAddress(step.intent.baseToken)
+    const baseToken = step.intent.baseToken === "xion" ? "uxion" : step.intent.baseToken
+    const timeout_timestamp = getTimeoutInNanoseconds24HoursFromNow().toString()
+    const salt = yield* generateSalt("cosmos")
+
+    const setCts = (nextCts: typeof cts) =>
+      Effect.sync(() => {
+        console.log(`CTS transitioning: ${cts._tag} -> ${nextCts._tag}`)
+        cts = nextCts
+      })
+
+    const nextState = Effect.tap(
+      Effect.suspend(() =>
+        WriteCosmos.nextState(
+          cts,
+          step.intent.sourceChain,
+          sender,
+          fromHex(step.intent.channel.source_port_id, "string"),
+          {
+            send: {
+              channel_id: step.intent.channel.source_channel_id,
+              timeout_height: "0",
+              timeout_timestamp,
+              salt,
+              instruction: encodeAbiParameters(instructionAbi, [
+                step.instruction.version,
+                step.instruction.opcode,
+                encodeAbi(step.instruction),
+              ]),
+            },
+          },
+          isNative
+            ? [
+              {
+                denom: baseToken,
+                amount: step.intent.baseAmount.toString(),
+              },
+            ]
+            : undefined,
+        )
+      ),
+      setCts,
+    )
+
+    yield* pipe(
+      nextState,
+      Effect.repeat({ until: WriteCosmos.is("WriteContractComplete") }),
+      Effect.andThen(({ exit }) =>
+        // TODO: remove cast
+        startPolling(exit.transactionHash as TransactionHash)
+      ),
+    )
+  })
+
+  const sourceChainRpcType = step.intent.sourceChain.rpc_type
+  yield* Match.value(sourceChainRpcType).pipe(
+    Match.when("evm", () => doEvm),
+    Match.when("cosmos", () => doCosmos),
+    Match.orElse(() =>
+      Effect.gen(function*() {
+        yield* Effect.logFatal("Unknown chain type")
+        // TODO: make fail
+        return Effect.succeed("unknown chain type")
+      })
+    ),
+  )
+
+  yield* Effect.sync(() => {
     isSubmitting = false
-  }
+  })
 })
 
 const handleSubmit = () => {
@@ -253,10 +277,13 @@ const handleSubmit = () => {
     Exit.match(exit, {
       onFailure: cause => {
         const err = Cause.originalError(cause)
-        error = Option.some({
-          _tag: err.name || "UnhandledError",
-          cause: extractErrorDetails(cause),
-        })
+        Effect.runSync(Effect.logError(cause))
+        error = pipe(
+          err,
+          Cause.failures,
+          xs => Array.from(xs),
+          Arr.head,
+        )
         isSubmitting = false
       },
       onSuccess: constVoid,
@@ -291,37 +318,29 @@ const handleSubmit = () => {
       >
         Cancel
       </Button>
-      {#if Option.isSome(error)}
-        <div class="flex gap-2">
-          <Button
-            variant="danger"
-            onclick={() => (showError = true)}
-          >
-            Error
-          </Button>
-          <Button
-            variant="primary"
-            onclick={handleSubmit}
-            disabled={!isButtonEnabled}
-          >
-            {getSubmitButtonText}
-          </Button>
-        </div>
-      {:else}
-        <Button
-          variant="primary"
-          onclick={handleSubmit}
-          disabled={!isButtonEnabled}
-        >
-          {getSubmitButtonText}
-        </Button>
-      {/if}
+      <Button
+        variant="primary"
+        onclick={handleSubmit}
+        disabled={!isButtonEnabled}
+      >
+        {submitButtonText}
+      </Button>
     </div>
+    {#if Option.isSome(error)}
+      <div class="h-2"></div>
+      <ErrorComponent
+        onOpen={() => {
+          showError = true
+        }}
+        error={error.value}
+      />
+    {/if}
   {:else}
     <div class="flex items-center justify-center h-full">
       <p class="text-zinc-400">Loading submission details...</p>
     </div>
   {/if}
+
   <InsetError
     open={showError}
     error={Option.isSome(error) ? error.value : null}

--- a/app2/src/lib/transfer/shared/errors/index.ts
+++ b/app2/src/lib/transfer/shared/errors/index.ts
@@ -9,7 +9,8 @@ export class InsufficientFundsError extends Data.TaggedError("InsufficientFundsE
 }> {}
 
 export class AllowanceCheckError extends Data.TaggedError("AllowanceCheckError")<{
-  cause: unknown
+  message: string
+  cause?: unknown
 }> {}
 
 export class OrderCreationError extends Data.TaggedError("OrderCreationError")<{

--- a/app2/src/lib/transfer/shared/services/write-cosmos.ts
+++ b/app2/src/lib/transfer/shared/services/write-cosmos.ts
@@ -1,97 +1,104 @@
-import { switchChain } from "$lib/services/transfer-ucs03-cosmos"
+import {
+  CosmosSwitchChainError,
+  CosmosWalletNotConnectedError,
+  CosmosWalletNotOnWindowError,
+  CosmWasmError,
+  GasPriceError,
+  GetChainInfoError,
+  NoCosmosChainInfoError,
+  OfflineSignerError,
+  switchChain,
+} from "$lib/services/transfer-ucs03-cosmos"
+import type { EffectToExit, HasKey } from "$lib/types"
 import type { SigningCosmWasmClient } from "@cosmjs/cosmwasm-stargate"
-import { executeContract } from "@unionlabs/sdk/cosmos"
+import { executeContract, ExecuteContractError } from "@unionlabs/sdk/cosmos"
 import type { Chain } from "@unionlabs/sdk/schema"
-import { Data, Effect, type Exit, Schedule } from "effect"
+import { Data, Effect, Exit, Match, pipe, Predicate, Schedule } from "effect"
 
-export type EffectToExit<T> = T extends Effect.Effect<infer A, infer E, any> ? Exit.Exit<A, E>
-  : never
-
-export type TransactionSubmissionCosmos = Data.TaggedEnum<{
+export type TransactionState = Data.TaggedEnum<{
   Filling: {}
   SwitchChainInProgress: {}
-  SwitchChainComplete: { exit: EffectToExit<ReturnType<typeof switchChain>> }
+  SwitchChainComplete: { exit: Effect.Effect.Success<ReturnType<typeof switchChain>> }
   WriteContractInProgress: { signingClient: SigningCosmWasmClient }
   WriteContractComplete: {
     signingClient: SigningCosmWasmClient
-    exit: EffectToExit<ReturnType<typeof executeContract>>
+    exit: Effect.Effect.Success<ReturnType<typeof executeContract>>
   }
 }>
+type ExitStates = HasKey<TransactionState, "exit">
 
-export const TransactionSubmissionCosmos = Data.taggedEnum<TransactionSubmissionCosmos>()
-const {
+export const TransactionState = Data.taggedEnum<TransactionState>()
+export const {
   SwitchChainInProgress,
   SwitchChainComplete,
   WriteContractInProgress,
   WriteContractComplete,
-} = TransactionSubmissionCosmos
+  $is: is,
+} = TransactionState
 
-export const nextStateCosmos = async (
-  ts: TransactionSubmissionCosmos,
+export const nextState = (
+  ts: TransactionState,
   chain: Chain,
   senderAddress: string,
   contractAddress: string,
   msg: Record<string, unknown>,
   funds?: ReadonlyArray<{ denom: string; amount: string }>,
-): Promise<TransactionSubmissionCosmos> =>
-  TransactionSubmissionCosmos.$match(ts, {
-    Filling: () => {
-      return SwitchChainInProgress()
-    },
-    SwitchChainInProgress: async () => {
-      const switchResult = await Effect.runPromiseExit(switchChain(chain))
-      return SwitchChainComplete({
-        exit: switchResult,
-      })
-    },
-    SwitchChainComplete: ({ exit }) => {
-      if (exit._tag === "Failure") {
-        console.error("[SwitchChainComplete] Chain switch failed with error:", exit.cause)
-        console.log("[SwitchChainComplete] → Retrying SwitchChainInProgress")
-        return SwitchChainInProgress()
-      }
-      console.log(
-        "[SwitchChainComplete] Chain switch successful. → Moving to ExecuteContractInProgress",
-      )
-      return WriteContractInProgress({ signingClient: exit.value.signingClient })
-    },
-    WriteContractInProgress: async ({ signingClient }) => {
-      const retryableExecute = executeContract(
-        signingClient,
-        senderAddress,
-        contractAddress,
-        msg,
-        funds,
-      ).pipe(
-        Effect.retry({
-          while: error => error.message.includes("429"),
-          schedule: Schedule.fibonacci("1 second"),
-        }),
-      )
+): Effect.Effect<
+  TransactionState,
+  | CosmWasmError
+  | CosmosWalletNotConnectedError
+  | CosmosWalletNotOnWindowError
+  | ExecuteContractError
+  | GasPriceError
+  | GetChainInfoError
+  | NoCosmosChainInfoError
+  | OfflineSignerError
+  | CosmosSwitchChainError,
+  never
+> =>
+  TransactionState.$match(ts, {
+    Filling: () => Effect.succeed(SwitchChainInProgress()),
 
-      return WriteContractComplete({
-        signingClient,
-        exit: await Effect.runPromiseExit(retryableExecute),
-      })
-    },
+    SwitchChainInProgress: () =>
+      pipe(
+        switchChain(chain),
+        Effect.map((exit) => SwitchChainComplete({ exit })),
+      ),
 
-    WriteContractComplete: ({ signingClient, exit }) => {
-      if (exit._tag === "Failure") {
-        console.error("[ExecuteContractComplete] Contract execution failed with error:", exit.cause)
-        console.log("[ExecuteContractComplete] → Retrying ExecuteContractInProgress")
-        return WriteContractInProgress({ signingClient })
-      }
-      console.log("ExecuteContractComplete] Contract execution successful. Transaction complete!")
-      return ts
-    },
+    SwitchChainComplete: ({ exit }) =>
+      Effect.succeed(WriteContractInProgress({ signingClient: exit.signingClient })),
+
+    WriteContractInProgress: ({ signingClient }) =>
+      Effect.gen(function*() {
+        const retryableExecute = yield* executeContract(
+          signingClient,
+          senderAddress,
+          contractAddress,
+          msg,
+          funds,
+        ).pipe(
+          // TODO: replace with retry-after header policy
+          Effect.retry({
+            while: error => error.message.includes("429"),
+            schedule: Schedule.fibonacci("1 second"),
+          }),
+        )
+
+        return WriteContractComplete({
+          signingClient,
+          exit: retryableExecute,
+        })
+      }),
+
+    WriteContractComplete: ({ signingClient, exit }) => Effect.succeed(ts),
   })
 
-export const hasFailedExit = (state: TransactionSubmissionCosmos) =>
-  "exit" in state && state.exit._tag === "Failure"
-
-export const isComplete = (state: TransactionSubmissionCosmos): string | false => {
-  if (state._tag === "WriteContractComplete" && state.exit._tag === "Success") {
-    return state.exit.value.transactionHash
-  }
-  return false
-}
+export const toCtaText = (orElse: string) =>
+  pipe(
+    Match.type<TransactionState>(),
+    Match.tags({
+      WriteContractInProgress: () => "Confirming Transaction..." as const,
+      SwitchChainInProgress: () => "Switching Chain..." as const,
+    }),
+    Match.orElse(() => orElse),
+  )

--- a/app2/src/lib/transfer/shared/services/write-cosmos.ts
+++ b/app2/src/lib/transfer/shared/services/write-cosmos.ts
@@ -77,7 +77,8 @@ export const nextState = (
           msg,
           funds,
         ).pipe(
-          // TODO: replace with retry-after header policy
+          // TODO: replace with retry-after header policy (?)
+          // TODO: consider load-balancer scenario
           Effect.retry({
             while: error => error.message.includes("429"),
             schedule: Schedule.fibonacci("1 second"),

--- a/app2/src/lib/transfer/shared/services/write-evm.ts
+++ b/app2/src/lib/transfer/shared/services/write-evm.ts
@@ -79,13 +79,12 @@ export const nextState = <
 
     SwitchChainInProgress: () =>
       Effect.gen(function*() {
-        const isSafeWallet = getLastConnectedWalletId() === "safe" // safe wagmi connector does not support wagmiSwitchChain
+        // safe wagmi connector does not support wagmiSwitchChain
+        const isSafeWallet = getLastConnectedWalletId() === "safe"
 
         if (isSafeWallet) {
           return WriteContractInProgress()
         }
-
-        yield* Effect.logInfo("switch chain in progress")
 
         return yield* pipe(
           switchChain(chain),
@@ -93,9 +92,7 @@ export const nextState = <
         )
       }),
 
-    SwitchChainComplete: ({ exit }) =>
-      // exit._tag === "Failure" ? SwitchChainInProgress() : WriteContractInProgress(),
-      Effect.succeed(WriteContractInProgress()),
+    SwitchChainComplete: ({ exit }) => Effect.succeed(WriteContractInProgress()),
 
     WriteContractInProgress: () =>
       pipe(
@@ -109,19 +106,9 @@ export const nextState = <
 
     WriteContractComplete: ({ exit: hash }) =>
       Effect.gen(function*() {
-        // if (exit._tag === "Failure") {
-        //   return WriteContractInProgress()
-        // }
-
         const wallet = getLastConnectedWalletId()
 
         // needed due to safe wagmi connector returns safeTx hash and not the onchain one
-        if (wallet === "safe") {
-          return WaitForSafeWalletHash({ hash })
-        }
-
-        return TransactionReceiptInProgress({ hash })
-
         return wallet === "safe"
           ? WaitForSafeWalletHash({ hash })
           : TransactionReceiptInProgress({ hash })
@@ -132,9 +119,6 @@ export const nextState = <
         const resolvedHash = yield* resolveSafeTx(hash) // TODO ???
 
         return TransactionReceiptInProgress({ hash: resolvedHash })
-        // return resolvedExit._tag === "Failure"
-        //   ? WaitForSafeWalletHash({ hash })
-        //   : TransactionReceiptInProgress({ hash: resolvedExit.value })
       }),
 
     TransactionReceiptInProgress: ({ hash }) =>

--- a/app2/src/lib/types.ts
+++ b/app2/src/lib/types.ts
@@ -1,0 +1,27 @@
+import type { Effect, Exit } from "effect"
+
+/**
+ * Transform {@link Effect.Effect} to {@link Exit.Exit}
+ */
+export type EffectToExit<T> = T extends Effect.Effect<infer A, infer E, any> ? Exit.Exit<A, E>
+  : never
+
+/**
+ * Filter sum type to variants which contain a given property key.
+ */
+export type HasKey<T, K extends PropertyKey> = T extends any ? K extends keyof T ? T
+  : never
+  : never
+
+/**
+ * Map {@link Exit.Success} onto `exit` property of given type.
+ */
+type WithExitToSuccess<T> = T extends { exit: Exit.Exit<infer A, infer E> } ? {
+    [K in keyof T]: K extends "exit" ? Exit.Success<A, E> : T[K]
+  }
+  : never
+
+/**
+ * Drop first entry in an array.
+ */
+export type Tail<T extends any[]> = T extends [any, ...infer Rest] ? Rest : []

--- a/app2/src/lib/utils/interpolate.ts
+++ b/app2/src/lib/utils/interpolate.ts
@@ -1,0 +1,27 @@
+import { Array as A, Record as R, String as S } from "effect"
+import { dual, pipe } from "effect/Function"
+
+type ExtractPlaceholders<T extends string> = T extends
+  `${infer _Start}{{${infer Key}}}${infer Rest}` ? Key | ExtractPlaceholders<Rest>
+  : never
+
+export const interpolate: {
+  <T extends string, Keys extends ExtractPlaceholders<T>>(
+    self: T,
+  ): (map: { [K in Keys]: string }) => string
+  <T extends string, Keys extends ExtractPlaceholders<T>>(
+    self: T,
+    map: { [K in Keys]: string },
+  ): string
+} = dual(
+  2,
+  <T extends string, Keys extends ExtractPlaceholders<T>>(
+    self: T,
+    map: { [K in Keys]: string },
+  ): string =>
+    pipe(
+      R.map(map, (a, key) => S.replaceAll(`{{${key}}}`, a)),
+      R.values,
+      A.reduce(self as string, (acc, f) => f(acc)),
+    ),
+)

--- a/app2/tsconfig.json
+++ b/app2/tsconfig.json
@@ -19,7 +19,6 @@
     "sourceMap": true,
     "strict": true,
     "exactOptionalPropertyTypes": true,
-    "noErrorTruncation": true,
     "moduleResolution": "bundler",
     "allowImportingTsExtensions": true,
     "plugins": [

--- a/app2/tsconfig.json
+++ b/app2/tsconfig.json
@@ -1,7 +1,14 @@
 {
   "$schema": "https://json.schemastore.org/tsconfig",
   "extends": "./.svelte-kit/tsconfig.json",
-  "references": [{ "path": "../ts-sdk" }, { "path": "../typescript-sdk" }],
+  "references": [
+    {
+      "path": "../ts-sdk"
+    },
+    {
+      "path": "../typescript-sdk"
+    }
+  ],
   "compilerOptions": {
     "allowJs": true,
     "checkJs": true,
@@ -12,10 +19,13 @@
     "sourceMap": true,
     "strict": true,
     "exactOptionalPropertyTypes": true,
+    "noErrorTruncation": true,
     "moduleResolution": "bundler",
     "allowImportingTsExtensions": true,
     "plugins": [
-      { "name": "@effect/language-service" },
+      {
+        "name": "@effect/language-service"
+      },
       {
         "name": "gql.tada/ts-plugin",
         "schema": "./src/generated/schema.graphql",


### PR DESCRIPTION
- Full rewrite of EVM and Cosmos transaction FSMs for the sake of type clarity. No more `Promise` and `Exit` usage until execution boundary.
- Fixes to CTA button copy not being updated separately for EVM and Cosmos in Approval and Submit steps.
- All errors now discriminable and tracked at the type level in Approval and Submit steps.
- `<ErrorComponent />` additions to guarantee every provided error has a corresponding human-readable message. <sub>_(also reintroduction of this component in the transfer flow to replace "Error" CTA)_<sub>
- An extraordinary amount of exhaustive matching.
- Unfinished interpolation functions for dynamic copywrite.
- `SwitchChainError` is now a sum type containing `EvmSwitchChainError` and `CosmosSwitchChainError` to serve as an example moving forward, such that errors have unique tags and can be matched appropriately.
- Fixed weird case of balance checking hanging in [`5ec947f`](https://github.com/unionlabs/union/pull/4550/commits/5ec947fda6f0e6e7edf8462f06afb94a815938d4).
- Fixed issue in `<InsetError />` component causing leading whitespace before the opening brace.