### PR TITLE
refactor(zk_verifier): reuse HashToField from cometbls/crypto/bn254

### DIFF
--- a/11-cometbls/zk_verifier_test.go
+++ b/11-cometbls/zk_verifier_test.go
@@ -21,7 +21,7 @@ func TestVerifier(t *testing.T) {
 	err = zkp.Verify(
 
 		trustedValHash,
-		LightHeader{
+		ProverLightHeader{
 			ChainId:            "union-devnet-1337",
 			Height:             3405691582,
 			Time:               time.Unix(1710783278, 499600406),


### PR DESCRIPTION
This PR removes the locally defined `HashToField` function in `zk_verifier.go` and instead reuses the implementation provided in the `cometbls` repository under:

- https://github.com/unionlabs/cometbls/blob/960ce8b37bd94347cd17dd4dbed18159a2855520/crypto/bn254/bn254.go#L194

The function was already defined and exported in the bn254 module, so duplicating it locally was unnecessary.

Changes:
- Removed the local `HashToField` function from `zk_verifier.go`
- Replaced it with `comet.HashToField` from `github.com/unionlabs/cometbls/crypto/bn254`
- Verified that the behavior and logic match the original

Closes #2804
