### PR TITLE
Add mainnet-only switch to transfers and packets

### DIFF
--- a/app2/src/generated/graphql-env.d.ts
+++ b/app2/src/generated/graphql-env.d.ts
@@ -1,232 +1,6 @@
 /* eslint-disable */
 /* prettier-ignore */
 
-export type introspection_types = {
-    'Boolean': unknown;
-    'Boolean_comparison_exp': { kind: 'INPUT_OBJECT'; name: 'Boolean_comparison_exp'; isOneOf: false; inputFields: [{ name: '_eq'; type: { kind: 'SCALAR'; name: 'Boolean'; ofType: null; }; defaultValue: null }, { name: '_gt'; type: { kind: 'SCALAR'; name: 'Boolean'; ofType: null; }; defaultValue: null }, { name: '_gte'; type: { kind: 'SCALAR'; name: 'Boolean'; ofType: null; }; defaultValue: null }, { name: '_in'; type: { kind: 'LIST'; name: never; ofType: { kind: 'NON_NULL'; name: never; ofType: { kind: 'SCALAR'; name: 'Boolean'; ofType: null; }; }; }; defaultValue: null }, { name: '_is_null'; type: { kind: 'SCALAR'; name: 'Boolean'; ofType: null; }; defaultValue: null }, { name: '_lt'; type: { kind: 'SCALAR'; name: 'Boolean'; ofType: null; }; defaultValue: null }, { name: '_lte'; type: { kind: 'SCALAR'; name: 'Boolean'; ofType: null; }; defaultValue: null }, { name: '_neq'; type: { kind: 'SCALAR'; name: 'Boolean'; ofType: null; }; defaultValue: null }, { name: '_nin'; type: { kind: 'LIST'; name: never; ofType: { kind: 'NON_NULL'; name: never; ofType: { kind: 'SCALAR'; name: 'Boolean'; ofType: null; }; }; }; defaultValue: null }]; };
-    'Int': unknown;
-    'Int_comparison_exp': { kind: 'INPUT_OBJECT'; name: 'Int_comparison_exp'; isOneOf: false; inputFields: [{ name: '_eq'; type: { kind: 'SCALAR'; name: 'Int'; ofType: null; }; defaultValue: null }, { name: '_gt'; type: { kind: 'SCALAR'; name: 'Int'; ofType: null; }; defaultValue: null }, { name: '_gte'; type: { kind: 'SCALAR'; name: 'Int'; ofType: null; }; defaultValue: null }, { name: '_in'; type: { kind: 'LIST'; name: never; ofType: { kind: 'NON_NULL'; name: never; ofType: { kind: 'SCALAR'; name: 'Int'; ofType: null; }; }; }; defaultValue: null }, { name: '_is_null'; type: { kind: 'SCALAR'; name: 'Boolean'; ofType: null; }; defaultValue: null }, { name: '_lt'; type: { kind: 'SCALAR'; name: 'Int'; ofType: null; }; defaultValue: null }, { name: '_lte'; type: { kind: 'SCALAR'; name: 'Int'; ofType: null; }; defaultValue: null }, { name: '_neq'; type: { kind: 'SCALAR'; name: 'Int'; ofType: null; }; defaultValue: null }, { name: '_nin'; type: { kind: 'LIST'; name: never; ofType: { kind: 'NON_NULL'; name: never; ofType: { kind: 'SCALAR'; name: 'Int'; ofType: null; }; }; }; defaultValue: null }]; };
-    'Request': { kind: 'OBJECT'; name: 'Request'; fields: { 'address': { name: 'address'; type: { kind: 'NON_NULL'; name: never; ofType: { kind: 'SCALAR'; name: 'String'; ofType: null; }; } }; 'id': { name: 'id'; type: { kind: 'NON_NULL'; name: never; ofType: { kind: 'SCALAR'; name: 'Int'; ofType: null; }; } }; 'time': { name: 'time'; type: { kind: 'NON_NULL'; name: never; ofType: { kind: 'SCALAR'; name: 'String'; ofType: null; }; } }; 'txHash': { name: 'txHash'; type: { kind: 'SCALAR'; name: 'String'; ofType: null; } }; }; };
-    'String': unknown;
-    'String_array_comparison_exp': { kind: 'INPUT_OBJECT'; name: 'String_array_comparison_exp'; isOneOf: false; inputFields: [{ name: '_contained_in'; type: { kind: 'LIST'; name: never; ofType: { kind: 'NON_NULL'; name: never; ofType: { kind: 'SCALAR'; name: 'String'; ofType: null; }; }; }; defaultValue: null }, { name: '_contains'; type: { kind: 'LIST'; name: never; ofType: { kind: 'NON_NULL'; name: never; ofType: { kind: 'SCALAR'; name: 'String'; ofType: null; }; }; }; defaultValue: null }, { name: '_eq'; type: { kind: 'LIST'; name: never; ofType: { kind: 'NON_NULL'; name: never; ofType: { kind: 'SCALAR'; name: 'String'; ofType: null; }; }; }; defaultValue: null }, { name: '_gt'; type: { kind: 'LIST'; name: never; ofType: { kind: 'NON_NULL'; name: never; ofType: { kind: 'SCALAR'; name: 'String'; ofType: null; }; }; }; defaultValue: null }, { name: '_gte'; type: { kind: 'LIST'; name: never; ofType: { kind: 'NON_NULL'; name: never; ofType: { kind: 'SCALAR'; name: 'String'; ofType: null; }; }; }; defaultValue: null }, { name: '_in'; type: { kind: 'LIST'; name: never; ofType: { kind: 'NON_NULL'; name: never; ofType: { kind: 'LIST'; name: never; ofType: { kind: 'NON_NULL'; name: never; ofType: { kind: 'SCALAR'; name: 'String'; ofType: null; }; }; }; }; }; defaultValue: null }, { name: '_is_null'; type: { kind: 'SCALAR'; name: 'Boolean'; ofType: null; }; defaultValue: null }, { name: '_lt'; type: { kind: 'LIST'; name: never; ofType: { kind: 'NON_NULL'; name: never; ofType: { kind: 'SCALAR'; name: 'String'; ofType: null; }; }; }; defaultValue: null }, { name: '_lte'; type: { kind: 'LIST'; name: never; ofType: { kind: 'NON_NULL'; name: never; ofType: { kind: 'SCALAR'; name: 'String'; ofType: null; }; }; }; defaultValue: null }, { name: '_neq'; type: { kind: 'LIST'; name: never; ofType: { kind: 'NON_NULL'; name: never; ofType: { kind: 'SCALAR'; name: 'String'; ofType: null; }; }; }; defaultValue: null }, { name: '_nin'; type: { kind: 'LIST'; name: never; ofType: { kind: 'NON_NULL'; name: never; ofType: { kind: 'LIST'; name: never; ofType: { kind: 'NON_NULL'; name: never; ofType: { kind: 'SCALAR'; name: 'String'; ofType: null; }; }; }; }; }; defaultValue: null }]; };
-    'String_comparison_exp': { kind: 'INPUT_OBJECT'; name: 'String_comparison_exp'; isOneOf: false; inputFields: [{ name: '_eq'; type: { kind: 'SCALAR'; name: 'String'; ofType: null; }; defaultValue: null }, { name: '_gt'; type: { kind: 'SCALAR'; name: 'String'; ofType: null; }; defaultValue: null }, { name: '_gte'; type: { kind: 'SCALAR'; name: 'String'; ofType: null; }; defaultValue: null }, { name: '_ilike'; type: { kind: 'SCALAR'; name: 'String'; ofType: null; }; defaultValue: null }, { name: '_in'; type: { kind: 'LIST'; name: never; ofType: { kind: 'NON_NULL'; name: never; ofType: { kind: 'SCALAR'; name: 'String'; ofType: null; }; }; }; defaultValue: null }, { name: '_iregex'; type: { kind: 'SCALAR'; name: 'String'; ofType: null; }; defaultValue: null }, { name: '_is_null'; type: { kind: 'SCALAR'; name: 'Boolean'; ofType: null; }; defaultValue: null }, { name: '_like'; type: { kind: 'SCALAR'; name: 'String'; ofType: null; }; defaultValue: null }, { name: '_lt'; type: { kind: 'SCALAR'; name: 'String'; ofType: null; }; defaultValue: null }, { name: '_lte'; type: { kind: 'SCALAR'; name: 'String'; ofType: null; }; defaultValue: null }, { name: '_neq'; type: { kind: 'SCALAR'; name: 'String'; ofType: null; }; defaultValue: null }, { name: '_nilike'; type: { kind: 'SCALAR'; name: 'String'; ofType: null; }; defaultValue: null }, { name: '_nin'; type: { kind: 'LIST'; name: never; ofType: { kind: 'NON_NULL'; name: never; ofType: { kind: 'SCALAR'; name: 'String'; ofType: null; }; }; }; defaultValue: null }, { name: '_niregex'; type: { kind: 'SCALAR'; name: 'String'; ofType: null; }; defaultValue: null }, { name: '_nlike'; type: { kind: 'SCALAR'; name: 'String'; ofType: null; }; defaultValue: null }, { name: '_nregex'; type: { kind: 'SCALAR'; name: 'String'; ofType: null; }; defaultValue: null }, { name: '_nsimilar'; type: { kind: 'SCALAR'; name: 'String'; ofType: null; }; defaultValue: null }, { name: '_regex'; type: { kind: 'SCALAR'; name: 'String'; ofType: null; }; defaultValue: null }, { name: '_similar'; type: { kind: 'SCALAR'; name: 'String'; ofType: null; }; defaultValue: null }]; };
-    'cursor_ordering': { name: 'cursor_ordering'; enumValues: 'ASC' | 'DESC'; };
-    'dashboard_count_by_chain_type': { kind: 'OBJECT'; name: 'dashboard_count_by_chain_type'; fields: { 'count': { name: 'count'; type: { kind: 'SCALAR'; name: 'String'; ofType: null; } }; 'phase': { name: 'phase'; type: { kind: 'SCALAR'; name: 'String'; ofType: null; } }; 'universal_chain_id': { name: 'universal_chain_id'; type: { kind: 'SCALAR'; name: 'String'; ofType: null; } }; }; };
-    'dashboard_count_by_chain_type_bool_exp': { kind: 'INPUT_OBJECT'; name: 'dashboard_count_by_chain_type_bool_exp'; isOneOf: false; inputFields: [{ name: '_and'; type: { kind: 'LIST'; name: never; ofType: { kind: 'NON_NULL'; name: never; ofType: { kind: 'INPUT_OBJECT'; name: 'dashboard_count_by_chain_type_bool_exp'; ofType: null; }; }; }; defaultValue: null }, { name: '_not'; type: { kind: 'INPUT_OBJECT'; name: 'dashboard_count_by_chain_type_bool_exp'; ofType: null; }; defaultValue: null }, { name: '_or'; type: { kind: 'LIST'; name: never; ofType: { kind: 'NON_NULL'; name: never; ofType: { kind: 'INPUT_OBJECT'; name: 'dashboard_count_by_chain_type_bool_exp'; ofType: null; }; }; }; defaultValue: null }, { name: 'count'; type: { kind: 'INPUT_OBJECT'; name: 'String_comparison_exp'; ofType: null; }; defaultValue: null }, { name: 'phase'; type: { kind: 'INPUT_OBJECT'; name: 'String_comparison_exp'; ofType: null; }; defaultValue: null }, { name: 'universal_chain_id'; type: { kind: 'INPUT_OBJECT'; name: 'String_comparison_exp'; ofType: null; }; defaultValue: null }]; };
-    'dashboard_count_by_chain_type_order_by': { kind: 'INPUT_OBJECT'; name: 'dashboard_count_by_chain_type_order_by'; isOneOf: false; inputFields: [{ name: 'count'; type: { kind: 'ENUM'; name: 'order_by'; ofType: null; }; defaultValue: null }, { name: 'phase'; type: { kind: 'ENUM'; name: 'order_by'; ofType: null; }; defaultValue: null }, { name: 'universal_chain_id'; type: { kind: 'ENUM'; name: 'order_by'; ofType: null; }; defaultValue: null }]; };
-    'dashboard_count_by_chain_type_select_column': { name: 'dashboard_count_by_chain_type_select_column'; enumValues: 'count' | 'phase' | 'universal_chain_id'; };
-    'dashboard_days_by_chain_type': { kind: 'OBJECT'; name: 'dashboard_days_by_chain_type'; fields: { 'day_count': { name: 'day_count'; type: { kind: 'SCALAR'; name: 'String'; ofType: null; } }; 'universal_chain_id': { name: 'universal_chain_id'; type: { kind: 'SCALAR'; name: 'String'; ofType: null; } }; }; };
-    'dashboard_days_by_chain_type_bool_exp': { kind: 'INPUT_OBJECT'; name: 'dashboard_days_by_chain_type_bool_exp'; isOneOf: false; inputFields: [{ name: '_and'; type: { kind: 'LIST'; name: never; ofType: { kind: 'NON_NULL'; name: never; ofType: { kind: 'INPUT_OBJECT'; name: 'dashboard_days_by_chain_type_bool_exp'; ofType: null; }; }; }; defaultValue: null }, { name: '_not'; type: { kind: 'INPUT_OBJECT'; name: 'dashboard_days_by_chain_type_bool_exp'; ofType: null; }; defaultValue: null }, { name: '_or'; type: { kind: 'LIST'; name: never; ofType: { kind: 'NON_NULL'; name: never; ofType: { kind: 'INPUT_OBJECT'; name: 'dashboard_days_by_chain_type_bool_exp'; ofType: null; }; }; }; defaultValue: null }, { name: 'day_count'; type: { kind: 'INPUT_OBJECT'; name: 'String_comparison_exp'; ofType: null; }; defaultValue: null }, { name: 'universal_chain_id'; type: { kind: 'INPUT_OBJECT'; name: 'String_comparison_exp'; ofType: null; }; defaultValue: null }]; };
-    'dashboard_days_by_chain_type_order_by': { kind: 'INPUT_OBJECT'; name: 'dashboard_days_by_chain_type_order_by'; isOneOf: false; inputFields: [{ name: 'day_count'; type: { kind: 'ENUM'; name: 'order_by'; ofType: null; }; defaultValue: null }, { name: 'universal_chain_id'; type: { kind: 'ENUM'; name: 'order_by'; ofType: null; }; defaultValue: null }]; };
-    'dashboard_days_by_chain_type_select_column': { name: 'dashboard_days_by_chain_type_select_column'; enumValues: 'day_count' | 'universal_chain_id'; };
-    'dashboard_transfer_count_by_chain_args': { kind: 'INPUT_OBJECT'; name: 'dashboard_transfer_count_by_chain_args'; isOneOf: false; inputFields: [{ name: 'p_addresses_dashboard'; type: { kind: 'SCALAR'; name: 'jsonb'; ofType: null; }; defaultValue: null }, { name: 'p_phase'; type: { kind: 'SCALAR'; name: 'String'; ofType: null; }; defaultValue: null }]; };
-    'dashboard_transfer_days_count_by_chain_args': { kind: 'INPUT_OBJECT'; name: 'dashboard_transfer_days_count_by_chain_args'; isOneOf: false; inputFields: [{ name: 'p_addresses_dashboard'; type: { kind: 'SCALAR'; name: 'jsonb'; ofType: null; }; defaultValue: null }]; };
-    'date': unknown;
-    'date_comparison_exp': { kind: 'INPUT_OBJECT'; name: 'date_comparison_exp'; isOneOf: false; inputFields: [{ name: '_eq'; type: { kind: 'SCALAR'; name: 'date'; ofType: null; }; defaultValue: null }, { name: '_gt'; type: { kind: 'SCALAR'; name: 'date'; ofType: null; }; defaultValue: null }, { name: '_gte'; type: { kind: 'SCALAR'; name: 'date'; ofType: null; }; defaultValue: null }, { name: '_in'; type: { kind: 'LIST'; name: never; ofType: { kind: 'NON_NULL'; name: never; ofType: { kind: 'SCALAR'; name: 'date'; ofType: null; }; }; }; defaultValue: null }, { name: '_is_null'; type: { kind: 'SCALAR'; name: 'Boolean'; ofType: null; }; defaultValue: null }, { name: '_lt'; type: { kind: 'SCALAR'; name: 'date'; ofType: null; }; defaultValue: null }, { name: '_lte'; type: { kind: 'SCALAR'; name: 'date'; ofType: null; }; defaultValue: null }, { name: '_neq'; type: { kind: 'SCALAR'; name: 'date'; ofType: null; }; defaultValue: null }, { name: '_nin'; type: { kind: 'LIST'; name: never; ofType: { kind: 'NON_NULL'; name: never; ofType: { kind: 'SCALAR'; name: 'date'; ofType: null; }; }; }; defaultValue: null }]; };
-    'drip_dropMutation': { kind: 'OBJECT'; name: 'drip_dropMutation'; fields: { 'send': { name: 'send'; type: { kind: 'NON_NULL'; name: never; ofType: { kind: 'SCALAR'; name: 'String'; ofType: null; }; } }; }; };
-    'drip_dropQuery': { kind: 'OBJECT'; name: 'drip_dropQuery'; fields: { 'handledTransfers': { name: 'handledTransfers'; type: { kind: 'NON_NULL'; name: never; ofType: { kind: 'LIST'; name: never; ofType: { kind: 'NON_NULL'; name: never; ofType: { kind: 'OBJECT'; name: 'Request'; ofType: null; }; }; }; } }; 'transfersForAddress': { name: 'transfersForAddress'; type: { kind: 'NON_NULL'; name: never; ofType: { kind: 'LIST'; name: never; ofType: { kind: 'NON_NULL'; name: never; ofType: { kind: 'OBJECT'; name: 'Request'; ofType: null; }; }; }; } }; 'unhandledTransfers': { name: 'unhandledTransfers'; type: { kind: 'NON_NULL'; name: never; ofType: { kind: 'LIST'; name: never; ofType: { kind: 'NON_NULL'; name: never; ofType: { kind: 'OBJECT'; name: 'Request'; ofType: null; }; }; }; } }; }; };
-    'jsonb': unknown;
-    'jsonb_cast_exp': { kind: 'INPUT_OBJECT'; name: 'jsonb_cast_exp'; isOneOf: false; inputFields: [{ name: 'String'; type: { kind: 'INPUT_OBJECT'; name: 'String_comparison_exp'; ofType: null; }; defaultValue: null }]; };
-    'jsonb_comparison_exp': { kind: 'INPUT_OBJECT'; name: 'jsonb_comparison_exp'; isOneOf: false; inputFields: [{ name: '_cast'; type: { kind: 'INPUT_OBJECT'; name: 'jsonb_cast_exp'; ofType: null; }; defaultValue: null }, { name: '_contained_in'; type: { kind: 'SCALAR'; name: 'jsonb'; ofType: null; }; defaultValue: null }, { name: '_contains'; type: { kind: 'SCALAR'; name: 'jsonb'; ofType: null; }; defaultValue: null }, { name: '_eq'; type: { kind: 'SCALAR'; name: 'jsonb'; ofType: null; }; defaultValue: null }, { name: '_gt'; type: { kind: 'SCALAR'; name: 'jsonb'; ofType: null; }; defaultValue: null }, { name: '_gte'; type: { kind: 'SCALAR'; name: 'jsonb'; ofType: null; }; defaultValue: null }, { name: '_has_key'; type: { kind: 'SCALAR'; name: 'String'; ofType: null; }; defaultValue: null }, { name: '_has_keys_all'; type: { kind: 'LIST'; name: never; ofType: { kind: 'NON_NULL'; name: never; ofType: { kind: 'SCALAR'; name: 'String'; ofType: null; }; }; }; defaultValue: null }, { name: '_has_keys_any'; type: { kind: 'LIST'; name: never; ofType: { kind: 'NON_NULL'; name: never; ofType: { kind: 'SCALAR'; name: 'String'; ofType: null; }; }; }; defaultValue: null }, { name: '_in'; type: { kind: 'LIST'; name: never; ofType: { kind: 'NON_NULL'; name: never; ofType: { kind: 'SCALAR'; name: 'jsonb'; ofType: null; }; }; }; defaultValue: null }, { name: '_is_null'; type: { kind: 'SCALAR'; name: 'Boolean'; ofType: null; }; defaultValue: null }, { name: '_lt'; type: { kind: 'SCALAR'; name: 'jsonb'; ofType: null; }; defaultValue: null }, { name: '_lte'; type: { kind: 'SCALAR'; name: 'jsonb'; ofType: null; }; defaultValue: null }, { name: '_neq'; type: { kind: 'SCALAR'; name: 'jsonb'; ofType: null; }; defaultValue: null }, { name: '_nin'; type: { kind: 'LIST'; name: never; ofType: { kind: 'NON_NULL'; name: never; ofType: { kind: 'SCALAR'; name: 'jsonb'; ofType: null; }; }; }; defaultValue: null }]; };
-    'latency_percentiles_scalar': unknown;
-    'latency_percentiles_scalar_comparison_exp': { kind: 'INPUT_OBJECT'; name: 'latency_percentiles_scalar_comparison_exp'; isOneOf: false; inputFields: [{ name: '_eq'; type: { kind: 'SCALAR'; name: 'latency_percentiles_scalar'; ofType: null; }; defaultValue: null }, { name: '_gt'; type: { kind: 'SCALAR'; name: 'latency_percentiles_scalar'; ofType: null; }; defaultValue: null }, { name: '_gte'; type: { kind: 'SCALAR'; name: 'latency_percentiles_scalar'; ofType: null; }; defaultValue: null }, { name: '_in'; type: { kind: 'LIST'; name: never; ofType: { kind: 'NON_NULL'; name: never; ofType: { kind: 'SCALAR'; name: 'latency_percentiles_scalar'; ofType: null; }; }; }; defaultValue: null }, { name: '_is_null'; type: { kind: 'SCALAR'; name: 'Boolean'; ofType: null; }; defaultValue: null }, { name: '_lt'; type: { kind: 'SCALAR'; name: 'latency_percentiles_scalar'; ofType: null; }; defaultValue: null }, { name: '_lte'; type: { kind: 'SCALAR'; name: 'latency_percentiles_scalar'; ofType: null; }; defaultValue: null }, { name: '_neq'; type: { kind: 'SCALAR'; name: 'latency_percentiles_scalar'; ofType: null; }; defaultValue: null }, { name: '_nin'; type: { kind: 'LIST'; name: never; ofType: { kind: 'NON_NULL'; name: never; ofType: { kind: 'SCALAR'; name: 'latency_percentiles_scalar'; ofType: null; }; }; }; defaultValue: null }]; };
-    'mutation_root': { kind: 'OBJECT'; name: 'mutation_root'; fields: { 'drip_drop': { name: 'drip_drop'; type: { kind: 'OBJECT'; name: 'drip_dropMutation'; ofType: null; } }; }; };
-    'order_by': { name: 'order_by'; enumValues: 'asc' | 'asc_nulls_first' | 'asc_nulls_last' | 'desc' | 'desc_nulls_first' | 'desc_nulls_last'; };
-    'query_root': { kind: 'OBJECT'; name: 'query_root'; fields: { 'dashboard_transfer_count_by_chain': { name: 'dashboard_transfer_count_by_chain'; type: { kind: 'NON_NULL'; name: never; ofType: { kind: 'LIST'; name: never; ofType: { kind: 'NON_NULL'; name: never; ofType: { kind: 'OBJECT'; name: 'dashboard_count_by_chain_type'; ofType: null; }; }; }; } }; 'dashboard_transfer_days_count_by_chain': { name: 'dashboard_transfer_days_count_by_chain'; type: { kind: 'NON_NULL'; name: never; ofType: { kind: 'LIST'; name: never; ofType: { kind: 'NON_NULL'; name: never; ofType: { kind: 'OBJECT'; name: 'dashboard_days_by_chain_type'; ofType: null; }; }; }; } }; 'drip_drop': { name: 'drip_drop'; type: { kind: 'OBJECT'; name: 'drip_dropQuery'; ofType: null; } }; 'v2_chains': { name: 'v2_chains'; type: { kind: 'NON_NULL'; name: never; ofType: { kind: 'LIST'; name: never; ofType: { kind: 'NON_NULL'; name: never; ofType: { kind: 'OBJECT'; name: 'v2_chain_type'; ofType: null; }; }; }; } }; 'v2_channels': { name: 'v2_channels'; type: { kind: 'NON_NULL'; name: never; ofType: { kind: 'LIST'; name: never; ofType: { kind: 'NON_NULL'; name: never; ofType: { kind: 'OBJECT'; name: 'v2_channel_type'; ofType: null; }; }; }; } }; 'v2_clients': { name: 'v2_clients'; type: { kind: 'NON_NULL'; name: never; ofType: { kind: 'LIST'; name: never; ofType: { kind: 'NON_NULL'; name: never; ofType: { kind: 'OBJECT'; name: 'v2_client_type'; ofType: null; }; }; }; } }; 'v2_connections': { name: 'v2_connections'; type: { kind: 'NON_NULL'; name: never; ofType: { kind: 'LIST'; name: never; ofType: { kind: 'NON_NULL'; name: never; ofType: { kind: 'OBJECT'; name: 'v2_connection_type'; ofType: null; }; }; }; } }; 'v2_error_type': { name: 'v2_error_type'; type: { kind: 'NON_NULL'; name: never; ofType: { kind: 'LIST'; name: never; ofType: { kind: 'NON_NULL'; name: never; ofType: { kind: 'OBJECT'; name: 'v2_error_type'; ofType: null; }; }; }; } }; 'v2_errors': { name: 'v2_errors'; type: { kind: 'NON_NULL'; name: never; ofType: { kind: 'LIST'; name: never; ofType: { kind: 'NON_NULL'; name: never; ofType: { kind: 'OBJECT'; name: 'v2_error_type'; ofType: null; }; }; }; } }; 'v2_health_check': { name: 'v2_health_check'; type: { kind: 'NON_NULL'; name: never; ofType: { kind: 'LIST'; name: never; ofType: { kind: 'NON_NULL'; name: never; ofType: { kind: 'OBJECT'; name: 'v2_health_check_type'; ofType: null; }; }; }; } }; 'v2_packets': { name: 'v2_packets'; type: { kind: 'NON_NULL'; name: never; ofType: { kind: 'LIST'; name: never; ofType: { kind: 'NON_NULL'; name: never; ofType: { kind: 'OBJECT'; name: 'v2_packet_type'; ofType: null; }; }; }; } }; 'v2_stats_count': { name: 'v2_stats_count'; type: { kind: 'NON_NULL'; name: never; ofType: { kind: 'LIST'; name: never; ofType: { kind: 'NON_NULL'; name: never; ofType: { kind: 'OBJECT'; name: 'v2_stats_type'; ofType: null; }; }; }; } }; 'v2_stats_latency': { name: 'v2_stats_latency'; type: { kind: 'NON_NULL'; name: never; ofType: { kind: 'LIST'; name: never; ofType: { kind: 'NON_NULL'; name: never; ofType: { kind: 'OBJECT'; name: 'v2_stats_latency_type'; ofType: null; }; }; }; } }; 'v2_stats_packets_chain': { name: 'v2_stats_packets_chain'; type: { kind: 'NON_NULL'; name: never; ofType: { kind: 'LIST'; name: never; ofType: { kind: 'NON_NULL'; name: never; ofType: { kind: 'OBJECT'; name: 'v2_stats_packets_chain_type'; ofType: null; }; }; }; } }; 'v2_stats_packets_daily_count': { name: 'v2_stats_packets_daily_count'; type: { kind: 'NON_NULL'; name: never; ofType: { kind: 'LIST'; name: never; ofType: { kind: 'NON_NULL'; name: never; ofType: { kind: 'OBJECT'; name: 'v2_stats_daily_count_type'; ofType: null; }; }; }; } }; 'v2_stats_transfers_address': { name: 'v2_stats_transfers_address'; type: { kind: 'NON_NULL'; name: never; ofType: { kind: 'LIST'; name: never; ofType: { kind: 'NON_NULL'; name: never; ofType: { kind: 'OBJECT'; name: 'v2_stats_transfers_address_type'; ofType: null; }; }; }; } }; 'v2_stats_transfers_chain': { name: 'v2_stats_transfers_chain'; type: { kind: 'NON_NULL'; name: never; ofType: { kind: 'LIST'; name: never; ofType: { kind: 'NON_NULL'; name: never; ofType: { kind: 'OBJECT'; name: 'v2_stats_transfers_chain_type'; ofType: null; }; }; }; } }; 'v2_stats_transfers_daily_count': { name: 'v2_stats_transfers_daily_count'; type: { kind: 'NON_NULL'; name: never; ofType: { kind: 'LIST'; name: never; ofType: { kind: 'NON_NULL'; name: never; ofType: { kind: 'OBJECT'; name: 'v2_stats_daily_count_type'; ofType: null; }; }; }; } }; 'v2_tokens': { name: 'v2_tokens'; type: { kind: 'NON_NULL'; name: never; ofType: { kind: 'LIST'; name: never; ofType: { kind: 'NON_NULL'; name: never; ofType: { kind: 'OBJECT'; name: 'v2_token_meta'; ofType: null; }; }; }; } }; 'v2_transfers': { name: 'v2_transfers'; type: { kind: 'NON_NULL'; name: never; ofType: { kind: 'LIST'; name: never; ofType: { kind: 'NON_NULL'; name: never; ofType: { kind: 'OBJECT'; name: 'v2_transfer_type'; ofType: null; }; }; }; } }; 'v2_util_get_address_types_for_display_address': { name: 'v2_util_get_address_types_for_display_address'; type: { kind: 'NON_NULL'; name: never; ofType: { kind: 'LIST'; name: never; ofType: { kind: 'NON_NULL'; name: never; ofType: { kind: 'OBJECT'; name: 'v2_util_get_address_types_for_display_address_type'; ofType: null; }; }; }; } }; 'v2_util_get_transfer_request_details': { name: 'v2_util_get_transfer_request_details'; type: { kind: 'NON_NULL'; name: never; ofType: { kind: 'LIST'; name: never; ofType: { kind: 'NON_NULL'; name: never; ofType: { kind: 'OBJECT'; name: 'v2_util_get_transfer_request_details_type'; ofType: null; }; }; }; } }; }; };
-    'subscription_root': { kind: 'OBJECT'; name: 'subscription_root'; fields: { 'dashboard_transfer_count_by_chain': { name: 'dashboard_transfer_count_by_chain'; type: { kind: 'NON_NULL'; name: never; ofType: { kind: 'LIST'; name: never; ofType: { kind: 'NON_NULL'; name: never; ofType: { kind: 'OBJECT'; name: 'dashboard_count_by_chain_type'; ofType: null; }; }; }; } }; 'dashboard_transfer_days_count_by_chain': { name: 'dashboard_transfer_days_count_by_chain'; type: { kind: 'NON_NULL'; name: never; ofType: { kind: 'LIST'; name: never; ofType: { kind: 'NON_NULL'; name: never; ofType: { kind: 'OBJECT'; name: 'dashboard_days_by_chain_type'; ofType: null; }; }; }; } }; 'v2_chains': { name: 'v2_chains'; type: { kind: 'NON_NULL'; name: never; ofType: { kind: 'LIST'; name: never; ofType: { kind: 'NON_NULL'; name: never; ofType: { kind: 'OBJECT'; name: 'v2_chain_type'; ofType: null; }; }; }; } }; 'v2_channels': { name: 'v2_channels'; type: { kind: 'NON_NULL'; name: never; ofType: { kind: 'LIST'; name: never; ofType: { kind: 'NON_NULL'; name: never; ofType: { kind: 'OBJECT'; name: 'v2_channel_type'; ofType: null; }; }; }; } }; 'v2_clients': { name: 'v2_clients'; type: { kind: 'NON_NULL'; name: never; ofType: { kind: 'LIST'; name: never; ofType: { kind: 'NON_NULL'; name: never; ofType: { kind: 'OBJECT'; name: 'v2_client_type'; ofType: null; }; }; }; } }; 'v2_connections': { name: 'v2_connections'; type: { kind: 'NON_NULL'; name: never; ofType: { kind: 'LIST'; name: never; ofType: { kind: 'NON_NULL'; name: never; ofType: { kind: 'OBJECT'; name: 'v2_connection_type'; ofType: null; }; }; }; } }; 'v2_error_type': { name: 'v2_error_type'; type: { kind: 'NON_NULL'; name: never; ofType: { kind: 'LIST'; name: never; ofType: { kind: 'NON_NULL'; name: never; ofType: { kind: 'OBJECT'; name: 'v2_error_type'; ofType: null; }; }; }; } }; 'v2_error_type_stream': { name: 'v2_error_type_stream'; type: { kind: 'NON_NULL'; name: never; ofType: { kind: 'LIST'; name: never; ofType: { kind: 'NON_NULL'; name: never; ofType: { kind: 'OBJECT'; name: 'v2_error_type'; ofType: null; }; }; }; } }; 'v2_errors': { name: 'v2_errors'; type: { kind: 'NON_NULL'; name: never; ofType: { kind: 'LIST'; name: never; ofType: { kind: 'NON_NULL'; name: never; ofType: { kind: 'OBJECT'; name: 'v2_error_type'; ofType: null; }; }; }; } }; 'v2_health_check': { name: 'v2_health_check'; type: { kind: 'NON_NULL'; name: never; ofType: { kind: 'LIST'; name: never; ofType: { kind: 'NON_NULL'; name: never; ofType: { kind: 'OBJECT'; name: 'v2_health_check_type'; ofType: null; }; }; }; } }; 'v2_packets': { name: 'v2_packets'; type: { kind: 'NON_NULL'; name: never; ofType: { kind: 'LIST'; name: never; ofType: { kind: 'NON_NULL'; name: never; ofType: { kind: 'OBJECT'; name: 'v2_packet_type'; ofType: null; }; }; }; } }; 'v2_stats_count': { name: 'v2_stats_count'; type: { kind: 'NON_NULL'; name: never; ofType: { kind: 'LIST'; name: never; ofType: { kind: 'NON_NULL'; name: never; ofType: { kind: 'OBJECT'; name: 'v2_stats_type'; ofType: null; }; }; }; } }; 'v2_stats_latency': { name: 'v2_stats_latency'; type: { kind: 'NON_NULL'; name: never; ofType: { kind: 'LIST'; name: never; ofType: { kind: 'NON_NULL'; name: never; ofType: { kind: 'OBJECT'; name: 'v2_stats_latency_type'; ofType: null; }; }; }; } }; 'v2_stats_packets_chain': { name: 'v2_stats_packets_chain'; type: { kind: 'NON_NULL'; name: never; ofType: { kind: 'LIST'; name: never; ofType: { kind: 'NON_NULL'; name: never; ofType: { kind: 'OBJECT'; name: 'v2_stats_packets_chain_type'; ofType: null; }; }; }; } }; 'v2_stats_packets_daily_count': { name: 'v2_stats_packets_daily_count'; type: { kind: 'NON_NULL'; name: never; ofType: { kind: 'LIST'; name: never; ofType: { kind: 'NON_NULL'; name: never; ofType: { kind: 'OBJECT'; name: 'v2_stats_daily_count_type'; ofType: null; }; }; }; } }; 'v2_stats_transfers_address': { name: 'v2_stats_transfers_address'; type: { kind: 'NON_NULL'; name: never; ofType: { kind: 'LIST'; name: never; ofType: { kind: 'NON_NULL'; name: never; ofType: { kind: 'OBJECT'; name: 'v2_stats_transfers_address_type'; ofType: null; }; }; }; } }; 'v2_stats_transfers_chain': { name: 'v2_stats_transfers_chain'; type: { kind: 'NON_NULL'; name: never; ofType: { kind: 'LIST'; name: never; ofType: { kind: 'NON_NULL'; name: never; ofType: { kind: 'OBJECT'; name: 'v2_stats_transfers_chain_type'; ofType: null; }; }; }; } }; 'v2_stats_transfers_daily_count': { name: 'v2_stats_transfers_daily_count'; type: { kind: 'NON_NULL'; name: never; ofType: { kind: 'LIST'; name: never; ofType: { kind: 'NON_NULL'; name: never; ofType: { kind: 'OBJECT'; name: 'v2_stats_daily_count_type'; ofType: null; }; }; }; } }; 'v2_tokens': { name: 'v2_tokens'; type: { kind: 'NON_NULL'; name: never; ofType: { kind: 'LIST'; name: never; ofType: { kind: 'NON_NULL'; name: never; ofType: { kind: 'OBJECT'; name: 'v2_token_meta'; ofType: null; }; }; }; } }; 'v2_transfers': { name: 'v2_transfers'; type: { kind: 'NON_NULL'; name: never; ofType: { kind: 'LIST'; name: never; ofType: { kind: 'NON_NULL'; name: never; ofType: { kind: 'OBJECT'; name: 'v2_transfer_type'; ofType: null; }; }; }; } }; 'v2_util_get_address_types_for_display_address': { name: 'v2_util_get_address_types_for_display_address'; type: { kind: 'NON_NULL'; name: never; ofType: { kind: 'LIST'; name: never; ofType: { kind: 'NON_NULL'; name: never; ofType: { kind: 'OBJECT'; name: 'v2_util_get_address_types_for_display_address_type'; ofType: null; }; }; }; } }; 'v2_util_get_transfer_request_details': { name: 'v2_util_get_transfer_request_details'; type: { kind: 'NON_NULL'; name: never; ofType: { kind: 'LIST'; name: never; ofType: { kind: 'NON_NULL'; name: never; ofType: { kind: 'OBJECT'; name: 'v2_util_get_transfer_request_details_type'; ofType: null; }; }; }; } }; }; };
-    'timestamptz': unknown;
-    'timestamptz_comparison_exp': { kind: 'INPUT_OBJECT'; name: 'timestamptz_comparison_exp'; isOneOf: false; inputFields: [{ name: '_eq'; type: { kind: 'SCALAR'; name: 'timestamptz'; ofType: null; }; defaultValue: null }, { name: '_gt'; type: { kind: 'SCALAR'; name: 'timestamptz'; ofType: null; }; defaultValue: null }, { name: '_gte'; type: { kind: 'SCALAR'; name: 'timestamptz'; ofType: null; }; defaultValue: null }, { name: '_in'; type: { kind: 'LIST'; name: never; ofType: { kind: 'NON_NULL'; name: never; ofType: { kind: 'SCALAR'; name: 'timestamptz'; ofType: null; }; }; }; defaultValue: null }, { name: '_is_null'; type: { kind: 'SCALAR'; name: 'Boolean'; ofType: null; }; defaultValue: null }, { name: '_lt'; type: { kind: 'SCALAR'; name: 'timestamptz'; ofType: null; }; defaultValue: null }, { name: '_lte'; type: { kind: 'SCALAR'; name: 'timestamptz'; ofType: null; }; defaultValue: null }, { name: '_neq'; type: { kind: 'SCALAR'; name: 'timestamptz'; ofType: null; }; defaultValue: null }, { name: '_nin'; type: { kind: 'LIST'; name: never; ofType: { kind: 'NON_NULL'; name: never; ofType: { kind: 'SCALAR'; name: 'timestamptz'; ofType: null; }; }; }; defaultValue: null }]; };
-    'v2_chain_editions': { kind: 'OBJECT'; name: 'v2_chain_editions'; fields: { 'environment': { name: 'environment'; type: { kind: 'SCALAR'; name: 'String'; ofType: null; } }; 'name': { name: 'name'; type: { kind: 'SCALAR'; name: 'String'; ofType: null; } }; }; };
-    'v2_chain_editions_aggregate_order_by': { kind: 'INPUT_OBJECT'; name: 'v2_chain_editions_aggregate_order_by'; isOneOf: false; inputFields: [{ name: 'count'; type: { kind: 'ENUM'; name: 'order_by'; ofType: null; }; defaultValue: null }, { name: 'max'; type: { kind: 'INPUT_OBJECT'; name: 'v2_chain_editions_max_order_by'; ofType: null; }; defaultValue: null }, { name: 'min'; type: { kind: 'INPUT_OBJECT'; name: 'v2_chain_editions_min_order_by'; ofType: null; }; defaultValue: null }]; };
-    'v2_chain_editions_bool_exp': { kind: 'INPUT_OBJECT'; name: 'v2_chain_editions_bool_exp'; isOneOf: false; inputFields: [{ name: '_and'; type: { kind: 'LIST'; name: never; ofType: { kind: 'NON_NULL'; name: never; ofType: { kind: 'INPUT_OBJECT'; name: 'v2_chain_editions_bool_exp'; ofType: null; }; }; }; defaultValue: null }, { name: '_not'; type: { kind: 'INPUT_OBJECT'; name: 'v2_chain_editions_bool_exp'; ofType: null; }; defaultValue: null }, { name: '_or'; type: { kind: 'LIST'; name: never; ofType: { kind: 'NON_NULL'; name: never; ofType: { kind: 'INPUT_OBJECT'; name: 'v2_chain_editions_bool_exp'; ofType: null; }; }; }; defaultValue: null }, { name: 'environment'; type: { kind: 'INPUT_OBJECT'; name: 'String_comparison_exp'; ofType: null; }; defaultValue: null }, { name: 'name'; type: { kind: 'INPUT_OBJECT'; name: 'String_comparison_exp'; ofType: null; }; defaultValue: null }]; };
-    'v2_chain_editions_max_order_by': { kind: 'INPUT_OBJECT'; name: 'v2_chain_editions_max_order_by'; isOneOf: false; inputFields: [{ name: 'environment'; type: { kind: 'ENUM'; name: 'order_by'; ofType: null; }; defaultValue: null }, { name: 'name'; type: { kind: 'ENUM'; name: 'order_by'; ofType: null; }; defaultValue: null }]; };
-    'v2_chain_editions_min_order_by': { kind: 'INPUT_OBJECT'; name: 'v2_chain_editions_min_order_by'; isOneOf: false; inputFields: [{ name: 'environment'; type: { kind: 'ENUM'; name: 'order_by'; ofType: null; }; defaultValue: null }, { name: 'name'; type: { kind: 'ENUM'; name: 'order_by'; ofType: null; }; defaultValue: null }]; };
-    'v2_chain_editions_order_by': { kind: 'INPUT_OBJECT'; name: 'v2_chain_editions_order_by'; isOneOf: false; inputFields: [{ name: 'environment'; type: { kind: 'ENUM'; name: 'order_by'; ofType: null; }; defaultValue: null }, { name: 'name'; type: { kind: 'ENUM'; name: 'order_by'; ofType: null; }; defaultValue: null }]; };
-    'v2_chain_editions_select_column': { name: 'v2_chain_editions_select_column'; enumValues: 'environment' | 'name'; };
-    'v2_chain_features': { kind: 'OBJECT'; name: 'v2_chain_features'; fields: { 'channel_list': { name: 'channel_list'; type: { kind: 'SCALAR'; name: 'Boolean'; ofType: null; } }; 'connection_list': { name: 'connection_list'; type: { kind: 'SCALAR'; name: 'Boolean'; ofType: null; } }; 'environment': { name: 'environment'; type: { kind: 'SCALAR'; name: 'String'; ofType: null; } }; 'index_status': { name: 'index_status'; type: { kind: 'SCALAR'; name: 'Boolean'; ofType: null; } }; 'packet_list': { name: 'packet_list'; type: { kind: 'SCALAR'; name: 'Boolean'; ofType: null; } }; 'transfer_list': { name: 'transfer_list'; type: { kind: 'SCALAR'; name: 'Boolean'; ofType: null; } }; 'transfer_submission': { name: 'transfer_submission'; type: { kind: 'SCALAR'; name: 'Boolean'; ofType: null; } }; }; };
-    'v2_chain_features_aggregate_order_by': { kind: 'INPUT_OBJECT'; name: 'v2_chain_features_aggregate_order_by'; isOneOf: false; inputFields: [{ name: 'count'; type: { kind: 'ENUM'; name: 'order_by'; ofType: null; }; defaultValue: null }, { name: 'max'; type: { kind: 'INPUT_OBJECT'; name: 'v2_chain_features_max_order_by'; ofType: null; }; defaultValue: null }, { name: 'min'; type: { kind: 'INPUT_OBJECT'; name: 'v2_chain_features_min_order_by'; ofType: null; }; defaultValue: null }]; };
-    'v2_chain_features_bool_exp': { kind: 'INPUT_OBJECT'; name: 'v2_chain_features_bool_exp'; isOneOf: false; inputFields: [{ name: '_and'; type: { kind: 'LIST'; name: never; ofType: { kind: 'NON_NULL'; name: never; ofType: { kind: 'INPUT_OBJECT'; name: 'v2_chain_features_bool_exp'; ofType: null; }; }; }; defaultValue: null }, { name: '_not'; type: { kind: 'INPUT_OBJECT'; name: 'v2_chain_features_bool_exp'; ofType: null; }; defaultValue: null }, { name: '_or'; type: { kind: 'LIST'; name: never; ofType: { kind: 'NON_NULL'; name: never; ofType: { kind: 'INPUT_OBJECT'; name: 'v2_chain_features_bool_exp'; ofType: null; }; }; }; defaultValue: null }, { name: 'channel_list'; type: { kind: 'INPUT_OBJECT'; name: 'Boolean_comparison_exp'; ofType: null; }; defaultValue: null }, { name: 'connection_list'; type: { kind: 'INPUT_OBJECT'; name: 'Boolean_comparison_exp'; ofType: null; }; defaultValue: null }, { name: 'environment'; type: { kind: 'INPUT_OBJECT'; name: 'String_comparison_exp'; ofType: null; }; defaultValue: null }, { name: 'index_status'; type: { kind: 'INPUT_OBJECT'; name: 'Boolean_comparison_exp'; ofType: null; }; defaultValue: null }, { name: 'packet_list'; type: { kind: 'INPUT_OBJECT'; name: 'Boolean_comparison_exp'; ofType: null; }; defaultValue: null }, { name: 'transfer_list'; type: { kind: 'INPUT_OBJECT'; name: 'Boolean_comparison_exp'; ofType: null; }; defaultValue: null }, { name: 'transfer_submission'; type: { kind: 'INPUT_OBJECT'; name: 'Boolean_comparison_exp'; ofType: null; }; defaultValue: null }]; };
-    'v2_chain_features_max_order_by': { kind: 'INPUT_OBJECT'; name: 'v2_chain_features_max_order_by'; isOneOf: false; inputFields: [{ name: 'environment'; type: { kind: 'ENUM'; name: 'order_by'; ofType: null; }; defaultValue: null }]; };
-    'v2_chain_features_min_order_by': { kind: 'INPUT_OBJECT'; name: 'v2_chain_features_min_order_by'; isOneOf: false; inputFields: [{ name: 'environment'; type: { kind: 'ENUM'; name: 'order_by'; ofType: null; }; defaultValue: null }]; };
-    'v2_chain_features_order_by': { kind: 'INPUT_OBJECT'; name: 'v2_chain_features_order_by'; isOneOf: false; inputFields: [{ name: 'channel_list'; type: { kind: 'ENUM'; name: 'order_by'; ofType: null; }; defaultValue: null }, { name: 'connection_list'; type: { kind: 'ENUM'; name: 'order_by'; ofType: null; }; defaultValue: null }, { name: 'environment'; type: { kind: 'ENUM'; name: 'order_by'; ofType: null; }; defaultValue: null }, { name: 'index_status'; type: { kind: 'ENUM'; name: 'order_by'; ofType: null; }; defaultValue: null }, { name: 'packet_list'; type: { kind: 'ENUM'; name: 'order_by'; ofType: null; }; defaultValue: null }, { name: 'transfer_list'; type: { kind: 'ENUM'; name: 'order_by'; ofType: null; }; defaultValue: null }, { name: 'transfer_submission'; type: { kind: 'ENUM'; name: 'order_by'; ofType: null; }; defaultValue: null }]; };
-    'v2_chain_features_select_column': { name: 'v2_chain_features_select_column'; enumValues: 'channel_list' | 'connection_list' | 'environment' | 'index_status' | 'packet_list' | 'transfer_list' | 'transfer_submission'; };
-    'v2_chain_status_type': { kind: 'OBJECT'; name: 'v2_chain_status_type'; fields: { 'height': { name: 'height'; type: { kind: 'SCALAR'; name: 'String'; ofType: null; } }; 'status': { name: 'status'; type: { kind: 'SCALAR'; name: 'String'; ofType: null; } }; 'timestamp': { name: 'timestamp'; type: { kind: 'SCALAR'; name: 'timestamptz'; ofType: null; } }; 'tip_age_seconds': { name: 'tip_age_seconds'; type: { kind: 'SCALAR'; name: 'Int'; ofType: null; } }; }; };
-    'v2_chain_status_type_aggregate_order_by': { kind: 'INPUT_OBJECT'; name: 'v2_chain_status_type_aggregate_order_by'; isOneOf: false; inputFields: [{ name: 'avg'; type: { kind: 'INPUT_OBJECT'; name: 'v2_chain_status_type_avg_order_by'; ofType: null; }; defaultValue: null }, { name: 'count'; type: { kind: 'ENUM'; name: 'order_by'; ofType: null; }; defaultValue: null }, { name: 'max'; type: { kind: 'INPUT_OBJECT'; name: 'v2_chain_status_type_max_order_by'; ofType: null; }; defaultValue: null }, { name: 'min'; type: { kind: 'INPUT_OBJECT'; name: 'v2_chain_status_type_min_order_by'; ofType: null; }; defaultValue: null }, { name: 'stddev'; type: { kind: 'INPUT_OBJECT'; name: 'v2_chain_status_type_stddev_order_by'; ofType: null; }; defaultValue: null }, { name: 'stddev_pop'; type: { kind: 'INPUT_OBJECT'; name: 'v2_chain_status_type_stddev_pop_order_by'; ofType: null; }; defaultValue: null }, { name: 'stddev_samp'; type: { kind: 'INPUT_OBJECT'; name: 'v2_chain_status_type_stddev_samp_order_by'; ofType: null; }; defaultValue: null }, { name: 'sum'; type: { kind: 'INPUT_OBJECT'; name: 'v2_chain_status_type_sum_order_by'; ofType: null; }; defaultValue: null }, { name: 'var_pop'; type: { kind: 'INPUT_OBJECT'; name: 'v2_chain_status_type_var_pop_order_by'; ofType: null; }; defaultValue: null }, { name: 'var_samp'; type: { kind: 'INPUT_OBJECT'; name: 'v2_chain_status_type_var_samp_order_by'; ofType: null; }; defaultValue: null }, { name: 'variance'; type: { kind: 'INPUT_OBJECT'; name: 'v2_chain_status_type_variance_order_by'; ofType: null; }; defaultValue: null }]; };
-    'v2_chain_status_type_avg_order_by': { kind: 'INPUT_OBJECT'; name: 'v2_chain_status_type_avg_order_by'; isOneOf: false; inputFields: [{ name: 'tip_age_seconds'; type: { kind: 'ENUM'; name: 'order_by'; ofType: null; }; defaultValue: null }]; };
-    'v2_chain_status_type_bool_exp': { kind: 'INPUT_OBJECT'; name: 'v2_chain_status_type_bool_exp'; isOneOf: false; inputFields: [{ name: '_and'; type: { kind: 'LIST'; name: never; ofType: { kind: 'NON_NULL'; name: never; ofType: { kind: 'INPUT_OBJECT'; name: 'v2_chain_status_type_bool_exp'; ofType: null; }; }; }; defaultValue: null }, { name: '_not'; type: { kind: 'INPUT_OBJECT'; name: 'v2_chain_status_type_bool_exp'; ofType: null; }; defaultValue: null }, { name: '_or'; type: { kind: 'LIST'; name: never; ofType: { kind: 'NON_NULL'; name: never; ofType: { kind: 'INPUT_OBJECT'; name: 'v2_chain_status_type_bool_exp'; ofType: null; }; }; }; defaultValue: null }, { name: 'height'; type: { kind: 'INPUT_OBJECT'; name: 'String_comparison_exp'; ofType: null; }; defaultValue: null }, { name: 'status'; type: { kind: 'INPUT_OBJECT'; name: 'String_comparison_exp'; ofType: null; }; defaultValue: null }, { name: 'timestamp'; type: { kind: 'INPUT_OBJECT'; name: 'timestamptz_comparison_exp'; ofType: null; }; defaultValue: null }, { name: 'tip_age_seconds'; type: { kind: 'INPUT_OBJECT'; name: 'Int_comparison_exp'; ofType: null; }; defaultValue: null }]; };
-    'v2_chain_status_type_max_order_by': { kind: 'INPUT_OBJECT'; name: 'v2_chain_status_type_max_order_by'; isOneOf: false; inputFields: [{ name: 'height'; type: { kind: 'ENUM'; name: 'order_by'; ofType: null; }; defaultValue: null }, { name: 'status'; type: { kind: 'ENUM'; name: 'order_by'; ofType: null; }; defaultValue: null }, { name: 'timestamp'; type: { kind: 'ENUM'; name: 'order_by'; ofType: null; }; defaultValue: null }, { name: 'tip_age_seconds'; type: { kind: 'ENUM'; name: 'order_by'; ofType: null; }; defaultValue: null }]; };
-    'v2_chain_status_type_min_order_by': { kind: 'INPUT_OBJECT'; name: 'v2_chain_status_type_min_order_by'; isOneOf: false; inputFields: [{ name: 'height'; type: { kind: 'ENUM'; name: 'order_by'; ofType: null; }; defaultValue: null }, { name: 'status'; type: { kind: 'ENUM'; name: 'order_by'; ofType: null; }; defaultValue: null }, { name: 'timestamp'; type: { kind: 'ENUM'; name: 'order_by'; ofType: null; }; defaultValue: null }, { name: 'tip_age_seconds'; type: { kind: 'ENUM'; name: 'order_by'; ofType: null; }; defaultValue: null }]; };
-    'v2_chain_status_type_order_by': { kind: 'INPUT_OBJECT'; name: 'v2_chain_status_type_order_by'; isOneOf: false; inputFields: [{ name: 'height'; type: { kind: 'ENUM'; name: 'order_by'; ofType: null; }; defaultValue: null }, { name: 'status'; type: { kind: 'ENUM'; name: 'order_by'; ofType: null; }; defaultValue: null }, { name: 'timestamp'; type: { kind: 'ENUM'; name: 'order_by'; ofType: null; }; defaultValue: null }, { name: 'tip_age_seconds'; type: { kind: 'ENUM'; name: 'order_by'; ofType: null; }; defaultValue: null }]; };
-    'v2_chain_status_type_select_column': { name: 'v2_chain_status_type_select_column'; enumValues: 'height' | 'status' | 'timestamp' | 'tip_age_seconds'; };
-    'v2_chain_status_type_stddev_order_by': { kind: 'INPUT_OBJECT'; name: 'v2_chain_status_type_stddev_order_by'; isOneOf: false; inputFields: [{ name: 'tip_age_seconds'; type: { kind: 'ENUM'; name: 'order_by'; ofType: null; }; defaultValue: null }]; };
-    'v2_chain_status_type_stddev_pop_order_by': { kind: 'INPUT_OBJECT'; name: 'v2_chain_status_type_stddev_pop_order_by'; isOneOf: false; inputFields: [{ name: 'tip_age_seconds'; type: { kind: 'ENUM'; name: 'order_by'; ofType: null; }; defaultValue: null }]; };
-    'v2_chain_status_type_stddev_samp_order_by': { kind: 'INPUT_OBJECT'; name: 'v2_chain_status_type_stddev_samp_order_by'; isOneOf: false; inputFields: [{ name: 'tip_age_seconds'; type: { kind: 'ENUM'; name: 'order_by'; ofType: null; }; defaultValue: null }]; };
-    'v2_chain_status_type_sum_order_by': { kind: 'INPUT_OBJECT'; name: 'v2_chain_status_type_sum_order_by'; isOneOf: false; inputFields: [{ name: 'tip_age_seconds'; type: { kind: 'ENUM'; name: 'order_by'; ofType: null; }; defaultValue: null }]; };
-    'v2_chain_status_type_var_pop_order_by': { kind: 'INPUT_OBJECT'; name: 'v2_chain_status_type_var_pop_order_by'; isOneOf: false; inputFields: [{ name: 'tip_age_seconds'; type: { kind: 'ENUM'; name: 'order_by'; ofType: null; }; defaultValue: null }]; };
-    'v2_chain_status_type_var_samp_order_by': { kind: 'INPUT_OBJECT'; name: 'v2_chain_status_type_var_samp_order_by'; isOneOf: false; inputFields: [{ name: 'tip_age_seconds'; type: { kind: 'ENUM'; name: 'order_by'; ofType: null; }; defaultValue: null }]; };
-    'v2_chain_status_type_variance_order_by': { kind: 'INPUT_OBJECT'; name: 'v2_chain_status_type_variance_order_by'; isOneOf: false; inputFields: [{ name: 'tip_age_seconds'; type: { kind: 'ENUM'; name: 'order_by'; ofType: null; }; defaultValue: null }]; };
-    'v2_chain_type': { kind: 'OBJECT'; name: 'v2_chain_type'; fields: { 'addr_prefix': { name: 'addr_prefix'; type: { kind: 'SCALAR'; name: 'String'; ofType: null; } }; 'chain_id': { name: 'chain_id'; type: { kind: 'SCALAR'; name: 'String'; ofType: null; } }; 'display_name': { name: 'display_name'; type: { kind: 'SCALAR'; name: 'String'; ofType: null; } }; 'editions': { name: 'editions'; type: { kind: 'NON_NULL'; name: never; ofType: { kind: 'LIST'; name: never; ofType: { kind: 'NON_NULL'; name: never; ofType: { kind: 'OBJECT'; name: 'v2_chain_editions'; ofType: null; }; }; }; } }; 'explorers': { name: 'explorers'; type: { kind: 'NON_NULL'; name: never; ofType: { kind: 'LIST'; name: never; ofType: { kind: 'NON_NULL'; name: never; ofType: { kind: 'OBJECT'; name: 'v2_explorers'; ofType: null; }; }; }; } }; 'features': { name: 'features'; type: { kind: 'NON_NULL'; name: never; ofType: { kind: 'LIST'; name: never; ofType: { kind: 'NON_NULL'; name: never; ofType: { kind: 'OBJECT'; name: 'v2_chain_features'; ofType: null; }; }; }; } }; 'logo_uri': { name: 'logo_uri'; type: { kind: 'SCALAR'; name: 'String'; ofType: null; } }; 'rpc_type': { name: 'rpc_type'; type: { kind: 'SCALAR'; name: 'String'; ofType: null; } }; 'rpcs': { name: 'rpcs'; type: { kind: 'NON_NULL'; name: never; ofType: { kind: 'LIST'; name: never; ofType: { kind: 'NON_NULL'; name: never; ofType: { kind: 'OBJECT'; name: 'v2_rpcs'; ofType: null; }; }; }; } }; 'status': { name: 'status'; type: { kind: 'LIST'; name: never; ofType: { kind: 'NON_NULL'; name: never; ofType: { kind: 'OBJECT'; name: 'v2_chain_status_type'; ofType: null; }; }; } }; 'testnet': { name: 'testnet'; type: { kind: 'SCALAR'; name: 'Boolean'; ofType: null; } }; 'universal_chain_id': { name: 'universal_chain_id'; type: { kind: 'SCALAR'; name: 'String'; ofType: null; } }; }; };
-    'v2_chain_type_bool_exp': { kind: 'INPUT_OBJECT'; name: 'v2_chain_type_bool_exp'; isOneOf: false; inputFields: [{ name: '_and'; type: { kind: 'LIST'; name: never; ofType: { kind: 'NON_NULL'; name: never; ofType: { kind: 'INPUT_OBJECT'; name: 'v2_chain_type_bool_exp'; ofType: null; }; }; }; defaultValue: null }, { name: '_not'; type: { kind: 'INPUT_OBJECT'; name: 'v2_chain_type_bool_exp'; ofType: null; }; defaultValue: null }, { name: '_or'; type: { kind: 'LIST'; name: never; ofType: { kind: 'NON_NULL'; name: never; ofType: { kind: 'INPUT_OBJECT'; name: 'v2_chain_type_bool_exp'; ofType: null; }; }; }; defaultValue: null }, { name: 'addr_prefix'; type: { kind: 'INPUT_OBJECT'; name: 'String_comparison_exp'; ofType: null; }; defaultValue: null }, { name: 'chain_id'; type: { kind: 'INPUT_OBJECT'; name: 'String_comparison_exp'; ofType: null; }; defaultValue: null }, { name: 'display_name'; type: { kind: 'INPUT_OBJECT'; name: 'String_comparison_exp'; ofType: null; }; defaultValue: null }, { name: 'editions'; type: { kind: 'INPUT_OBJECT'; name: 'v2_chain_editions_bool_exp'; ofType: null; }; defaultValue: null }, { name: 'explorers'; type: { kind: 'INPUT_OBJECT'; name: 'v2_explorers_bool_exp'; ofType: null; }; defaultValue: null }, { name: 'features'; type: { kind: 'INPUT_OBJECT'; name: 'v2_chain_features_bool_exp'; ofType: null; }; defaultValue: null }, { name: 'logo_uri'; type: { kind: 'INPUT_OBJECT'; name: 'String_comparison_exp'; ofType: null; }; defaultValue: null }, { name: 'rpc_type'; type: { kind: 'INPUT_OBJECT'; name: 'String_comparison_exp'; ofType: null; }; defaultValue: null }, { name: 'rpcs'; type: { kind: 'INPUT_OBJECT'; name: 'v2_rpcs_bool_exp'; ofType: null; }; defaultValue: null }, { name: 'status'; type: { kind: 'INPUT_OBJECT'; name: 'v2_chain_status_type_bool_exp'; ofType: null; }; defaultValue: null }, { name: 'testnet'; type: { kind: 'INPUT_OBJECT'; name: 'Boolean_comparison_exp'; ofType: null; }; defaultValue: null }, { name: 'universal_chain_id'; type: { kind: 'INPUT_OBJECT'; name: 'String_comparison_exp'; ofType: null; }; defaultValue: null }]; };
-    'v2_chain_type_order_by': { kind: 'INPUT_OBJECT'; name: 'v2_chain_type_order_by'; isOneOf: false; inputFields: [{ name: 'addr_prefix'; type: { kind: 'ENUM'; name: 'order_by'; ofType: null; }; defaultValue: null }, { name: 'chain_id'; type: { kind: 'ENUM'; name: 'order_by'; ofType: null; }; defaultValue: null }, { name: 'display_name'; type: { kind: 'ENUM'; name: 'order_by'; ofType: null; }; defaultValue: null }, { name: 'editions_aggregate'; type: { kind: 'INPUT_OBJECT'; name: 'v2_chain_editions_aggregate_order_by'; ofType: null; }; defaultValue: null }, { name: 'explorers_aggregate'; type: { kind: 'INPUT_OBJECT'; name: 'v2_explorers_aggregate_order_by'; ofType: null; }; defaultValue: null }, { name: 'features_aggregate'; type: { kind: 'INPUT_OBJECT'; name: 'v2_chain_features_aggregate_order_by'; ofType: null; }; defaultValue: null }, { name: 'logo_uri'; type: { kind: 'ENUM'; name: 'order_by'; ofType: null; }; defaultValue: null }, { name: 'rpc_type'; type: { kind: 'ENUM'; name: 'order_by'; ofType: null; }; defaultValue: null }, { name: 'rpcs_aggregate'; type: { kind: 'INPUT_OBJECT'; name: 'v2_rpcs_aggregate_order_by'; ofType: null; }; defaultValue: null }, { name: 'status_aggregate'; type: { kind: 'INPUT_OBJECT'; name: 'v2_chain_status_type_aggregate_order_by'; ofType: null; }; defaultValue: null }, { name: 'testnet'; type: { kind: 'ENUM'; name: 'order_by'; ofType: null; }; defaultValue: null }, { name: 'universal_chain_id'; type: { kind: 'ENUM'; name: 'order_by'; ofType: null; }; defaultValue: null }]; };
-    'v2_chain_type_select_column': { name: 'v2_chain_type_select_column'; enumValues: 'addr_prefix' | 'chain_id' | 'display_name' | 'logo_uri' | 'rpc_type' | 'testnet' | 'universal_chain_id'; };
-    'v2_chains_args': { kind: 'INPUT_OBJECT'; name: 'v2_chains_args'; isOneOf: false; inputFields: [{ name: 'p_comparison'; type: { kind: 'SCALAR'; name: 'String'; ofType: null; }; defaultValue: null }, { name: 'p_limit'; type: { kind: 'SCALAR'; name: 'Int'; ofType: null; }; defaultValue: null }, { name: 'p_sort_order'; type: { kind: 'SCALAR'; name: 'String'; ofType: null; }; defaultValue: null }, { name: 'p_universal_chain_id'; type: { kind: 'SCALAR'; name: 'String'; ofType: null; }; defaultValue: null }]; };
-    'v2_chains_view': { kind: 'OBJECT'; name: 'v2_chains_view'; fields: { 'addr_prefix': { name: 'addr_prefix'; type: { kind: 'SCALAR'; name: 'String'; ofType: null; } }; 'chain_id': { name: 'chain_id'; type: { kind: 'SCALAR'; name: 'String'; ofType: null; } }; 'display_name': { name: 'display_name'; type: { kind: 'SCALAR'; name: 'String'; ofType: null; } }; 'logo_uri': { name: 'logo_uri'; type: { kind: 'SCALAR'; name: 'String'; ofType: null; } }; 'rpc_type': { name: 'rpc_type'; type: { kind: 'SCALAR'; name: 'String'; ofType: null; } }; 'testnet': { name: 'testnet'; type: { kind: 'SCALAR'; name: 'Boolean'; ofType: null; } }; 'universal_chain_id': { name: 'universal_chain_id'; type: { kind: 'SCALAR'; name: 'String'; ofType: null; } }; }; };
-    'v2_chains_view_bool_exp': { kind: 'INPUT_OBJECT'; name: 'v2_chains_view_bool_exp'; isOneOf: false; inputFields: [{ name: '_and'; type: { kind: 'LIST'; name: never; ofType: { kind: 'NON_NULL'; name: never; ofType: { kind: 'INPUT_OBJECT'; name: 'v2_chains_view_bool_exp'; ofType: null; }; }; }; defaultValue: null }, { name: '_not'; type: { kind: 'INPUT_OBJECT'; name: 'v2_chains_view_bool_exp'; ofType: null; }; defaultValue: null }, { name: '_or'; type: { kind: 'LIST'; name: never; ofType: { kind: 'NON_NULL'; name: never; ofType: { kind: 'INPUT_OBJECT'; name: 'v2_chains_view_bool_exp'; ofType: null; }; }; }; defaultValue: null }, { name: 'addr_prefix'; type: { kind: 'INPUT_OBJECT'; name: 'String_comparison_exp'; ofType: null; }; defaultValue: null }, { name: 'chain_id'; type: { kind: 'INPUT_OBJECT'; name: 'String_comparison_exp'; ofType: null; }; defaultValue: null }, { name: 'display_name'; type: { kind: 'INPUT_OBJECT'; name: 'String_comparison_exp'; ofType: null; }; defaultValue: null }, { name: 'logo_uri'; type: { kind: 'INPUT_OBJECT'; name: 'String_comparison_exp'; ofType: null; }; defaultValue: null }, { name: 'rpc_type'; type: { kind: 'INPUT_OBJECT'; name: 'String_comparison_exp'; ofType: null; }; defaultValue: null }, { name: 'testnet'; type: { kind: 'INPUT_OBJECT'; name: 'Boolean_comparison_exp'; ofType: null; }; defaultValue: null }, { name: 'universal_chain_id'; type: { kind: 'INPUT_OBJECT'; name: 'String_comparison_exp'; ofType: null; }; defaultValue: null }]; };
-    'v2_chains_view_order_by': { kind: 'INPUT_OBJECT'; name: 'v2_chains_view_order_by'; isOneOf: false; inputFields: [{ name: 'addr_prefix'; type: { kind: 'ENUM'; name: 'order_by'; ofType: null; }; defaultValue: null }, { name: 'chain_id'; type: { kind: 'ENUM'; name: 'order_by'; ofType: null; }; defaultValue: null }, { name: 'display_name'; type: { kind: 'ENUM'; name: 'order_by'; ofType: null; }; defaultValue: null }, { name: 'logo_uri'; type: { kind: 'ENUM'; name: 'order_by'; ofType: null; }; defaultValue: null }, { name: 'rpc_type'; type: { kind: 'ENUM'; name: 'order_by'; ofType: null; }; defaultValue: null }, { name: 'testnet'; type: { kind: 'ENUM'; name: 'order_by'; ofType: null; }; defaultValue: null }, { name: 'universal_chain_id'; type: { kind: 'ENUM'; name: 'order_by'; ofType: null; }; defaultValue: null }]; };
-    'v2_channel_type': { kind: 'OBJECT'; name: 'v2_channel_type'; fields: { 'destination_chain': { name: 'destination_chain'; type: { kind: 'OBJECT'; name: 'v2_chains_view'; ofType: null; } }; 'destination_channel_id': { name: 'destination_channel_id'; type: { kind: 'SCALAR'; name: 'Int'; ofType: null; } }; 'destination_client_id': { name: 'destination_client_id'; type: { kind: 'SCALAR'; name: 'Int'; ofType: null; } }; 'destination_connection_id': { name: 'destination_connection_id'; type: { kind: 'SCALAR'; name: 'Int'; ofType: null; } }; 'destination_port_id': { name: 'destination_port_id'; type: { kind: 'SCALAR'; name: 'String'; ofType: null; } }; 'destination_universal_chain_id': { name: 'destination_universal_chain_id'; type: { kind: 'SCALAR'; name: 'String'; ofType: null; } }; 'sort_order': { name: 'sort_order'; type: { kind: 'SCALAR'; name: 'String'; ofType: null; } }; 'source_chain': { name: 'source_chain'; type: { kind: 'OBJECT'; name: 'v2_chains_view'; ofType: null; } }; 'source_channel_id': { name: 'source_channel_id'; type: { kind: 'SCALAR'; name: 'Int'; ofType: null; } }; 'source_client_id': { name: 'source_client_id'; type: { kind: 'SCALAR'; name: 'Int'; ofType: null; } }; 'source_connection_id': { name: 'source_connection_id'; type: { kind: 'SCALAR'; name: 'Int'; ofType: null; } }; 'source_port_id': { name: 'source_port_id'; type: { kind: 'SCALAR'; name: 'String'; ofType: null; } }; 'source_universal_chain_id': { name: 'source_universal_chain_id'; type: { kind: 'SCALAR'; name: 'String'; ofType: null; } }; 'tags': { name: 'tags'; type: { kind: 'LIST'; name: never; ofType: { kind: 'NON_NULL'; name: never; ofType: { kind: 'SCALAR'; name: 'String'; ofType: null; }; }; } }; 'version': { name: 'version'; type: { kind: 'SCALAR'; name: 'String'; ofType: null; } }; }; };
-    'v2_channel_type_bool_exp': { kind: 'INPUT_OBJECT'; name: 'v2_channel_type_bool_exp'; isOneOf: false; inputFields: [{ name: '_and'; type: { kind: 'LIST'; name: never; ofType: { kind: 'NON_NULL'; name: never; ofType: { kind: 'INPUT_OBJECT'; name: 'v2_channel_type_bool_exp'; ofType: null; }; }; }; defaultValue: null }, { name: '_not'; type: { kind: 'INPUT_OBJECT'; name: 'v2_channel_type_bool_exp'; ofType: null; }; defaultValue: null }, { name: '_or'; type: { kind: 'LIST'; name: never; ofType: { kind: 'NON_NULL'; name: never; ofType: { kind: 'INPUT_OBJECT'; name: 'v2_channel_type_bool_exp'; ofType: null; }; }; }; defaultValue: null }, { name: 'destination_chain'; type: { kind: 'INPUT_OBJECT'; name: 'v2_chains_view_bool_exp'; ofType: null; }; defaultValue: null }, { name: 'destination_channel_id'; type: { kind: 'INPUT_OBJECT'; name: 'Int_comparison_exp'; ofType: null; }; defaultValue: null }, { name: 'destination_client_id'; type: { kind: 'INPUT_OBJECT'; name: 'Int_comparison_exp'; ofType: null; }; defaultValue: null }, { name: 'destination_connection_id'; type: { kind: 'INPUT_OBJECT'; name: 'Int_comparison_exp'; ofType: null; }; defaultValue: null }, { name: 'destination_port_id'; type: { kind: 'INPUT_OBJECT'; name: 'String_comparison_exp'; ofType: null; }; defaultValue: null }, { name: 'destination_universal_chain_id'; type: { kind: 'INPUT_OBJECT'; name: 'String_comparison_exp'; ofType: null; }; defaultValue: null }, { name: 'sort_order'; type: { kind: 'INPUT_OBJECT'; name: 'String_comparison_exp'; ofType: null; }; defaultValue: null }, { name: 'source_chain'; type: { kind: 'INPUT_OBJECT'; name: 'v2_chains_view_bool_exp'; ofType: null; }; defaultValue: null }, { name: 'source_channel_id'; type: { kind: 'INPUT_OBJECT'; name: 'Int_comparison_exp'; ofType: null; }; defaultValue: null }, { name: 'source_client_id'; type: { kind: 'INPUT_OBJECT'; name: 'Int_comparison_exp'; ofType: null; }; defaultValue: null }, { name: 'source_connection_id'; type: { kind: 'INPUT_OBJECT'; name: 'Int_comparison_exp'; ofType: null; }; defaultValue: null }, { name: 'source_port_id'; type: { kind: 'INPUT_OBJECT'; name: 'String_comparison_exp'; ofType: null; }; defaultValue: null }, { name: 'source_universal_chain_id'; type: { kind: 'INPUT_OBJECT'; name: 'String_comparison_exp'; ofType: null; }; defaultValue: null }, { name: 'tags'; type: { kind: 'INPUT_OBJECT'; name: 'String_array_comparison_exp'; ofType: null; }; defaultValue: null }, { name: 'version'; type: { kind: 'INPUT_OBJECT'; name: 'String_comparison_exp'; ofType: null; }; defaultValue: null }]; };
-    'v2_channel_type_order_by': { kind: 'INPUT_OBJECT'; name: 'v2_channel_type_order_by'; isOneOf: false; inputFields: [{ name: 'destination_chain'; type: { kind: 'INPUT_OBJECT'; name: 'v2_chains_view_order_by'; ofType: null; }; defaultValue: null }, { name: 'destination_channel_id'; type: { kind: 'ENUM'; name: 'order_by'; ofType: null; }; defaultValue: null }, { name: 'destination_client_id'; type: { kind: 'ENUM'; name: 'order_by'; ofType: null; }; defaultValue: null }, { name: 'destination_connection_id'; type: { kind: 'ENUM'; name: 'order_by'; ofType: null; }; defaultValue: null }, { name: 'destination_port_id'; type: { kind: 'ENUM'; name: 'order_by'; ofType: null; }; defaultValue: null }, { name: 'destination_universal_chain_id'; type: { kind: 'ENUM'; name: 'order_by'; ofType: null; }; defaultValue: null }, { name: 'sort_order'; type: { kind: 'ENUM'; name: 'order_by'; ofType: null; }; defaultValue: null }, { name: 'source_chain'; type: { kind: 'INPUT_OBJECT'; name: 'v2_chains_view_order_by'; ofType: null; }; defaultValue: null }, { name: 'source_channel_id'; type: { kind: 'ENUM'; name: 'order_by'; ofType: null; }; defaultValue: null }, { name: 'source_client_id'; type: { kind: 'ENUM'; name: 'order_by'; ofType: null; }; defaultValue: null }, { name: 'source_connection_id'; type: { kind: 'ENUM'; name: 'order_by'; ofType: null; }; defaultValue: null }, { name: 'source_port_id'; type: { kind: 'ENUM'; name: 'order_by'; ofType: null; }; defaultValue: null }, { name: 'source_universal_chain_id'; type: { kind: 'ENUM'; name: 'order_by'; ofType: null; }; defaultValue: null }, { name: 'tags'; type: { kind: 'ENUM'; name: 'order_by'; ofType: null; }; defaultValue: null }, { name: 'version'; type: { kind: 'ENUM'; name: 'order_by'; ofType: null; }; defaultValue: null }]; };
-    'v2_channel_type_select_column': { name: 'v2_channel_type_select_column'; enumValues: 'destination_channel_id' | 'destination_client_id' | 'destination_connection_id' | 'destination_port_id' | 'destination_universal_chain_id' | 'sort_order' | 'source_channel_id' | 'source_client_id' | 'source_connection_id' | 'source_port_id' | 'source_universal_chain_id' | 'tags' | 'version'; };
-    'v2_channels_args': { kind: 'INPUT_OBJECT'; name: 'v2_channels_args'; isOneOf: false; inputFields: [{ name: 'p_comparison'; type: { kind: 'SCALAR'; name: 'String'; ofType: null; }; defaultValue: null }, { name: 'p_destination_channel_id'; type: { kind: 'SCALAR'; name: 'Int'; ofType: null; }; defaultValue: null }, { name: 'p_destination_client_id'; type: { kind: 'SCALAR'; name: 'Int'; ofType: null; }; defaultValue: null }, { name: 'p_destination_connection_id'; type: { kind: 'SCALAR'; name: 'Int'; ofType: null; }; defaultValue: null }, { name: 'p_destination_port_id'; type: { kind: 'SCALAR'; name: 'String'; ofType: null; }; defaultValue: null }, { name: 'p_destination_universal_chain_id'; type: { kind: 'SCALAR'; name: 'String'; ofType: null; }; defaultValue: null }, { name: 'p_limit'; type: { kind: 'SCALAR'; name: 'Int'; ofType: null; }; defaultValue: null }, { name: 'p_recommended'; type: { kind: 'SCALAR'; name: 'Boolean'; ofType: null; }; defaultValue: null }, { name: 'p_sort_order'; type: { kind: 'SCALAR'; name: 'String'; ofType: null; }; defaultValue: null }, { name: 'p_source_channel_id'; type: { kind: 'SCALAR'; name: 'Int'; ofType: null; }; defaultValue: null }, { name: 'p_source_client_id'; type: { kind: 'SCALAR'; name: 'Int'; ofType: null; }; defaultValue: null }, { name: 'p_source_connection_id'; type: { kind: 'SCALAR'; name: 'Int'; ofType: null; }; defaultValue: null }, { name: 'p_source_port_id'; type: { kind: 'SCALAR'; name: 'String'; ofType: null; }; defaultValue: null }, { name: 'p_source_universal_chain_id'; type: { kind: 'SCALAR'; name: 'String'; ofType: null; }; defaultValue: null }, { name: 'p_tags'; type: { kind: 'SCALAR'; name: 'jsonb'; ofType: null; }; defaultValue: null }, { name: 'p_version'; type: { kind: 'SCALAR'; name: 'String'; ofType: null; }; defaultValue: null }]; };
-    'v2_client_type': { kind: 'OBJECT'; name: 'v2_client_type'; fields: { 'client_id': { name: 'client_id'; type: { kind: 'SCALAR'; name: 'Int'; ofType: null; } }; 'counterparty_universal_chain_id': { name: 'counterparty_universal_chain_id'; type: { kind: 'SCALAR'; name: 'String'; ofType: null; } }; 'sort_order': { name: 'sort_order'; type: { kind: 'SCALAR'; name: 'String'; ofType: null; } }; 'universal_chain_id': { name: 'universal_chain_id'; type: { kind: 'SCALAR'; name: 'String'; ofType: null; } }; }; };
-    'v2_client_type_bool_exp': { kind: 'INPUT_OBJECT'; name: 'v2_client_type_bool_exp'; isOneOf: false; inputFields: [{ name: '_and'; type: { kind: 'LIST'; name: never; ofType: { kind: 'NON_NULL'; name: never; ofType: { kind: 'INPUT_OBJECT'; name: 'v2_client_type_bool_exp'; ofType: null; }; }; }; defaultValue: null }, { name: '_not'; type: { kind: 'INPUT_OBJECT'; name: 'v2_client_type_bool_exp'; ofType: null; }; defaultValue: null }, { name: '_or'; type: { kind: 'LIST'; name: never; ofType: { kind: 'NON_NULL'; name: never; ofType: { kind: 'INPUT_OBJECT'; name: 'v2_client_type_bool_exp'; ofType: null; }; }; }; defaultValue: null }, { name: 'client_id'; type: { kind: 'INPUT_OBJECT'; name: 'Int_comparison_exp'; ofType: null; }; defaultValue: null }, { name: 'counterparty_universal_chain_id'; type: { kind: 'INPUT_OBJECT'; name: 'String_comparison_exp'; ofType: null; }; defaultValue: null }, { name: 'sort_order'; type: { kind: 'INPUT_OBJECT'; name: 'String_comparison_exp'; ofType: null; }; defaultValue: null }, { name: 'universal_chain_id'; type: { kind: 'INPUT_OBJECT'; name: 'String_comparison_exp'; ofType: null; }; defaultValue: null }]; };
-    'v2_client_type_order_by': { kind: 'INPUT_OBJECT'; name: 'v2_client_type_order_by'; isOneOf: false; inputFields: [{ name: 'client_id'; type: { kind: 'ENUM'; name: 'order_by'; ofType: null; }; defaultValue: null }, { name: 'counterparty_universal_chain_id'; type: { kind: 'ENUM'; name: 'order_by'; ofType: null; }; defaultValue: null }, { name: 'sort_order'; type: { kind: 'ENUM'; name: 'order_by'; ofType: null; }; defaultValue: null }, { name: 'universal_chain_id'; type: { kind: 'ENUM'; name: 'order_by'; ofType: null; }; defaultValue: null }]; };
-    'v2_client_type_select_column': { name: 'v2_client_type_select_column'; enumValues: 'client_id' | 'counterparty_universal_chain_id' | 'sort_order' | 'universal_chain_id'; };
-    'v2_clients_args': { kind: 'INPUT_OBJECT'; name: 'v2_clients_args'; isOneOf: false; inputFields: [{ name: 'p_client_id'; type: { kind: 'SCALAR'; name: 'Int'; ofType: null; }; defaultValue: null }, { name: 'p_comparison'; type: { kind: 'SCALAR'; name: 'String'; ofType: null; }; defaultValue: null }, { name: 'p_counterparty_universal_chain_id'; type: { kind: 'SCALAR'; name: 'String'; ofType: null; }; defaultValue: null }, { name: 'p_limit'; type: { kind: 'SCALAR'; name: 'Int'; ofType: null; }; defaultValue: null }, { name: 'p_sort_order'; type: { kind: 'SCALAR'; name: 'String'; ofType: null; }; defaultValue: null }, { name: 'p_universal_chain_id'; type: { kind: 'SCALAR'; name: 'String'; ofType: null; }; defaultValue: null }]; };
-    'v2_connection_type': { kind: 'OBJECT'; name: 'v2_connection_type'; fields: { 'destination_chain': { name: 'destination_chain'; type: { kind: 'OBJECT'; name: 'v2_chains_view'; ofType: null; } }; 'destination_client_id': { name: 'destination_client_id'; type: { kind: 'SCALAR'; name: 'Int'; ofType: null; } }; 'destination_connection_id': { name: 'destination_connection_id'; type: { kind: 'SCALAR'; name: 'Int'; ofType: null; } }; 'destination_universal_chain_id': { name: 'destination_universal_chain_id'; type: { kind: 'SCALAR'; name: 'String'; ofType: null; } }; 'sort_order': { name: 'sort_order'; type: { kind: 'SCALAR'; name: 'String'; ofType: null; } }; 'source_chain': { name: 'source_chain'; type: { kind: 'OBJECT'; name: 'v2_chains_view'; ofType: null; } }; 'source_client_id': { name: 'source_client_id'; type: { kind: 'SCALAR'; name: 'Int'; ofType: null; } }; 'source_connection_id': { name: 'source_connection_id'; type: { kind: 'SCALAR'; name: 'Int'; ofType: null; } }; 'source_universal_chain_id': { name: 'source_universal_chain_id'; type: { kind: 'SCALAR'; name: 'String'; ofType: null; } }; }; };
-    'v2_connection_type_bool_exp': { kind: 'INPUT_OBJECT'; name: 'v2_connection_type_bool_exp'; isOneOf: false; inputFields: [{ name: '_and'; type: { kind: 'LIST'; name: never; ofType: { kind: 'NON_NULL'; name: never; ofType: { kind: 'INPUT_OBJECT'; name: 'v2_connection_type_bool_exp'; ofType: null; }; }; }; defaultValue: null }, { name: '_not'; type: { kind: 'INPUT_OBJECT'; name: 'v2_connection_type_bool_exp'; ofType: null; }; defaultValue: null }, { name: '_or'; type: { kind: 'LIST'; name: never; ofType: { kind: 'NON_NULL'; name: never; ofType: { kind: 'INPUT_OBJECT'; name: 'v2_connection_type_bool_exp'; ofType: null; }; }; }; defaultValue: null }, { name: 'destination_chain'; type: { kind: 'INPUT_OBJECT'; name: 'v2_chains_view_bool_exp'; ofType: null; }; defaultValue: null }, { name: 'destination_client_id'; type: { kind: 'INPUT_OBJECT'; name: 'Int_comparison_exp'; ofType: null; }; defaultValue: null }, { name: 'destination_connection_id'; type: { kind: 'INPUT_OBJECT'; name: 'Int_comparison_exp'; ofType: null; }; defaultValue: null }, { name: 'destination_universal_chain_id'; type: { kind: 'INPUT_OBJECT'; name: 'String_comparison_exp'; ofType: null; }; defaultValue: null }, { name: 'sort_order'; type: { kind: 'INPUT_OBJECT'; name: 'String_comparison_exp'; ofType: null; }; defaultValue: null }, { name: 'source_chain'; type: { kind: 'INPUT_OBJECT'; name: 'v2_chains_view_bool_exp'; ofType: null; }; defaultValue: null }, { name: 'source_client_id'; type: { kind: 'INPUT_OBJECT'; name: 'Int_comparison_exp'; ofType: null; }; defaultValue: null }, { name: 'source_connection_id'; type: { kind: 'INPUT_OBJECT'; name: 'Int_comparison_exp'; ofType: null; }; defaultValue: null }, { name: 'source_universal_chain_id'; type: { kind: 'INPUT_OBJECT'; name: 'String_comparison_exp'; ofType: null; }; defaultValue: null }]; };
-    'v2_connection_type_order_by': { kind: 'INPUT_OBJECT'; name: 'v2_connection_type_order_by'; isOneOf: false; inputFields: [{ name: 'destination_chain'; type: { kind: 'INPUT_OBJECT'; name: 'v2_chains_view_order_by'; ofType: null; }; defaultValue: null }, { name: 'destination_client_id'; type: { kind: 'ENUM'; name: 'order_by'; ofType: null; }; defaultValue: null }, { name: 'destination_connection_id'; type: { kind: 'ENUM'; name: 'order_by'; ofType: null; }; defaultValue: null }, { name: 'destination_universal_chain_id'; type: { kind: 'ENUM'; name: 'order_by'; ofType: null; }; defaultValue: null }, { name: 'sort_order'; type: { kind: 'ENUM'; name: 'order_by'; ofType: null; }; defaultValue: null }, { name: 'source_chain'; type: { kind: 'INPUT_OBJECT'; name: 'v2_chains_view_order_by'; ofType: null; }; defaultValue: null }, { name: 'source_client_id'; type: { kind: 'ENUM'; name: 'order_by'; ofType: null; }; defaultValue: null }, { name: 'source_connection_id'; type: { kind: 'ENUM'; name: 'order_by'; ofType: null; }; defaultValue: null }, { name: 'source_universal_chain_id'; type: { kind: 'ENUM'; name: 'order_by'; ofType: null; }; defaultValue: null }]; };
-    'v2_connection_type_select_column': { name: 'v2_connection_type_select_column'; enumValues: 'destination_client_id' | 'destination_connection_id' | 'destination_universal_chain_id' | 'sort_order' | 'source_client_id' | 'source_connection_id' | 'source_universal_chain_id'; };
-    'v2_connections_args': { kind: 'INPUT_OBJECT'; name: 'v2_connections_args'; isOneOf: false; inputFields: [{ name: 'p_comparison'; type: { kind: 'SCALAR'; name: 'String'; ofType: null; }; defaultValue: null }, { name: 'p_destination_client_id'; type: { kind: 'SCALAR'; name: 'Int'; ofType: null; }; defaultValue: null }, { name: 'p_destination_connection_id'; type: { kind: 'SCALAR'; name: 'Int'; ofType: null; }; defaultValue: null }, { name: 'p_destination_universal_chain_id'; type: { kind: 'SCALAR'; name: 'String'; ofType: null; }; defaultValue: null }, { name: 'p_limit'; type: { kind: 'SCALAR'; name: 'Int'; ofType: null; }; defaultValue: null }, { name: 'p_sort_order'; type: { kind: 'SCALAR'; name: 'String'; ofType: null; }; defaultValue: null }, { name: 'p_source_client_id'; type: { kind: 'SCALAR'; name: 'Int'; ofType: null; }; defaultValue: null }, { name: 'p_source_connection_id'; type: { kind: 'SCALAR'; name: 'Int'; ofType: null; }; defaultValue: null }, { name: 'p_source_universal_chain_id'; type: { kind: 'SCALAR'; name: 'String'; ofType: null; }; defaultValue: null }]; };
-    'v2_error_type': { kind: 'OBJECT'; name: 'v2_error_type'; fields: { 'detail': { name: 'detail'; type: { kind: 'SCALAR'; name: 'String'; ofType: null; } }; 'hint': { name: 'hint'; type: { kind: 'SCALAR'; name: 'String'; ofType: null; } }; 'message': { name: 'message'; type: { kind: 'SCALAR'; name: 'String'; ofType: null; } }; 'union_error_code': { name: 'union_error_code'; type: { kind: 'SCALAR'; name: 'String'; ofType: null; } }; }; };
-    'v2_error_type_bool_exp': { kind: 'INPUT_OBJECT'; name: 'v2_error_type_bool_exp'; isOneOf: false; inputFields: [{ name: '_and'; type: { kind: 'LIST'; name: never; ofType: { kind: 'NON_NULL'; name: never; ofType: { kind: 'INPUT_OBJECT'; name: 'v2_error_type_bool_exp'; ofType: null; }; }; }; defaultValue: null }, { name: '_not'; type: { kind: 'INPUT_OBJECT'; name: 'v2_error_type_bool_exp'; ofType: null; }; defaultValue: null }, { name: '_or'; type: { kind: 'LIST'; name: never; ofType: { kind: 'NON_NULL'; name: never; ofType: { kind: 'INPUT_OBJECT'; name: 'v2_error_type_bool_exp'; ofType: null; }; }; }; defaultValue: null }, { name: 'detail'; type: { kind: 'INPUT_OBJECT'; name: 'String_comparison_exp'; ofType: null; }; defaultValue: null }, { name: 'hint'; type: { kind: 'INPUT_OBJECT'; name: 'String_comparison_exp'; ofType: null; }; defaultValue: null }, { name: 'message'; type: { kind: 'INPUT_OBJECT'; name: 'String_comparison_exp'; ofType: null; }; defaultValue: null }, { name: 'union_error_code'; type: { kind: 'INPUT_OBJECT'; name: 'String_comparison_exp'; ofType: null; }; defaultValue: null }]; };
-    'v2_error_type_order_by': { kind: 'INPUT_OBJECT'; name: 'v2_error_type_order_by'; isOneOf: false; inputFields: [{ name: 'detail'; type: { kind: 'ENUM'; name: 'order_by'; ofType: null; }; defaultValue: null }, { name: 'hint'; type: { kind: 'ENUM'; name: 'order_by'; ofType: null; }; defaultValue: null }, { name: 'message'; type: { kind: 'ENUM'; name: 'order_by'; ofType: null; }; defaultValue: null }, { name: 'union_error_code'; type: { kind: 'ENUM'; name: 'order_by'; ofType: null; }; defaultValue: null }]; };
-    'v2_error_type_select_column': { name: 'v2_error_type_select_column'; enumValues: 'detail' | 'hint' | 'message' | 'union_error_code'; };
-    'v2_error_type_stream_cursor_input': { kind: 'INPUT_OBJECT'; name: 'v2_error_type_stream_cursor_input'; isOneOf: false; inputFields: [{ name: 'initial_value'; type: { kind: 'NON_NULL'; name: never; ofType: { kind: 'INPUT_OBJECT'; name: 'v2_error_type_stream_cursor_value_input'; ofType: null; }; }; defaultValue: null }, { name: 'ordering'; type: { kind: 'ENUM'; name: 'cursor_ordering'; ofType: null; }; defaultValue: null }]; };
-    'v2_error_type_stream_cursor_value_input': { kind: 'INPUT_OBJECT'; name: 'v2_error_type_stream_cursor_value_input'; isOneOf: false; inputFields: [{ name: 'detail'; type: { kind: 'SCALAR'; name: 'String'; ofType: null; }; defaultValue: null }, { name: 'hint'; type: { kind: 'SCALAR'; name: 'String'; ofType: null; }; defaultValue: null }, { name: 'message'; type: { kind: 'SCALAR'; name: 'String'; ofType: null; }; defaultValue: null }, { name: 'union_error_code'; type: { kind: 'SCALAR'; name: 'String'; ofType: null; }; defaultValue: null }]; };
-    'v2_explorers': { kind: 'OBJECT'; name: 'v2_explorers'; fields: { 'address_url': { name: 'address_url'; type: { kind: 'SCALAR'; name: 'String'; ofType: null; } }; 'block_url': { name: 'block_url'; type: { kind: 'SCALAR'; name: 'String'; ofType: null; } }; 'description': { name: 'description'; type: { kind: 'SCALAR'; name: 'String'; ofType: null; } }; 'display_name': { name: 'display_name'; type: { kind: 'SCALAR'; name: 'String'; ofType: null; } }; 'home_url': { name: 'home_url'; type: { kind: 'SCALAR'; name: 'String'; ofType: null; } }; 'logo_uri': { name: 'logo_uri'; type: { kind: 'SCALAR'; name: 'String'; ofType: null; } }; 'name': { name: 'name'; type: { kind: 'SCALAR'; name: 'String'; ofType: null; } }; 'tx_url': { name: 'tx_url'; type: { kind: 'SCALAR'; name: 'String'; ofType: null; } }; }; };
-    'v2_explorers_aggregate_order_by': { kind: 'INPUT_OBJECT'; name: 'v2_explorers_aggregate_order_by'; isOneOf: false; inputFields: [{ name: 'count'; type: { kind: 'ENUM'; name: 'order_by'; ofType: null; }; defaultValue: null }, { name: 'max'; type: { kind: 'INPUT_OBJECT'; name: 'v2_explorers_max_order_by'; ofType: null; }; defaultValue: null }, { name: 'min'; type: { kind: 'INPUT_OBJECT'; name: 'v2_explorers_min_order_by'; ofType: null; }; defaultValue: null }]; };
-    'v2_explorers_bool_exp': { kind: 'INPUT_OBJECT'; name: 'v2_explorers_bool_exp'; isOneOf: false; inputFields: [{ name: '_and'; type: { kind: 'LIST'; name: never; ofType: { kind: 'NON_NULL'; name: never; ofType: { kind: 'INPUT_OBJECT'; name: 'v2_explorers_bool_exp'; ofType: null; }; }; }; defaultValue: null }, { name: '_not'; type: { kind: 'INPUT_OBJECT'; name: 'v2_explorers_bool_exp'; ofType: null; }; defaultValue: null }, { name: '_or'; type: { kind: 'LIST'; name: never; ofType: { kind: 'NON_NULL'; name: never; ofType: { kind: 'INPUT_OBJECT'; name: 'v2_explorers_bool_exp'; ofType: null; }; }; }; defaultValue: null }, { name: 'address_url'; type: { kind: 'INPUT_OBJECT'; name: 'String_comparison_exp'; ofType: null; }; defaultValue: null }, { name: 'block_url'; type: { kind: 'INPUT_OBJECT'; name: 'String_comparison_exp'; ofType: null; }; defaultValue: null }, { name: 'description'; type: { kind: 'INPUT_OBJECT'; name: 'String_comparison_exp'; ofType: null; }; defaultValue: null }, { name: 'display_name'; type: { kind: 'INPUT_OBJECT'; name: 'String_comparison_exp'; ofType: null; }; defaultValue: null }, { name: 'home_url'; type: { kind: 'INPUT_OBJECT'; name: 'String_comparison_exp'; ofType: null; }; defaultValue: null }, { name: 'logo_uri'; type: { kind: 'INPUT_OBJECT'; name: 'String_comparison_exp'; ofType: null; }; defaultValue: null }, { name: 'name'; type: { kind: 'INPUT_OBJECT'; name: 'String_comparison_exp'; ofType: null; }; defaultValue: null }, { name: 'tx_url'; type: { kind: 'INPUT_OBJECT'; name: 'String_comparison_exp'; ofType: null; }; defaultValue: null }]; };
-    'v2_explorers_max_order_by': { kind: 'INPUT_OBJECT'; name: 'v2_explorers_max_order_by'; isOneOf: false; inputFields: [{ name: 'address_url'; type: { kind: 'ENUM'; name: 'order_by'; ofType: null; }; defaultValue: null }, { name: 'block_url'; type: { kind: 'ENUM'; name: 'order_by'; ofType: null; }; defaultValue: null }, { name: 'description'; type: { kind: 'ENUM'; name: 'order_by'; ofType: null; }; defaultValue: null }, { name: 'display_name'; type: { kind: 'ENUM'; name: 'order_by'; ofType: null; }; defaultValue: null }, { name: 'home_url'; type: { kind: 'ENUM'; name: 'order_by'; ofType: null; }; defaultValue: null }, { name: 'logo_uri'; type: { kind: 'ENUM'; name: 'order_by'; ofType: null; }; defaultValue: null }, { name: 'name'; type: { kind: 'ENUM'; name: 'order_by'; ofType: null; }; defaultValue: null }, { name: 'tx_url'; type: { kind: 'ENUM'; name: 'order_by'; ofType: null; }; defaultValue: null }]; };
-    'v2_explorers_min_order_by': { kind: 'INPUT_OBJECT'; name: 'v2_explorers_min_order_by'; isOneOf: false; inputFields: [{ name: 'address_url'; type: { kind: 'ENUM'; name: 'order_by'; ofType: null; }; defaultValue: null }, { name: 'block_url'; type: { kind: 'ENUM'; name: 'order_by'; ofType: null; }; defaultValue: null }, { name: 'description'; type: { kind: 'ENUM'; name: 'order_by'; ofType: null; }; defaultValue: null }, { name: 'display_name'; type: { kind: 'ENUM'; name: 'order_by'; ofType: null; }; defaultValue: null }, { name: 'home_url'; type: { kind: 'ENUM'; name: 'order_by'; ofType: null; }; defaultValue: null }, { name: 'logo_uri'; type: { kind: 'ENUM'; name: 'order_by'; ofType: null; }; defaultValue: null }, { name: 'name'; type: { kind: 'ENUM'; name: 'order_by'; ofType: null; }; defaultValue: null }, { name: 'tx_url'; type: { kind: 'ENUM'; name: 'order_by'; ofType: null; }; defaultValue: null }]; };
-    'v2_explorers_order_by': { kind: 'INPUT_OBJECT'; name: 'v2_explorers_order_by'; isOneOf: false; inputFields: [{ name: 'address_url'; type: { kind: 'ENUM'; name: 'order_by'; ofType: null; }; defaultValue: null }, { name: 'block_url'; type: { kind: 'ENUM'; name: 'order_by'; ofType: null; }; defaultValue: null }, { name: 'description'; type: { kind: 'ENUM'; name: 'order_by'; ofType: null; }; defaultValue: null }, { name: 'display_name'; type: { kind: 'ENUM'; name: 'order_by'; ofType: null; }; defaultValue: null }, { name: 'home_url'; type: { kind: 'ENUM'; name: 'order_by'; ofType: null; }; defaultValue: null }, { name: 'logo_uri'; type: { kind: 'ENUM'; name: 'order_by'; ofType: null; }; defaultValue: null }, { name: 'name'; type: { kind: 'ENUM'; name: 'order_by'; ofType: null; }; defaultValue: null }, { name: 'tx_url'; type: { kind: 'ENUM'; name: 'order_by'; ofType: null; }; defaultValue: null }]; };
-    'v2_explorers_select_column': { name: 'v2_explorers_select_column'; enumValues: 'address_url' | 'block_url' | 'description' | 'display_name' | 'home_url' | 'logo_uri' | 'name' | 'tx_url'; };
-    'v2_health_check_type': { kind: 'OBJECT'; name: 'v2_health_check_type'; fields: { 'environment': { name: 'environment'; type: { kind: 'SCALAR'; name: 'String'; ofType: null; } }; 'last_update': { name: 'last_update'; type: { kind: 'SCALAR'; name: 'timestamptz'; ofType: null; } }; 'status': { name: 'status'; type: { kind: 'SCALAR'; name: 'String'; ofType: null; } }; }; };
-    'v2_health_check_type_bool_exp': { kind: 'INPUT_OBJECT'; name: 'v2_health_check_type_bool_exp'; isOneOf: false; inputFields: [{ name: '_and'; type: { kind: 'LIST'; name: never; ofType: { kind: 'NON_NULL'; name: never; ofType: { kind: 'INPUT_OBJECT'; name: 'v2_health_check_type_bool_exp'; ofType: null; }; }; }; defaultValue: null }, { name: '_not'; type: { kind: 'INPUT_OBJECT'; name: 'v2_health_check_type_bool_exp'; ofType: null; }; defaultValue: null }, { name: '_or'; type: { kind: 'LIST'; name: never; ofType: { kind: 'NON_NULL'; name: never; ofType: { kind: 'INPUT_OBJECT'; name: 'v2_health_check_type_bool_exp'; ofType: null; }; }; }; defaultValue: null }, { name: 'environment'; type: { kind: 'INPUT_OBJECT'; name: 'String_comparison_exp'; ofType: null; }; defaultValue: null }, { name: 'last_update'; type: { kind: 'INPUT_OBJECT'; name: 'timestamptz_comparison_exp'; ofType: null; }; defaultValue: null }, { name: 'status'; type: { kind: 'INPUT_OBJECT'; name: 'String_comparison_exp'; ofType: null; }; defaultValue: null }]; };
-    'v2_health_check_type_order_by': { kind: 'INPUT_OBJECT'; name: 'v2_health_check_type_order_by'; isOneOf: false; inputFields: [{ name: 'environment'; type: { kind: 'ENUM'; name: 'order_by'; ofType: null; }; defaultValue: null }, { name: 'last_update'; type: { kind: 'ENUM'; name: 'order_by'; ofType: null; }; defaultValue: null }, { name: 'status'; type: { kind: 'ENUM'; name: 'order_by'; ofType: null; }; defaultValue: null }]; };
-    'v2_health_check_type_select_column': { name: 'v2_health_check_type_select_column'; enumValues: 'environment' | 'last_update' | 'status'; };
-    'v2_packet_type': { kind: 'OBJECT'; name: 'v2_packet_type'; fields: { 'acknowledgement': { name: 'acknowledgement'; type: { kind: 'SCALAR'; name: 'String'; ofType: null; } }; 'channel_version': { name: 'channel_version'; type: { kind: 'SCALAR'; name: 'String'; ofType: null; } }; 'data': { name: 'data'; type: { kind: 'SCALAR'; name: 'String'; ofType: null; } }; 'decoded': { name: 'decoded'; type: { kind: 'SCALAR'; name: 'jsonb'; ofType: null; } }; 'decoded_flattened': { name: 'decoded_flattened'; type: { kind: 'SCALAR'; name: 'jsonb'; ofType: null; } }; 'destination_chain': { name: 'destination_chain'; type: { kind: 'OBJECT'; name: 'v2_chains_view'; ofType: null; } }; 'destination_chain_id': { name: 'destination_chain_id'; type: { kind: 'SCALAR'; name: 'String'; ofType: null; } }; 'destination_channel_id': { name: 'destination_channel_id'; type: { kind: 'SCALAR'; name: 'Int'; ofType: null; } }; 'destination_client_id': { name: 'destination_client_id'; type: { kind: 'SCALAR'; name: 'Int'; ofType: null; } }; 'destination_connection_id': { name: 'destination_connection_id'; type: { kind: 'SCALAR'; name: 'Int'; ofType: null; } }; 'destination_port_id': { name: 'destination_port_id'; type: { kind: 'SCALAR'; name: 'String'; ofType: null; } }; 'destination_universal_chain_id': { name: 'destination_universal_chain_id'; type: { kind: 'SCALAR'; name: 'String'; ofType: null; } }; 'packet_ack_block_hash': { name: 'packet_ack_block_hash'; type: { kind: 'SCALAR'; name: 'String'; ofType: null; } }; 'packet_ack_height': { name: 'packet_ack_height'; type: { kind: 'SCALAR'; name: 'String'; ofType: null; } }; 'packet_ack_maker': { name: 'packet_ack_maker'; type: { kind: 'SCALAR'; name: 'String'; ofType: null; } }; 'packet_ack_timestamp': { name: 'packet_ack_timestamp'; type: { kind: 'SCALAR'; name: 'timestamptz'; ofType: null; } }; 'packet_ack_transaction_hash': { name: 'packet_ack_transaction_hash'; type: { kind: 'SCALAR'; name: 'String'; ofType: null; } }; 'packet_hash': { name: 'packet_hash'; type: { kind: 'SCALAR'; name: 'String'; ofType: null; } }; 'packet_recv_block_hash': { name: 'packet_recv_block_hash'; type: { kind: 'SCALAR'; name: 'String'; ofType: null; } }; 'packet_recv_height': { name: 'packet_recv_height'; type: { kind: 'SCALAR'; name: 'String'; ofType: null; } }; 'packet_recv_maker': { name: 'packet_recv_maker'; type: { kind: 'SCALAR'; name: 'String'; ofType: null; } }; 'packet_recv_maker_msg': { name: 'packet_recv_maker_msg'; type: { kind: 'SCALAR'; name: 'String'; ofType: null; } }; 'packet_recv_timestamp': { name: 'packet_recv_timestamp'; type: { kind: 'SCALAR'; name: 'timestamptz'; ofType: null; } }; 'packet_recv_transaction_hash': { name: 'packet_recv_transaction_hash'; type: { kind: 'SCALAR'; name: 'String'; ofType: null; } }; 'packet_send_block_hash': { name: 'packet_send_block_hash'; type: { kind: 'SCALAR'; name: 'String'; ofType: null; } }; 'packet_send_height': { name: 'packet_send_height'; type: { kind: 'SCALAR'; name: 'String'; ofType: null; } }; 'packet_send_timestamp': { name: 'packet_send_timestamp'; type: { kind: 'SCALAR'; name: 'timestamptz'; ofType: null; } }; 'packet_send_transaction_hash': { name: 'packet_send_transaction_hash'; type: { kind: 'SCALAR'; name: 'String'; ofType: null; } }; 'packet_timeout_block_hash': { name: 'packet_timeout_block_hash'; type: { kind: 'SCALAR'; name: 'String'; ofType: null; } }; 'packet_timeout_height': { name: 'packet_timeout_height'; type: { kind: 'SCALAR'; name: 'String'; ofType: null; } }; 'packet_timeout_maker': { name: 'packet_timeout_maker'; type: { kind: 'SCALAR'; name: 'String'; ofType: null; } }; 'packet_timeout_timestamp': { name: 'packet_timeout_timestamp'; type: { kind: 'SCALAR'; name: 'timestamptz'; ofType: null; } }; 'packet_timeout_transaction_hash': { name: 'packet_timeout_transaction_hash'; type: { kind: 'SCALAR'; name: 'String'; ofType: null; } }; 'sort_order': { name: 'sort_order'; type: { kind: 'SCALAR'; name: 'String'; ofType: null; } }; 'source_chain': { name: 'source_chain'; type: { kind: 'OBJECT'; name: 'v2_chains_view'; ofType: null; } }; 'source_channel_id': { name: 'source_channel_id'; type: { kind: 'SCALAR'; name: 'Int'; ofType: null; } }; 'source_client_id': { name: 'source_client_id'; type: { kind: 'SCALAR'; name: 'Int'; ofType: null; } }; 'source_connection_id': { name: 'source_connection_id'; type: { kind: 'SCALAR'; name: 'Int'; ofType: null; } }; 'source_port_id': { name: 'source_port_id'; type: { kind: 'SCALAR'; name: 'String'; ofType: null; } }; 'source_universal_chain_id': { name: 'source_universal_chain_id'; type: { kind: 'SCALAR'; name: 'String'; ofType: null; } }; 'status': { name: 'status'; type: { kind: 'SCALAR'; name: 'String'; ofType: null; } }; 'success': { name: 'success'; type: { kind: 'SCALAR'; name: 'Boolean'; ofType: null; } }; 'timeout_height': { name: 'timeout_height'; type: { kind: 'SCALAR'; name: 'String'; ofType: null; } }; 'timeout_timestamp': { name: 'timeout_timestamp'; type: { kind: 'SCALAR'; name: 'String'; ofType: null; } }; 'traces': { name: 'traces'; type: { kind: 'LIST'; name: never; ofType: { kind: 'NON_NULL'; name: never; ofType: { kind: 'OBJECT'; name: 'v2_traces_type'; ofType: null; }; }; } }; 'write_ack_block_hash': { name: 'write_ack_block_hash'; type: { kind: 'SCALAR'; name: 'String'; ofType: null; } }; 'write_ack_height': { name: 'write_ack_height'; type: { kind: 'SCALAR'; name: 'String'; ofType: null; } }; 'write_ack_timestamp': { name: 'write_ack_timestamp'; type: { kind: 'SCALAR'; name: 'timestamptz'; ofType: null; } }; 'write_ack_transaction_hash': { name: 'write_ack_transaction_hash'; type: { kind: 'SCALAR'; name: 'String'; ofType: null; } }; }; };
-    'v2_packet_type_bool_exp': { kind: 'INPUT_OBJECT'; name: 'v2_packet_type_bool_exp'; isOneOf: false; inputFields: [{ name: '_and'; type: { kind: 'LIST'; name: never; ofType: { kind: 'NON_NULL'; name: never; ofType: { kind: 'INPUT_OBJECT'; name: 'v2_packet_type_bool_exp'; ofType: null; }; }; }; defaultValue: null }, { name: '_not'; type: { kind: 'INPUT_OBJECT'; name: 'v2_packet_type_bool_exp'; ofType: null; }; defaultValue: null }, { name: '_or'; type: { kind: 'LIST'; name: never; ofType: { kind: 'NON_NULL'; name: never; ofType: { kind: 'INPUT_OBJECT'; name: 'v2_packet_type_bool_exp'; ofType: null; }; }; }; defaultValue: null }, { name: 'acknowledgement'; type: { kind: 'INPUT_OBJECT'; name: 'String_comparison_exp'; ofType: null; }; defaultValue: null }, { name: 'channel_version'; type: { kind: 'INPUT_OBJECT'; name: 'String_comparison_exp'; ofType: null; }; defaultValue: null }, { name: 'data'; type: { kind: 'INPUT_OBJECT'; name: 'String_comparison_exp'; ofType: null; }; defaultValue: null }, { name: 'decoded'; type: { kind: 'INPUT_OBJECT'; name: 'jsonb_comparison_exp'; ofType: null; }; defaultValue: null }, { name: 'decoded_flattened'; type: { kind: 'INPUT_OBJECT'; name: 'jsonb_comparison_exp'; ofType: null; }; defaultValue: null }, { name: 'destination_chain'; type: { kind: 'INPUT_OBJECT'; name: 'v2_chains_view_bool_exp'; ofType: null; }; defaultValue: null }, { name: 'destination_chain_id'; type: { kind: 'INPUT_OBJECT'; name: 'String_comparison_exp'; ofType: null; }; defaultValue: null }, { name: 'destination_channel_id'; type: { kind: 'INPUT_OBJECT'; name: 'Int_comparison_exp'; ofType: null; }; defaultValue: null }, { name: 'destination_client_id'; type: { kind: 'INPUT_OBJECT'; name: 'Int_comparison_exp'; ofType: null; }; defaultValue: null }, { name: 'destination_connection_id'; type: { kind: 'INPUT_OBJECT'; name: 'Int_comparison_exp'; ofType: null; }; defaultValue: null }, { name: 'destination_port_id'; type: { kind: 'INPUT_OBJECT'; name: 'String_comparison_exp'; ofType: null; }; defaultValue: null }, { name: 'destination_universal_chain_id'; type: { kind: 'INPUT_OBJECT'; name: 'String_comparison_exp'; ofType: null; }; defaultValue: null }, { name: 'packet_ack_block_hash'; type: { kind: 'INPUT_OBJECT'; name: 'String_comparison_exp'; ofType: null; }; defaultValue: null }, { name: 'packet_ack_height'; type: { kind: 'INPUT_OBJECT'; name: 'String_comparison_exp'; ofType: null; }; defaultValue: null }, { name: 'packet_ack_maker'; type: { kind: 'INPUT_OBJECT'; name: 'String_comparison_exp'; ofType: null; }; defaultValue: null }, { name: 'packet_ack_timestamp'; type: { kind: 'INPUT_OBJECT'; name: 'timestamptz_comparison_exp'; ofType: null; }; defaultValue: null }, { name: 'packet_ack_transaction_hash'; type: { kind: 'INPUT_OBJECT'; name: 'String_comparison_exp'; ofType: null; }; defaultValue: null }, { name: 'packet_hash'; type: { kind: 'INPUT_OBJECT'; name: 'String_comparison_exp'; ofType: null; }; defaultValue: null }, { name: 'packet_recv_block_hash'; type: { kind: 'INPUT_OBJECT'; name: 'String_comparison_exp'; ofType: null; }; defaultValue: null }, { name: 'packet_recv_height'; type: { kind: 'INPUT_OBJECT'; name: 'String_comparison_exp'; ofType: null; }; defaultValue: null }, { name: 'packet_recv_maker'; type: { kind: 'INPUT_OBJECT'; name: 'String_comparison_exp'; ofType: null; }; defaultValue: null }, { name: 'packet_recv_maker_msg'; type: { kind: 'INPUT_OBJECT'; name: 'String_comparison_exp'; ofType: null; }; defaultValue: null }, { name: 'packet_recv_timestamp'; type: { kind: 'INPUT_OBJECT'; name: 'timestamptz_comparison_exp'; ofType: null; }; defaultValue: null }, { name: 'packet_recv_transaction_hash'; type: { kind: 'INPUT_OBJECT'; name: 'String_comparison_exp'; ofType: null; }; defaultValue: null }, { name: 'packet_send_block_hash'; type: { kind: 'INPUT_OBJECT'; name: 'String_comparison_exp'; ofType: null; }; defaultValue: null }, { name: 'packet_send_height'; type: { kind: 'INPUT_OBJECT'; name: 'String_comparison_exp'; ofType: null; }; defaultValue: null }, { name: 'packet_send_timestamp'; type: { kind: 'INPUT_OBJECT'; name: 'timestamptz_comparison_exp'; ofType: null; }; defaultValue: null }, { name: 'packet_send_transaction_hash'; type: { kind: 'INPUT_OBJECT'; name: 'String_comparison_exp'; ofType: null; }; defaultValue: null }, { name: 'packet_timeout_block_hash'; type: { kind: 'INPUT_OBJECT'; name: 'String_comparison_exp'; ofType: null; }; defaultValue: null }, { name: 'packet_timeout_height'; type: { kind: 'INPUT_OBJECT'; name: 'String_comparison_exp'; ofType: null; }; defaultValue: null }, { name: 'packet_timeout_maker'; type: { kind: 'INPUT_OBJECT'; name: 'String_comparison_exp'; ofType: null; }; defaultValue: null }, { name: 'packet_timeout_timestamp'; type: { kind: 'INPUT_OBJECT'; name: 'timestamptz_comparison_exp'; ofType: null; }; defaultValue: null }, { name: 'packet_timeout_transaction_hash'; type: { kind: 'INPUT_OBJECT'; name: 'String_comparison_exp'; ofType: null; }; defaultValue: null }, { name: 'sort_order'; type: { kind: 'INPUT_OBJECT'; name: 'String_comparison_exp'; ofType: null; }; defaultValue: null }, { name: 'source_chain'; type: { kind: 'INPUT_OBJECT'; name: 'v2_chains_view_bool_exp'; ofType: null; }; defaultValue: null }, { name: 'source_channel_id'; type: { kind: 'INPUT_OBJECT'; name: 'Int_comparison_exp'; ofType: null; }; defaultValue: null }, { name: 'source_client_id'; type: { kind: 'INPUT_OBJECT'; name: 'Int_comparison_exp'; ofType: null; }; defaultValue: null }, { name: 'source_connection_id'; type: { kind: 'INPUT_OBJECT'; name: 'Int_comparison_exp'; ofType: null; }; defaultValue: null }, { name: 'source_port_id'; type: { kind: 'INPUT_OBJECT'; name: 'String_comparison_exp'; ofType: null; }; defaultValue: null }, { name: 'source_universal_chain_id'; type: { kind: 'INPUT_OBJECT'; name: 'String_comparison_exp'; ofType: null; }; defaultValue: null }, { name: 'status'; type: { kind: 'INPUT_OBJECT'; name: 'String_comparison_exp'; ofType: null; }; defaultValue: null }, { name: 'success'; type: { kind: 'INPUT_OBJECT'; name: 'Boolean_comparison_exp'; ofType: null; }; defaultValue: null }, { name: 'timeout_height'; type: { kind: 'INPUT_OBJECT'; name: 'String_comparison_exp'; ofType: null; }; defaultValue: null }, { name: 'timeout_timestamp'; type: { kind: 'INPUT_OBJECT'; name: 'String_comparison_exp'; ofType: null; }; defaultValue: null }, { name: 'traces'; type: { kind: 'INPUT_OBJECT'; name: 'v2_traces_type_bool_exp'; ofType: null; }; defaultValue: null }, { name: 'write_ack_block_hash'; type: { kind: 'INPUT_OBJECT'; name: 'String_comparison_exp'; ofType: null; }; defaultValue: null }, { name: 'write_ack_height'; type: { kind: 'INPUT_OBJECT'; name: 'String_comparison_exp'; ofType: null; }; defaultValue: null }, { name: 'write_ack_timestamp'; type: { kind: 'INPUT_OBJECT'; name: 'timestamptz_comparison_exp'; ofType: null; }; defaultValue: null }, { name: 'write_ack_transaction_hash'; type: { kind: 'INPUT_OBJECT'; name: 'String_comparison_exp'; ofType: null; }; defaultValue: null }]; };
-    'v2_packet_type_order_by': { kind: 'INPUT_OBJECT'; name: 'v2_packet_type_order_by'; isOneOf: false; inputFields: [{ name: 'acknowledgement'; type: { kind: 'ENUM'; name: 'order_by'; ofType: null; }; defaultValue: null }, { name: 'channel_version'; type: { kind: 'ENUM'; name: 'order_by'; ofType: null; }; defaultValue: null }, { name: 'data'; type: { kind: 'ENUM'; name: 'order_by'; ofType: null; }; defaultValue: null }, { name: 'decoded'; type: { kind: 'ENUM'; name: 'order_by'; ofType: null; }; defaultValue: null }, { name: 'decoded_flattened'; type: { kind: 'ENUM'; name: 'order_by'; ofType: null; }; defaultValue: null }, { name: 'destination_chain'; type: { kind: 'INPUT_OBJECT'; name: 'v2_chains_view_order_by'; ofType: null; }; defaultValue: null }, { name: 'destination_chain_id'; type: { kind: 'ENUM'; name: 'order_by'; ofType: null; }; defaultValue: null }, { name: 'destination_channel_id'; type: { kind: 'ENUM'; name: 'order_by'; ofType: null; }; defaultValue: null }, { name: 'destination_client_id'; type: { kind: 'ENUM'; name: 'order_by'; ofType: null; }; defaultValue: null }, { name: 'destination_connection_id'; type: { kind: 'ENUM'; name: 'order_by'; ofType: null; }; defaultValue: null }, { name: 'destination_port_id'; type: { kind: 'ENUM'; name: 'order_by'; ofType: null; }; defaultValue: null }, { name: 'destination_universal_chain_id'; type: { kind: 'ENUM'; name: 'order_by'; ofType: null; }; defaultValue: null }, { name: 'packet_ack_block_hash'; type: { kind: 'ENUM'; name: 'order_by'; ofType: null; }; defaultValue: null }, { name: 'packet_ack_height'; type: { kind: 'ENUM'; name: 'order_by'; ofType: null; }; defaultValue: null }, { name: 'packet_ack_maker'; type: { kind: 'ENUM'; name: 'order_by'; ofType: null; }; defaultValue: null }, { name: 'packet_ack_timestamp'; type: { kind: 'ENUM'; name: 'order_by'; ofType: null; }; defaultValue: null }, { name: 'packet_ack_transaction_hash'; type: { kind: 'ENUM'; name: 'order_by'; ofType: null; }; defaultValue: null }, { name: 'packet_hash'; type: { kind: 'ENUM'; name: 'order_by'; ofType: null; }; defaultValue: null }, { name: 'packet_recv_block_hash'; type: { kind: 'ENUM'; name: 'order_by'; ofType: null; }; defaultValue: null }, { name: 'packet_recv_height'; type: { kind: 'ENUM'; name: 'order_by'; ofType: null; }; defaultValue: null }, { name: 'packet_recv_maker'; type: { kind: 'ENUM'; name: 'order_by'; ofType: null; }; defaultValue: null }, { name: 'packet_recv_maker_msg'; type: { kind: 'ENUM'; name: 'order_by'; ofType: null; }; defaultValue: null }, { name: 'packet_recv_timestamp'; type: { kind: 'ENUM'; name: 'order_by'; ofType: null; }; defaultValue: null }, { name: 'packet_recv_transaction_hash'; type: { kind: 'ENUM'; name: 'order_by'; ofType: null; }; defaultValue: null }, { name: 'packet_send_block_hash'; type: { kind: 'ENUM'; name: 'order_by'; ofType: null; }; defaultValue: null }, { name: 'packet_send_height'; type: { kind: 'ENUM'; name: 'order_by'; ofType: null; }; defaultValue: null }, { name: 'packet_send_timestamp'; type: { kind: 'ENUM'; name: 'order_by'; ofType: null; }; defaultValue: null }, { name: 'packet_send_transaction_hash'; type: { kind: 'ENUM'; name: 'order_by'; ofType: null; }; defaultValue: null }, { name: 'packet_timeout_block_hash'; type: { kind: 'ENUM'; name: 'order_by'; ofType: null; }; defaultValue: null }, { name: 'packet_timeout_height'; type: { kind: 'ENUM'; name: 'order_by'; ofType: null; }; defaultValue: null }, { name: 'packet_timeout_maker'; type: { kind: 'ENUM'; name: 'order_by'; ofType: null; }; defaultValue: null }, { name: 'packet_timeout_timestamp'; type: { kind: 'ENUM'; name: 'order_by'; ofType: null; }; defaultValue: null }, { name: 'packet_timeout_transaction_hash'; type: { kind: 'ENUM'; name: 'order_by'; ofType: null; }; defaultValue: null }, { name: 'sort_order'; type: { kind: 'ENUM'; name: 'order_by'; ofType: null; }; defaultValue: null }, { name: 'source_chain'; type: { kind: 'INPUT_OBJECT'; name: 'v2_chains_view_order_by'; ofType: null; }; defaultValue: null }, { name: 'source_channel_id'; type: { kind: 'ENUM'; name: 'order_by'; ofType: null; }; defaultValue: null }, { name: 'source_client_id'; type: { kind: 'ENUM'; name: 'order_by'; ofType: null; }; defaultValue: null }, { name: 'source_connection_id'; type: { kind: 'ENUM'; name: 'order_by'; ofType: null; }; defaultValue: null }, { name: 'source_port_id'; type: { kind: 'ENUM'; name: 'order_by'; ofType: null; }; defaultValue: null }, { name: 'source_universal_chain_id'; type: { kind: 'ENUM'; name: 'order_by'; ofType: null; }; defaultValue: null }, { name: 'status'; type: { kind: 'ENUM'; name: 'order_by'; ofType: null; }; defaultValue: null }, { name: 'success'; type: { kind: 'ENUM'; name: 'order_by'; ofType: null; }; defaultValue: null }, { name: 'timeout_height'; type: { kind: 'ENUM'; name: 'order_by'; ofType: null; }; defaultValue: null }, { name: 'timeout_timestamp'; type: { kind: 'ENUM'; name: 'order_by'; ofType: null; }; defaultValue: null }, { name: 'traces_aggregate'; type: { kind: 'INPUT_OBJECT'; name: 'v2_traces_type_aggregate_order_by'; ofType: null; }; defaultValue: null }, { name: 'write_ack_block_hash'; type: { kind: 'ENUM'; name: 'order_by'; ofType: null; }; defaultValue: null }, { name: 'write_ack_height'; type: { kind: 'ENUM'; name: 'order_by'; ofType: null; }; defaultValue: null }, { name: 'write_ack_timestamp'; type: { kind: 'ENUM'; name: 'order_by'; ofType: null; }; defaultValue: null }, { name: 'write_ack_transaction_hash'; type: { kind: 'ENUM'; name: 'order_by'; ofType: null; }; defaultValue: null }]; };
-    'v2_packet_type_select_column': { name: 'v2_packet_type_select_column'; enumValues: 'acknowledgement' | 'channel_version' | 'data' | 'decoded' | 'decoded_flattened' | 'destination_chain_id' | 'destination_channel_id' | 'destination_client_id' | 'destination_connection_id' | 'destination_port_id' | 'destination_universal_chain_id' | 'packet_ack_block_hash' | 'packet_ack_height' | 'packet_ack_maker' | 'packet_ack_timestamp' | 'packet_ack_transaction_hash' | 'packet_hash' | 'packet_recv_block_hash' | 'packet_recv_height' | 'packet_recv_maker' | 'packet_recv_maker_msg' | 'packet_recv_timestamp' | 'packet_recv_transaction_hash' | 'packet_send_block_hash' | 'packet_send_height' | 'packet_send_timestamp' | 'packet_send_transaction_hash' | 'packet_timeout_block_hash' | 'packet_timeout_height' | 'packet_timeout_maker' | 'packet_timeout_timestamp' | 'packet_timeout_transaction_hash' | 'sort_order' | 'source_channel_id' | 'source_client_id' | 'source_connection_id' | 'source_port_id' | 'source_universal_chain_id' | 'status' | 'success' | 'timeout_height' | 'timeout_timestamp' | 'write_ack_block_hash' | 'write_ack_height' | 'write_ack_timestamp' | 'write_ack_transaction_hash'; };
-    'v2_packets_args': { kind: 'INPUT_OBJECT'; name: 'v2_packets_args'; isOneOf: false; inputFields: [{ name: 'p_block_hash'; type: { kind: 'SCALAR'; name: 'String'; ofType: null; }; defaultValue: null }, { name: 'p_comparison'; type: { kind: 'SCALAR'; name: 'String'; ofType: null; }; defaultValue: null }, { name: 'p_destination_universal_chain_id'; type: { kind: 'SCALAR'; name: 'String'; ofType: null; }; defaultValue: null }, { name: 'p_limit'; type: { kind: 'SCALAR'; name: 'Int'; ofType: null; }; defaultValue: null }, { name: 'p_packet_hash'; type: { kind: 'SCALAR'; name: 'String'; ofType: null; }; defaultValue: null }, { name: 'p_packet_send_timestamp'; type: { kind: 'SCALAR'; name: 'timestamptz'; ofType: null; }; defaultValue: null }, { name: 'p_sort_order'; type: { kind: 'SCALAR'; name: 'String'; ofType: null; }; defaultValue: null }, { name: 'p_source_universal_chain_id'; type: { kind: 'SCALAR'; name: 'String'; ofType: null; }; defaultValue: null }, { name: 'p_transaction_hash'; type: { kind: 'SCALAR'; name: 'String'; ofType: null; }; defaultValue: null }]; };
-    'v2_rpcs': { kind: 'OBJECT'; name: 'v2_rpcs'; fields: { 'type': { name: 'type'; type: { kind: 'SCALAR'; name: 'String'; ofType: null; } }; 'url': { name: 'url'; type: { kind: 'SCALAR'; name: 'String'; ofType: null; } }; }; };
-    'v2_rpcs_aggregate_order_by': { kind: 'INPUT_OBJECT'; name: 'v2_rpcs_aggregate_order_by'; isOneOf: false; inputFields: [{ name: 'count'; type: { kind: 'ENUM'; name: 'order_by'; ofType: null; }; defaultValue: null }, { name: 'max'; type: { kind: 'INPUT_OBJECT'; name: 'v2_rpcs_max_order_by'; ofType: null; }; defaultValue: null }, { name: 'min'; type: { kind: 'INPUT_OBJECT'; name: 'v2_rpcs_min_order_by'; ofType: null; }; defaultValue: null }]; };
-    'v2_rpcs_bool_exp': { kind: 'INPUT_OBJECT'; name: 'v2_rpcs_bool_exp'; isOneOf: false; inputFields: [{ name: '_and'; type: { kind: 'LIST'; name: never; ofType: { kind: 'NON_NULL'; name: never; ofType: { kind: 'INPUT_OBJECT'; name: 'v2_rpcs_bool_exp'; ofType: null; }; }; }; defaultValue: null }, { name: '_not'; type: { kind: 'INPUT_OBJECT'; name: 'v2_rpcs_bool_exp'; ofType: null; }; defaultValue: null }, { name: '_or'; type: { kind: 'LIST'; name: never; ofType: { kind: 'NON_NULL'; name: never; ofType: { kind: 'INPUT_OBJECT'; name: 'v2_rpcs_bool_exp'; ofType: null; }; }; }; defaultValue: null }, { name: 'type'; type: { kind: 'INPUT_OBJECT'; name: 'String_comparison_exp'; ofType: null; }; defaultValue: null }, { name: 'url'; type: { kind: 'INPUT_OBJECT'; name: 'String_comparison_exp'; ofType: null; }; defaultValue: null }]; };
-    'v2_rpcs_max_order_by': { kind: 'INPUT_OBJECT'; name: 'v2_rpcs_max_order_by'; isOneOf: false; inputFields: [{ name: 'type'; type: { kind: 'ENUM'; name: 'order_by'; ofType: null; }; defaultValue: null }, { name: 'url'; type: { kind: 'ENUM'; name: 'order_by'; ofType: null; }; defaultValue: null }]; };
-    'v2_rpcs_min_order_by': { kind: 'INPUT_OBJECT'; name: 'v2_rpcs_min_order_by'; isOneOf: false; inputFields: [{ name: 'type'; type: { kind: 'ENUM'; name: 'order_by'; ofType: null; }; defaultValue: null }, { name: 'url'; type: { kind: 'ENUM'; name: 'order_by'; ofType: null; }; defaultValue: null }]; };
-    'v2_rpcs_order_by': { kind: 'INPUT_OBJECT'; name: 'v2_rpcs_order_by'; isOneOf: false; inputFields: [{ name: 'type'; type: { kind: 'ENUM'; name: 'order_by'; ofType: null; }; defaultValue: null }, { name: 'url'; type: { kind: 'ENUM'; name: 'order_by'; ofType: null; }; defaultValue: null }]; };
-    'v2_rpcs_select_column': { name: 'v2_rpcs_select_column'; enumValues: 'type' | 'url'; };
-    'v2_stats_daily_count_type': { kind: 'OBJECT'; name: 'v2_stats_daily_count_type'; fields: { 'count': { name: 'count'; type: { kind: 'SCALAR'; name: 'String'; ofType: null; } }; 'day_date': { name: 'day_date'; type: { kind: 'SCALAR'; name: 'date'; ofType: null; } }; }; };
-    'v2_stats_daily_count_type_bool_exp': { kind: 'INPUT_OBJECT'; name: 'v2_stats_daily_count_type_bool_exp'; isOneOf: false; inputFields: [{ name: '_and'; type: { kind: 'LIST'; name: never; ofType: { kind: 'NON_NULL'; name: never; ofType: { kind: 'INPUT_OBJECT'; name: 'v2_stats_daily_count_type_bool_exp'; ofType: null; }; }; }; defaultValue: null }, { name: '_not'; type: { kind: 'INPUT_OBJECT'; name: 'v2_stats_daily_count_type_bool_exp'; ofType: null; }; defaultValue: null }, { name: '_or'; type: { kind: 'LIST'; name: never; ofType: { kind: 'NON_NULL'; name: never; ofType: { kind: 'INPUT_OBJECT'; name: 'v2_stats_daily_count_type_bool_exp'; ofType: null; }; }; }; defaultValue: null }, { name: 'count'; type: { kind: 'INPUT_OBJECT'; name: 'String_comparison_exp'; ofType: null; }; defaultValue: null }, { name: 'day_date'; type: { kind: 'INPUT_OBJECT'; name: 'date_comparison_exp'; ofType: null; }; defaultValue: null }]; };
-    'v2_stats_daily_count_type_order_by': { kind: 'INPUT_OBJECT'; name: 'v2_stats_daily_count_type_order_by'; isOneOf: false; inputFields: [{ name: 'count'; type: { kind: 'ENUM'; name: 'order_by'; ofType: null; }; defaultValue: null }, { name: 'day_date'; type: { kind: 'ENUM'; name: 'order_by'; ofType: null; }; defaultValue: null }]; };
-    'v2_stats_daily_count_type_select_column': { name: 'v2_stats_daily_count_type_select_column'; enumValues: 'count' | 'day_date'; };
-    'v2_stats_latency_args': { kind: 'INPUT_OBJECT'; name: 'v2_stats_latency_args'; isOneOf: false; inputFields: [{ name: 'p_destination_universal_chain_id'; type: { kind: 'SCALAR'; name: 'String'; ofType: null; }; defaultValue: null }, { name: 'p_phase'; type: { kind: 'SCALAR'; name: 'String'; ofType: null; }; defaultValue: null }, { name: 'p_source_universal_chain_id'; type: { kind: 'SCALAR'; name: 'String'; ofType: null; }; defaultValue: null }]; };
-    'v2_stats_latency_type': { kind: 'OBJECT'; name: 'v2_stats_latency_type'; fields: { 'secs_until_packet_ack': { name: 'secs_until_packet_ack'; type: { kind: 'SCALAR'; name: 'latency_percentiles_scalar'; ofType: null; } }; 'secs_until_packet_recv': { name: 'secs_until_packet_recv'; type: { kind: 'SCALAR'; name: 'latency_percentiles_scalar'; ofType: null; } }; 'secs_until_write_ack': { name: 'secs_until_write_ack'; type: { kind: 'SCALAR'; name: 'latency_percentiles_scalar'; ofType: null; } }; }; };
-    'v2_stats_latency_type_bool_exp': { kind: 'INPUT_OBJECT'; name: 'v2_stats_latency_type_bool_exp'; isOneOf: false; inputFields: [{ name: '_and'; type: { kind: 'LIST'; name: never; ofType: { kind: 'NON_NULL'; name: never; ofType: { kind: 'INPUT_OBJECT'; name: 'v2_stats_latency_type_bool_exp'; ofType: null; }; }; }; defaultValue: null }, { name: '_not'; type: { kind: 'INPUT_OBJECT'; name: 'v2_stats_latency_type_bool_exp'; ofType: null; }; defaultValue: null }, { name: '_or'; type: { kind: 'LIST'; name: never; ofType: { kind: 'NON_NULL'; name: never; ofType: { kind: 'INPUT_OBJECT'; name: 'v2_stats_latency_type_bool_exp'; ofType: null; }; }; }; defaultValue: null }, { name: 'secs_until_packet_ack'; type: { kind: 'INPUT_OBJECT'; name: 'latency_percentiles_scalar_comparison_exp'; ofType: null; }; defaultValue: null }, { name: 'secs_until_packet_recv'; type: { kind: 'INPUT_OBJECT'; name: 'latency_percentiles_scalar_comparison_exp'; ofType: null; }; defaultValue: null }, { name: 'secs_until_write_ack'; type: { kind: 'INPUT_OBJECT'; name: 'latency_percentiles_scalar_comparison_exp'; ofType: null; }; defaultValue: null }]; };
-    'v2_stats_latency_type_order_by': { kind: 'INPUT_OBJECT'; name: 'v2_stats_latency_type_order_by'; isOneOf: false; inputFields: [{ name: 'secs_until_packet_ack'; type: { kind: 'ENUM'; name: 'order_by'; ofType: null; }; defaultValue: null }, { name: 'secs_until_packet_recv'; type: { kind: 'ENUM'; name: 'order_by'; ofType: null; }; defaultValue: null }, { name: 'secs_until_write_ack'; type: { kind: 'ENUM'; name: 'order_by'; ofType: null; }; defaultValue: null }]; };
-    'v2_stats_latency_type_select_column': { name: 'v2_stats_latency_type_select_column'; enumValues: 'secs_until_packet_ack' | 'secs_until_packet_recv' | 'secs_until_write_ack'; };
-    'v2_stats_packets_chain_args': { kind: 'INPUT_OBJECT'; name: 'v2_stats_packets_chain_args'; isOneOf: false; inputFields: [{ name: 'p_days_back'; type: { kind: 'SCALAR'; name: 'Int'; ofType: null; }; defaultValue: null }, { name: 'p_destination_universal_chain_id'; type: { kind: 'SCALAR'; name: 'String'; ofType: null; }; defaultValue: null }, { name: 'p_source_universal_chain_id'; type: { kind: 'SCALAR'; name: 'String'; ofType: null; }; defaultValue: null }]; };
-    'v2_stats_packets_chain_type': { kind: 'OBJECT'; name: 'v2_stats_packets_chain_type'; fields: { 'day_date': { name: 'day_date'; type: { kind: 'SCALAR'; name: 'date'; ofType: null; } }; 'destination_universal_chain_id': { name: 'destination_universal_chain_id'; type: { kind: 'SCALAR'; name: 'String'; ofType: null; } }; 'source_universal_chain_id': { name: 'source_universal_chain_id'; type: { kind: 'SCALAR'; name: 'String'; ofType: null; } }; 'total_packets': { name: 'total_packets'; type: { kind: 'SCALAR'; name: 'String'; ofType: null; } }; }; };
-    'v2_stats_packets_chain_type_bool_exp': { kind: 'INPUT_OBJECT'; name: 'v2_stats_packets_chain_type_bool_exp'; isOneOf: false; inputFields: [{ name: '_and'; type: { kind: 'LIST'; name: never; ofType: { kind: 'NON_NULL'; name: never; ofType: { kind: 'INPUT_OBJECT'; name: 'v2_stats_packets_chain_type_bool_exp'; ofType: null; }; }; }; defaultValue: null }, { name: '_not'; type: { kind: 'INPUT_OBJECT'; name: 'v2_stats_packets_chain_type_bool_exp'; ofType: null; }; defaultValue: null }, { name: '_or'; type: { kind: 'LIST'; name: never; ofType: { kind: 'NON_NULL'; name: never; ofType: { kind: 'INPUT_OBJECT'; name: 'v2_stats_packets_chain_type_bool_exp'; ofType: null; }; }; }; defaultValue: null }, { name: 'day_date'; type: { kind: 'INPUT_OBJECT'; name: 'date_comparison_exp'; ofType: null; }; defaultValue: null }, { name: 'destination_universal_chain_id'; type: { kind: 'INPUT_OBJECT'; name: 'String_comparison_exp'; ofType: null; }; defaultValue: null }, { name: 'source_universal_chain_id'; type: { kind: 'INPUT_OBJECT'; name: 'String_comparison_exp'; ofType: null; }; defaultValue: null }, { name: 'total_packets'; type: { kind: 'INPUT_OBJECT'; name: 'String_comparison_exp'; ofType: null; }; defaultValue: null }]; };
-    'v2_stats_packets_chain_type_order_by': { kind: 'INPUT_OBJECT'; name: 'v2_stats_packets_chain_type_order_by'; isOneOf: false; inputFields: [{ name: 'day_date'; type: { kind: 'ENUM'; name: 'order_by'; ofType: null; }; defaultValue: null }, { name: 'destination_universal_chain_id'; type: { kind: 'ENUM'; name: 'order_by'; ofType: null; }; defaultValue: null }, { name: 'source_universal_chain_id'; type: { kind: 'ENUM'; name: 'order_by'; ofType: null; }; defaultValue: null }, { name: 'total_packets'; type: { kind: 'ENUM'; name: 'order_by'; ofType: null; }; defaultValue: null }]; };
-    'v2_stats_packets_chain_type_select_column': { name: 'v2_stats_packets_chain_type_select_column'; enumValues: 'day_date' | 'destination_universal_chain_id' | 'source_universal_chain_id' | 'total_packets'; };
-    'v2_stats_packets_daily_count_args': { kind: 'INPUT_OBJECT'; name: 'v2_stats_packets_daily_count_args'; isOneOf: false; inputFields: [{ name: 'p_days_back'; type: { kind: 'SCALAR'; name: 'Int'; ofType: null; }; defaultValue: null }]; };
-    'v2_stats_transfers_address_args': { kind: 'INPUT_OBJECT'; name: 'v2_stats_transfers_address_args'; isOneOf: false; inputFields: [{ name: 'p_addresses_canonical'; type: { kind: 'SCALAR'; name: 'jsonb'; ofType: null; }; defaultValue: null }, { name: 'p_days_back'; type: { kind: 'SCALAR'; name: 'Int'; ofType: null; }; defaultValue: null }, { name: 'p_destination_universal_chain_id'; type: { kind: 'SCALAR'; name: 'String'; ofType: null; }; defaultValue: null }, { name: 'p_source_universal_chain_id'; type: { kind: 'SCALAR'; name: 'String'; ofType: null; }; defaultValue: null }]; };
-    'v2_stats_transfers_address_type': { kind: 'OBJECT'; name: 'v2_stats_transfers_address_type'; fields: { 'canonical_address': { name: 'canonical_address'; type: { kind: 'SCALAR'; name: 'String'; ofType: null; } }; 'day_date': { name: 'day_date'; type: { kind: 'SCALAR'; name: 'date'; ofType: null; } }; 'destination_universal_chain_id': { name: 'destination_universal_chain_id'; type: { kind: 'SCALAR'; name: 'String'; ofType: null; } }; 'source_universal_chain_id': { name: 'source_universal_chain_id'; type: { kind: 'SCALAR'; name: 'String'; ofType: null; } }; 'transfer_count': { name: 'transfer_count'; type: { kind: 'SCALAR'; name: 'String'; ofType: null; } }; }; };
-    'v2_stats_transfers_address_type_bool_exp': { kind: 'INPUT_OBJECT'; name: 'v2_stats_transfers_address_type_bool_exp'; isOneOf: false; inputFields: [{ name: '_and'; type: { kind: 'LIST'; name: never; ofType: { kind: 'NON_NULL'; name: never; ofType: { kind: 'INPUT_OBJECT'; name: 'v2_stats_transfers_address_type_bool_exp'; ofType: null; }; }; }; defaultValue: null }, { name: '_not'; type: { kind: 'INPUT_OBJECT'; name: 'v2_stats_transfers_address_type_bool_exp'; ofType: null; }; defaultValue: null }, { name: '_or'; type: { kind: 'LIST'; name: never; ofType: { kind: 'NON_NULL'; name: never; ofType: { kind: 'INPUT_OBJECT'; name: 'v2_stats_transfers_address_type_bool_exp'; ofType: null; }; }; }; defaultValue: null }, { name: 'canonical_address'; type: { kind: 'INPUT_OBJECT'; name: 'String_comparison_exp'; ofType: null; }; defaultValue: null }, { name: 'day_date'; type: { kind: 'INPUT_OBJECT'; name: 'date_comparison_exp'; ofType: null; }; defaultValue: null }, { name: 'destination_universal_chain_id'; type: { kind: 'INPUT_OBJECT'; name: 'String_comparison_exp'; ofType: null; }; defaultValue: null }, { name: 'source_universal_chain_id'; type: { kind: 'INPUT_OBJECT'; name: 'String_comparison_exp'; ofType: null; }; defaultValue: null }, { name: 'transfer_count'; type: { kind: 'INPUT_OBJECT'; name: 'String_comparison_exp'; ofType: null; }; defaultValue: null }]; };
-    'v2_stats_transfers_address_type_order_by': { kind: 'INPUT_OBJECT'; name: 'v2_stats_transfers_address_type_order_by'; isOneOf: false; inputFields: [{ name: 'canonical_address'; type: { kind: 'ENUM'; name: 'order_by'; ofType: null; }; defaultValue: null }, { name: 'day_date'; type: { kind: 'ENUM'; name: 'order_by'; ofType: null; }; defaultValue: null }, { name: 'destination_universal_chain_id'; type: { kind: 'ENUM'; name: 'order_by'; ofType: null; }; defaultValue: null }, { name: 'source_universal_chain_id'; type: { kind: 'ENUM'; name: 'order_by'; ofType: null; }; defaultValue: null }, { name: 'transfer_count'; type: { kind: 'ENUM'; name: 'order_by'; ofType: null; }; defaultValue: null }]; };
-    'v2_stats_transfers_address_type_select_column': { name: 'v2_stats_transfers_address_type_select_column'; enumValues: 'canonical_address' | 'day_date' | 'destination_universal_chain_id' | 'source_universal_chain_id' | 'transfer_count'; };
-    'v2_stats_transfers_chain_args': { kind: 'INPUT_OBJECT'; name: 'v2_stats_transfers_chain_args'; isOneOf: false; inputFields: [{ name: 'p_days_back'; type: { kind: 'SCALAR'; name: 'Int'; ofType: null; }; defaultValue: null }, { name: 'p_destination_universal_chain_id'; type: { kind: 'SCALAR'; name: 'String'; ofType: null; }; defaultValue: null }, { name: 'p_source_universal_chain_id'; type: { kind: 'SCALAR'; name: 'String'; ofType: null; }; defaultValue: null }]; };
-    'v2_stats_transfers_chain_type': { kind: 'OBJECT'; name: 'v2_stats_transfers_chain_type'; fields: { 'day_date': { name: 'day_date'; type: { kind: 'SCALAR'; name: 'date'; ofType: null; } }; 'destination_universal_chain_id': { name: 'destination_universal_chain_id'; type: { kind: 'SCALAR'; name: 'String'; ofType: null; } }; 'source_universal_chain_id': { name: 'source_universal_chain_id'; type: { kind: 'SCALAR'; name: 'String'; ofType: null; } }; 'total_transfers': { name: 'total_transfers'; type: { kind: 'SCALAR'; name: 'String'; ofType: null; } }; }; };
-    'v2_stats_transfers_chain_type_bool_exp': { kind: 'INPUT_OBJECT'; name: 'v2_stats_transfers_chain_type_bool_exp'; isOneOf: false; inputFields: [{ name: '_and'; type: { kind: 'LIST'; name: never; ofType: { kind: 'NON_NULL'; name: never; ofType: { kind: 'INPUT_OBJECT'; name: 'v2_stats_transfers_chain_type_bool_exp'; ofType: null; }; }; }; defaultValue: null }, { name: '_not'; type: { kind: 'INPUT_OBJECT'; name: 'v2_stats_transfers_chain_type_bool_exp'; ofType: null; }; defaultValue: null }, { name: '_or'; type: { kind: 'LIST'; name: never; ofType: { kind: 'NON_NULL'; name: never; ofType: { kind: 'INPUT_OBJECT'; name: 'v2_stats_transfers_chain_type_bool_exp'; ofType: null; }; }; }; defaultValue: null }, { name: 'day_date'; type: { kind: 'INPUT_OBJECT'; name: 'date_comparison_exp'; ofType: null; }; defaultValue: null }, { name: 'destination_universal_chain_id'; type: { kind: 'INPUT_OBJECT'; name: 'String_comparison_exp'; ofType: null; }; defaultValue: null }, { name: 'source_universal_chain_id'; type: { kind: 'INPUT_OBJECT'; name: 'String_comparison_exp'; ofType: null; }; defaultValue: null }, { name: 'total_transfers'; type: { kind: 'INPUT_OBJECT'; name: 'String_comparison_exp'; ofType: null; }; defaultValue: null }]; };
-    'v2_stats_transfers_chain_type_order_by': { kind: 'INPUT_OBJECT'; name: 'v2_stats_transfers_chain_type_order_by'; isOneOf: false; inputFields: [{ name: 'day_date'; type: { kind: 'ENUM'; name: 'order_by'; ofType: null; }; defaultValue: null }, { name: 'destination_universal_chain_id'; type: { kind: 'ENUM'; name: 'order_by'; ofType: null; }; defaultValue: null }, { name: 'source_universal_chain_id'; type: { kind: 'ENUM'; name: 'order_by'; ofType: null; }; defaultValue: null }, { name: 'total_transfers'; type: { kind: 'ENUM'; name: 'order_by'; ofType: null; }; defaultValue: null }]; };
-    'v2_stats_transfers_chain_type_select_column': { name: 'v2_stats_transfers_chain_type_select_column'; enumValues: 'day_date' | 'destination_universal_chain_id' | 'source_universal_chain_id' | 'total_transfers'; };
-    'v2_stats_transfers_daily_count_args': { kind: 'INPUT_OBJECT'; name: 'v2_stats_transfers_daily_count_args'; isOneOf: false; inputFields: [{ name: 'p_days_back'; type: { kind: 'SCALAR'; name: 'Int'; ofType: null; }; defaultValue: null }]; };
-    'v2_stats_type': { kind: 'OBJECT'; name: 'v2_stats_type'; fields: { 'name': { name: 'name'; type: { kind: 'SCALAR'; name: 'String'; ofType: null; } }; 'value': { name: 'value'; type: { kind: 'SCALAR'; name: 'String'; ofType: null; } }; }; };
-    'v2_stats_type_bool_exp': { kind: 'INPUT_OBJECT'; name: 'v2_stats_type_bool_exp'; isOneOf: false; inputFields: [{ name: '_and'; type: { kind: 'LIST'; name: never; ofType: { kind: 'NON_NULL'; name: never; ofType: { kind: 'INPUT_OBJECT'; name: 'v2_stats_type_bool_exp'; ofType: null; }; }; }; defaultValue: null }, { name: '_not'; type: { kind: 'INPUT_OBJECT'; name: 'v2_stats_type_bool_exp'; ofType: null; }; defaultValue: null }, { name: '_or'; type: { kind: 'LIST'; name: never; ofType: { kind: 'NON_NULL'; name: never; ofType: { kind: 'INPUT_OBJECT'; name: 'v2_stats_type_bool_exp'; ofType: null; }; }; }; defaultValue: null }, { name: 'name'; type: { kind: 'INPUT_OBJECT'; name: 'String_comparison_exp'; ofType: null; }; defaultValue: null }, { name: 'value'; type: { kind: 'INPUT_OBJECT'; name: 'String_comparison_exp'; ofType: null; }; defaultValue: null }]; };
-    'v2_stats_type_order_by': { kind: 'INPUT_OBJECT'; name: 'v2_stats_type_order_by'; isOneOf: false; inputFields: [{ name: 'name'; type: { kind: 'ENUM'; name: 'order_by'; ofType: null; }; defaultValue: null }, { name: 'value'; type: { kind: 'ENUM'; name: 'order_by'; ofType: null; }; defaultValue: null }]; };
-    'v2_stats_type_select_column': { name: 'v2_stats_type_select_column'; enumValues: 'name' | 'value'; };
-    'v2_token_meta': { kind: 'OBJECT'; name: 'v2_token_meta'; fields: { 'bucket': { name: 'bucket'; type: { kind: 'OBJECT'; name: 'v2_token_meta_bucket'; ofType: null; } }; 'chain': { name: 'chain'; type: { kind: 'OBJECT'; name: 'v2_chains_view'; ofType: null; } }; 'denom': { name: 'denom'; type: { kind: 'SCALAR'; name: 'String'; ofType: null; } }; 'rank': { name: 'rank'; type: { kind: 'SCALAR'; name: 'Int'; ofType: null; } }; 'representations': { name: 'representations'; type: { kind: 'NON_NULL'; name: never; ofType: { kind: 'LIST'; name: never; ofType: { kind: 'NON_NULL'; name: never; ofType: { kind: 'OBJECT'; name: 'v2_token_meta_representations'; ofType: null; }; }; }; } }; 'wrapping': { name: 'wrapping'; type: { kind: 'NON_NULL'; name: never; ofType: { kind: 'LIST'; name: never; ofType: { kind: 'NON_NULL'; name: never; ofType: { kind: 'OBJECT'; name: 'v2_token_meta_wrapping'; ofType: null; }; }; }; } }; }; };
-    'v2_token_meta_bool_exp': { kind: 'INPUT_OBJECT'; name: 'v2_token_meta_bool_exp'; isOneOf: false; inputFields: [{ name: '_and'; type: { kind: 'LIST'; name: never; ofType: { kind: 'NON_NULL'; name: never; ofType: { kind: 'INPUT_OBJECT'; name: 'v2_token_meta_bool_exp'; ofType: null; }; }; }; defaultValue: null }, { name: '_not'; type: { kind: 'INPUT_OBJECT'; name: 'v2_token_meta_bool_exp'; ofType: null; }; defaultValue: null }, { name: '_or'; type: { kind: 'LIST'; name: never; ofType: { kind: 'NON_NULL'; name: never; ofType: { kind: 'INPUT_OBJECT'; name: 'v2_token_meta_bool_exp'; ofType: null; }; }; }; defaultValue: null }, { name: 'bucket'; type: { kind: 'INPUT_OBJECT'; name: 'v2_token_meta_bucket_bool_exp'; ofType: null; }; defaultValue: null }, { name: 'chain'; type: { kind: 'INPUT_OBJECT'; name: 'v2_chains_view_bool_exp'; ofType: null; }; defaultValue: null }, { name: 'denom'; type: { kind: 'INPUT_OBJECT'; name: 'String_comparison_exp'; ofType: null; }; defaultValue: null }, { name: 'rank'; type: { kind: 'INPUT_OBJECT'; name: 'Int_comparison_exp'; ofType: null; }; defaultValue: null }, { name: 'representations'; type: { kind: 'INPUT_OBJECT'; name: 'v2_token_meta_representations_bool_exp'; ofType: null; }; defaultValue: null }, { name: 'wrapping'; type: { kind: 'INPUT_OBJECT'; name: 'v2_token_meta_wrapping_bool_exp'; ofType: null; }; defaultValue: null }]; };
-    'v2_token_meta_bucket': { kind: 'OBJECT'; name: 'v2_token_meta_bucket'; fields: { 'capacity': { name: 'capacity'; type: { kind: 'SCALAR'; name: 'String'; ofType: null; } }; 'refill_rate': { name: 'refill_rate'; type: { kind: 'SCALAR'; name: 'String'; ofType: null; } }; }; };
-    'v2_token_meta_bucket_bool_exp': { kind: 'INPUT_OBJECT'; name: 'v2_token_meta_bucket_bool_exp'; isOneOf: false; inputFields: [{ name: '_and'; type: { kind: 'LIST'; name: never; ofType: { kind: 'NON_NULL'; name: never; ofType: { kind: 'INPUT_OBJECT'; name: 'v2_token_meta_bucket_bool_exp'; ofType: null; }; }; }; defaultValue: null }, { name: '_not'; type: { kind: 'INPUT_OBJECT'; name: 'v2_token_meta_bucket_bool_exp'; ofType: null; }; defaultValue: null }, { name: '_or'; type: { kind: 'LIST'; name: never; ofType: { kind: 'NON_NULL'; name: never; ofType: { kind: 'INPUT_OBJECT'; name: 'v2_token_meta_bucket_bool_exp'; ofType: null; }; }; }; defaultValue: null }, { name: 'capacity'; type: { kind: 'INPUT_OBJECT'; name: 'String_comparison_exp'; ofType: null; }; defaultValue: null }, { name: 'refill_rate'; type: { kind: 'INPUT_OBJECT'; name: 'String_comparison_exp'; ofType: null; }; defaultValue: null }]; };
-    'v2_token_meta_bucket_order_by': { kind: 'INPUT_OBJECT'; name: 'v2_token_meta_bucket_order_by'; isOneOf: false; inputFields: [{ name: 'capacity'; type: { kind: 'ENUM'; name: 'order_by'; ofType: null; }; defaultValue: null }, { name: 'refill_rate'; type: { kind: 'ENUM'; name: 'order_by'; ofType: null; }; defaultValue: null }]; };
-    'v2_token_meta_order_by': { kind: 'INPUT_OBJECT'; name: 'v2_token_meta_order_by'; isOneOf: false; inputFields: [{ name: 'bucket'; type: { kind: 'INPUT_OBJECT'; name: 'v2_token_meta_bucket_order_by'; ofType: null; }; defaultValue: null }, { name: 'chain'; type: { kind: 'INPUT_OBJECT'; name: 'v2_chains_view_order_by'; ofType: null; }; defaultValue: null }, { name: 'denom'; type: { kind: 'ENUM'; name: 'order_by'; ofType: null; }; defaultValue: null }, { name: 'rank'; type: { kind: 'ENUM'; name: 'order_by'; ofType: null; }; defaultValue: null }, { name: 'representations_aggregate'; type: { kind: 'INPUT_OBJECT'; name: 'v2_token_meta_representations_aggregate_order_by'; ofType: null; }; defaultValue: null }, { name: 'wrapping_aggregate'; type: { kind: 'INPUT_OBJECT'; name: 'v2_token_meta_wrapping_aggregate_order_by'; ofType: null; }; defaultValue: null }]; };
-    'v2_token_meta_representation_sources': { kind: 'OBJECT'; name: 'v2_token_meta_representation_sources'; fields: { 'chain': { name: 'chain'; type: { kind: 'OBJECT'; name: 'v2_chains_view'; ofType: null; } }; 'decimals': { name: 'decimals'; type: { kind: 'SCALAR'; name: 'Int'; ofType: null; } }; 'denom': { name: 'denom'; type: { kind: 'SCALAR'; name: 'String'; ofType: null; } }; 'name': { name: 'name'; type: { kind: 'SCALAR'; name: 'String'; ofType: null; } }; 'source': { name: 'source'; type: { kind: 'OBJECT'; name: 'v2_token_meta_sources'; ofType: null; } }; 'symbol': { name: 'symbol'; type: { kind: 'SCALAR'; name: 'String'; ofType: null; } }; 'update_timestamp': { name: 'update_timestamp'; type: { kind: 'SCALAR'; name: 'timestamptz'; ofType: null; } }; 'wrapping': { name: 'wrapping'; type: { kind: 'NON_NULL'; name: never; ofType: { kind: 'LIST'; name: never; ofType: { kind: 'NON_NULL'; name: never; ofType: { kind: 'OBJECT'; name: 'v2_token_meta_representation_sources'; ofType: null; }; }; }; } }; }; };
-    'v2_token_meta_representation_sources_aggregate_order_by': { kind: 'INPUT_OBJECT'; name: 'v2_token_meta_representation_sources_aggregate_order_by'; isOneOf: false; inputFields: [{ name: 'avg'; type: { kind: 'INPUT_OBJECT'; name: 'v2_token_meta_representation_sources_avg_order_by'; ofType: null; }; defaultValue: null }, { name: 'count'; type: { kind: 'ENUM'; name: 'order_by'; ofType: null; }; defaultValue: null }, { name: 'max'; type: { kind: 'INPUT_OBJECT'; name: 'v2_token_meta_representation_sources_max_order_by'; ofType: null; }; defaultValue: null }, { name: 'min'; type: { kind: 'INPUT_OBJECT'; name: 'v2_token_meta_representation_sources_min_order_by'; ofType: null; }; defaultValue: null }, { name: 'stddev'; type: { kind: 'INPUT_OBJECT'; name: 'v2_token_meta_representation_sources_stddev_order_by'; ofType: null; }; defaultValue: null }, { name: 'stddev_pop'; type: { kind: 'INPUT_OBJECT'; name: 'v2_token_meta_representation_sources_stddev_pop_order_by'; ofType: null; }; defaultValue: null }, { name: 'stddev_samp'; type: { kind: 'INPUT_OBJECT'; name: 'v2_token_meta_representation_sources_stddev_samp_order_by'; ofType: null; }; defaultValue: null }, { name: 'sum'; type: { kind: 'INPUT_OBJECT'; name: 'v2_token_meta_representation_sources_sum_order_by'; ofType: null; }; defaultValue: null }, { name: 'var_pop'; type: { kind: 'INPUT_OBJECT'; name: 'v2_token_meta_representation_sources_var_pop_order_by'; ofType: null; }; defaultValue: null }, { name: 'var_samp'; type: { kind: 'INPUT_OBJECT'; name: 'v2_token_meta_representation_sources_var_samp_order_by'; ofType: null; }; defaultValue: null }, { name: 'variance'; type: { kind: 'INPUT_OBJECT'; name: 'v2_token_meta_representation_sources_variance_order_by'; ofType: null; }; defaultValue: null }]; };
-    'v2_token_meta_representation_sources_avg_order_by': { kind: 'INPUT_OBJECT'; name: 'v2_token_meta_representation_sources_avg_order_by'; isOneOf: false; inputFields: [{ name: 'decimals'; type: { kind: 'ENUM'; name: 'order_by'; ofType: null; }; defaultValue: null }]; };
-    'v2_token_meta_representation_sources_bool_exp': { kind: 'INPUT_OBJECT'; name: 'v2_token_meta_representation_sources_bool_exp'; isOneOf: false; inputFields: [{ name: '_and'; type: { kind: 'LIST'; name: never; ofType: { kind: 'NON_NULL'; name: never; ofType: { kind: 'INPUT_OBJECT'; name: 'v2_token_meta_representation_sources_bool_exp'; ofType: null; }; }; }; defaultValue: null }, { name: '_not'; type: { kind: 'INPUT_OBJECT'; name: 'v2_token_meta_representation_sources_bool_exp'; ofType: null; }; defaultValue: null }, { name: '_or'; type: { kind: 'LIST'; name: never; ofType: { kind: 'NON_NULL'; name: never; ofType: { kind: 'INPUT_OBJECT'; name: 'v2_token_meta_representation_sources_bool_exp'; ofType: null; }; }; }; defaultValue: null }, { name: 'chain'; type: { kind: 'INPUT_OBJECT'; name: 'v2_chains_view_bool_exp'; ofType: null; }; defaultValue: null }, { name: 'decimals'; type: { kind: 'INPUT_OBJECT'; name: 'Int_comparison_exp'; ofType: null; }; defaultValue: null }, { name: 'denom'; type: { kind: 'INPUT_OBJECT'; name: 'String_comparison_exp'; ofType: null; }; defaultValue: null }, { name: 'name'; type: { kind: 'INPUT_OBJECT'; name: 'String_comparison_exp'; ofType: null; }; defaultValue: null }, { name: 'source'; type: { kind: 'INPUT_OBJECT'; name: 'v2_token_meta_sources_bool_exp'; ofType: null; }; defaultValue: null }, { name: 'symbol'; type: { kind: 'INPUT_OBJECT'; name: 'String_comparison_exp'; ofType: null; }; defaultValue: null }, { name: 'update_timestamp'; type: { kind: 'INPUT_OBJECT'; name: 'timestamptz_comparison_exp'; ofType: null; }; defaultValue: null }, { name: 'wrapping'; type: { kind: 'INPUT_OBJECT'; name: 'v2_token_meta_representation_sources_bool_exp'; ofType: null; }; defaultValue: null }]; };
-    'v2_token_meta_representation_sources_max_order_by': { kind: 'INPUT_OBJECT'; name: 'v2_token_meta_representation_sources_max_order_by'; isOneOf: false; inputFields: [{ name: 'decimals'; type: { kind: 'ENUM'; name: 'order_by'; ofType: null; }; defaultValue: null }, { name: 'denom'; type: { kind: 'ENUM'; name: 'order_by'; ofType: null; }; defaultValue: null }, { name: 'name'; type: { kind: 'ENUM'; name: 'order_by'; ofType: null; }; defaultValue: null }, { name: 'symbol'; type: { kind: 'ENUM'; name: 'order_by'; ofType: null; }; defaultValue: null }, { name: 'update_timestamp'; type: { kind: 'ENUM'; name: 'order_by'; ofType: null; }; defaultValue: null }]; };
-    'v2_token_meta_representation_sources_min_order_by': { kind: 'INPUT_OBJECT'; name: 'v2_token_meta_representation_sources_min_order_by'; isOneOf: false; inputFields: [{ name: 'decimals'; type: { kind: 'ENUM'; name: 'order_by'; ofType: null; }; defaultValue: null }, { name: 'denom'; type: { kind: 'ENUM'; name: 'order_by'; ofType: null; }; defaultValue: null }, { name: 'name'; type: { kind: 'ENUM'; name: 'order_by'; ofType: null; }; defaultValue: null }, { name: 'symbol'; type: { kind: 'ENUM'; name: 'order_by'; ofType: null; }; defaultValue: null }, { name: 'update_timestamp'; type: { kind: 'ENUM'; name: 'order_by'; ofType: null; }; defaultValue: null }]; };
-    'v2_token_meta_representation_sources_order_by': { kind: 'INPUT_OBJECT'; name: 'v2_token_meta_representation_sources_order_by'; isOneOf: false; inputFields: [{ name: 'chain'; type: { kind: 'INPUT_OBJECT'; name: 'v2_chains_view_order_by'; ofType: null; }; defaultValue: null }, { name: 'decimals'; type: { kind: 'ENUM'; name: 'order_by'; ofType: null; }; defaultValue: null }, { name: 'denom'; type: { kind: 'ENUM'; name: 'order_by'; ofType: null; }; defaultValue: null }, { name: 'name'; type: { kind: 'ENUM'; name: 'order_by'; ofType: null; }; defaultValue: null }, { name: 'source'; type: { kind: 'INPUT_OBJECT'; name: 'v2_token_meta_sources_order_by'; ofType: null; }; defaultValue: null }, { name: 'symbol'; type: { kind: 'ENUM'; name: 'order_by'; ofType: null; }; defaultValue: null }, { name: 'update_timestamp'; type: { kind: 'ENUM'; name: 'order_by'; ofType: null; }; defaultValue: null }, { name: 'wrapping_aggregate'; type: { kind: 'INPUT_OBJECT'; name: 'v2_token_meta_representation_sources_aggregate_order_by'; ofType: null; }; defaultValue: null }]; };
-    'v2_token_meta_representation_sources_select_column': { name: 'v2_token_meta_representation_sources_select_column'; enumValues: 'decimals' | 'denom' | 'name' | 'symbol' | 'update_timestamp'; };
-    'v2_token_meta_representation_sources_stddev_order_by': { kind: 'INPUT_OBJECT'; name: 'v2_token_meta_representation_sources_stddev_order_by'; isOneOf: false; inputFields: [{ name: 'decimals'; type: { kind: 'ENUM'; name: 'order_by'; ofType: null; }; defaultValue: null }]; };
-    'v2_token_meta_representation_sources_stddev_pop_order_by': { kind: 'INPUT_OBJECT'; name: 'v2_token_meta_representation_sources_stddev_pop_order_by'; isOneOf: false; inputFields: [{ name: 'decimals'; type: { kind: 'ENUM'; name: 'order_by'; ofType: null; }; defaultValue: null }]; };
-    'v2_token_meta_representation_sources_stddev_samp_order_by': { kind: 'INPUT_OBJECT'; name: 'v2_token_meta_representation_sources_stddev_samp_order_by'; isOneOf: false; inputFields: [{ name: 'decimals'; type: { kind: 'ENUM'; name: 'order_by'; ofType: null; }; defaultValue: null }]; };
-    'v2_token_meta_representation_sources_sum_order_by': { kind: 'INPUT_OBJECT'; name: 'v2_token_meta_representation_sources_sum_order_by'; isOneOf: false; inputFields: [{ name: 'decimals'; type: { kind: 'ENUM'; name: 'order_by'; ofType: null; }; defaultValue: null }]; };
-    'v2_token_meta_representation_sources_var_pop_order_by': { kind: 'INPUT_OBJECT'; name: 'v2_token_meta_representation_sources_var_pop_order_by'; isOneOf: false; inputFields: [{ name: 'decimals'; type: { kind: 'ENUM'; name: 'order_by'; ofType: null; }; defaultValue: null }]; };
-    'v2_token_meta_representation_sources_var_samp_order_by': { kind: 'INPUT_OBJECT'; name: 'v2_token_meta_representation_sources_var_samp_order_by'; isOneOf: false; inputFields: [{ name: 'decimals'; type: { kind: 'ENUM'; name: 'order_by'; ofType: null; }; defaultValue: null }]; };
-    'v2_token_meta_representation_sources_variance_order_by': { kind: 'INPUT_OBJECT'; name: 'v2_token_meta_representation_sources_variance_order_by'; isOneOf: false; inputFields: [{ name: 'decimals'; type: { kind: 'ENUM'; name: 'order_by'; ofType: null; }; defaultValue: null }]; };
-    'v2_token_meta_representations': { kind: 'OBJECT'; name: 'v2_token_meta_representations'; fields: { 'chain': { name: 'chain'; type: { kind: 'OBJECT'; name: 'v2_chains_view'; ofType: null; } }; 'decimals': { name: 'decimals'; type: { kind: 'SCALAR'; name: 'Int'; ofType: null; } }; 'logo_uri': { name: 'logo_uri'; type: { kind: 'SCALAR'; name: 'String'; ofType: null; } }; 'name': { name: 'name'; type: { kind: 'SCALAR'; name: 'String'; ofType: null; } }; 'sources': { name: 'sources'; type: { kind: 'NON_NULL'; name: never; ofType: { kind: 'LIST'; name: never; ofType: { kind: 'NON_NULL'; name: never; ofType: { kind: 'OBJECT'; name: 'v2_token_meta_representation_sources'; ofType: null; }; }; }; } }; 'symbol': { name: 'symbol'; type: { kind: 'SCALAR'; name: 'String'; ofType: null; } }; }; };
-    'v2_token_meta_representations_aggregate_order_by': { kind: 'INPUT_OBJECT'; name: 'v2_token_meta_representations_aggregate_order_by'; isOneOf: false; inputFields: [{ name: 'avg'; type: { kind: 'INPUT_OBJECT'; name: 'v2_token_meta_representations_avg_order_by'; ofType: null; }; defaultValue: null }, { name: 'count'; type: { kind: 'ENUM'; name: 'order_by'; ofType: null; }; defaultValue: null }, { name: 'max'; type: { kind: 'INPUT_OBJECT'; name: 'v2_token_meta_representations_max_order_by'; ofType: null; }; defaultValue: null }, { name: 'min'; type: { kind: 'INPUT_OBJECT'; name: 'v2_token_meta_representations_min_order_by'; ofType: null; }; defaultValue: null }, { name: 'stddev'; type: { kind: 'INPUT_OBJECT'; name: 'v2_token_meta_representations_stddev_order_by'; ofType: null; }; defaultValue: null }, { name: 'stddev_pop'; type: { kind: 'INPUT_OBJECT'; name: 'v2_token_meta_representations_stddev_pop_order_by'; ofType: null; }; defaultValue: null }, { name: 'stddev_samp'; type: { kind: 'INPUT_OBJECT'; name: 'v2_token_meta_representations_stddev_samp_order_by'; ofType: null; }; defaultValue: null }, { name: 'sum'; type: { kind: 'INPUT_OBJECT'; name: 'v2_token_meta_representations_sum_order_by'; ofType: null; }; defaultValue: null }, { name: 'var_pop'; type: { kind: 'INPUT_OBJECT'; name: 'v2_token_meta_representations_var_pop_order_by'; ofType: null; }; defaultValue: null }, { name: 'var_samp'; type: { kind: 'INPUT_OBJECT'; name: 'v2_token_meta_representations_var_samp_order_by'; ofType: null; }; defaultValue: null }, { name: 'variance'; type: { kind: 'INPUT_OBJECT'; name: 'v2_token_meta_representations_variance_order_by'; ofType: null; }; defaultValue: null }]; };
-    'v2_token_meta_representations_avg_order_by': { kind: 'INPUT_OBJECT'; name: 'v2_token_meta_representations_avg_order_by'; isOneOf: false; inputFields: [{ name: 'decimals'; type: { kind: 'ENUM'; name: 'order_by'; ofType: null; }; defaultValue: null }]; };
-    'v2_token_meta_representations_bool_exp': { kind: 'INPUT_OBJECT'; name: 'v2_token_meta_representations_bool_exp'; isOneOf: false; inputFields: [{ name: '_and'; type: { kind: 'LIST'; name: never; ofType: { kind: 'NON_NULL'; name: never; ofType: { kind: 'INPUT_OBJECT'; name: 'v2_token_meta_representations_bool_exp'; ofType: null; }; }; }; defaultValue: null }, { name: '_not'; type: { kind: 'INPUT_OBJECT'; name: 'v2_token_meta_representations_bool_exp'; ofType: null; }; defaultValue: null }, { name: '_or'; type: { kind: 'LIST'; name: never; ofType: { kind: 'NON_NULL'; name: never; ofType: { kind: 'INPUT_OBJECT'; name: 'v2_token_meta_representations_bool_exp'; ofType: null; }; }; }; defaultValue: null }, { name: 'chain'; type: { kind: 'INPUT_OBJECT'; name: 'v2_chains_view_bool_exp'; ofType: null; }; defaultValue: null }, { name: 'decimals'; type: { kind: 'INPUT_OBJECT'; name: 'Int_comparison_exp'; ofType: null; }; defaultValue: null }, { name: 'logo_uri'; type: { kind: 'INPUT_OBJECT'; name: 'String_comparison_exp'; ofType: null; }; defaultValue: null }, { name: 'name'; type: { kind: 'INPUT_OBJECT'; name: 'String_comparison_exp'; ofType: null; }; defaultValue: null }, { name: 'sources'; type: { kind: 'INPUT_OBJECT'; name: 'v2_token_meta_representation_sources_bool_exp'; ofType: null; }; defaultValue: null }, { name: 'symbol'; type: { kind: 'INPUT_OBJECT'; name: 'String_comparison_exp'; ofType: null; }; defaultValue: null }]; };
-    'v2_token_meta_representations_max_order_by': { kind: 'INPUT_OBJECT'; name: 'v2_token_meta_representations_max_order_by'; isOneOf: false; inputFields: [{ name: 'decimals'; type: { kind: 'ENUM'; name: 'order_by'; ofType: null; }; defaultValue: null }, { name: 'logo_uri'; type: { kind: 'ENUM'; name: 'order_by'; ofType: null; }; defaultValue: null }, { name: 'name'; type: { kind: 'ENUM'; name: 'order_by'; ofType: null; }; defaultValue: null }, { name: 'symbol'; type: { kind: 'ENUM'; name: 'order_by'; ofType: null; }; defaultValue: null }]; };
-    'v2_token_meta_representations_min_order_by': { kind: 'INPUT_OBJECT'; name: 'v2_token_meta_representations_min_order_by'; isOneOf: false; inputFields: [{ name: 'decimals'; type: { kind: 'ENUM'; name: 'order_by'; ofType: null; }; defaultValue: null }, { name: 'logo_uri'; type: { kind: 'ENUM'; name: 'order_by'; ofType: null; }; defaultValue: null }, { name: 'name'; type: { kind: 'ENUM'; name: 'order_by'; ofType: null; }; defaultValue: null }, { name: 'symbol'; type: { kind: 'ENUM'; name: 'order_by'; ofType: null; }; defaultValue: null }]; };
-    'v2_token_meta_representations_order_by': { kind: 'INPUT_OBJECT'; name: 'v2_token_meta_representations_order_by'; isOneOf: false; inputFields: [{ name: 'chain'; type: { kind: 'INPUT_OBJECT'; name: 'v2_chains_view_order_by'; ofType: null; }; defaultValue: null }, { name: 'decimals'; type: { kind: 'ENUM'; name: 'order_by'; ofType: null; }; defaultValue: null }, { name: 'logo_uri'; type: { kind: 'ENUM'; name: 'order_by'; ofType: null; }; defaultValue: null }, { name: 'name'; type: { kind: 'ENUM'; name: 'order_by'; ofType: null; }; defaultValue: null }, { name: 'sources_aggregate'; type: { kind: 'INPUT_OBJECT'; name: 'v2_token_meta_representation_sources_aggregate_order_by'; ofType: null; }; defaultValue: null }, { name: 'symbol'; type: { kind: 'ENUM'; name: 'order_by'; ofType: null; }; defaultValue: null }]; };
-    'v2_token_meta_representations_select_column': { name: 'v2_token_meta_representations_select_column'; enumValues: 'decimals' | 'logo_uri' | 'name' | 'symbol'; };
-    'v2_token_meta_representations_stddev_order_by': { kind: 'INPUT_OBJECT'; name: 'v2_token_meta_representations_stddev_order_by'; isOneOf: false; inputFields: [{ name: 'decimals'; type: { kind: 'ENUM'; name: 'order_by'; ofType: null; }; defaultValue: null }]; };
-    'v2_token_meta_representations_stddev_pop_order_by': { kind: 'INPUT_OBJECT'; name: 'v2_token_meta_representations_stddev_pop_order_by'; isOneOf: false; inputFields: [{ name: 'decimals'; type: { kind: 'ENUM'; name: 'order_by'; ofType: null; }; defaultValue: null }]; };
-    'v2_token_meta_representations_stddev_samp_order_by': { kind: 'INPUT_OBJECT'; name: 'v2_token_meta_representations_stddev_samp_order_by'; isOneOf: false; inputFields: [{ name: 'decimals'; type: { kind: 'ENUM'; name: 'order_by'; ofType: null; }; defaultValue: null }]; };
-    'v2_token_meta_representations_sum_order_by': { kind: 'INPUT_OBJECT'; name: 'v2_token_meta_representations_sum_order_by'; isOneOf: false; inputFields: [{ name: 'decimals'; type: { kind: 'ENUM'; name: 'order_by'; ofType: null; }; defaultValue: null }]; };
-    'v2_token_meta_representations_var_pop_order_by': { kind: 'INPUT_OBJECT'; name: 'v2_token_meta_representations_var_pop_order_by'; isOneOf: false; inputFields: [{ name: 'decimals'; type: { kind: 'ENUM'; name: 'order_by'; ofType: null; }; defaultValue: null }]; };
-    'v2_token_meta_representations_var_samp_order_by': { kind: 'INPUT_OBJECT'; name: 'v2_token_meta_representations_var_samp_order_by'; isOneOf: false; inputFields: [{ name: 'decimals'; type: { kind: 'ENUM'; name: 'order_by'; ofType: null; }; defaultValue: null }]; };
-    'v2_token_meta_representations_variance_order_by': { kind: 'INPUT_OBJECT'; name: 'v2_token_meta_representations_variance_order_by'; isOneOf: false; inputFields: [{ name: 'decimals'; type: { kind: 'ENUM'; name: 'order_by'; ofType: null; }; defaultValue: null }]; };
-    'v2_token_meta_select_column': { name: 'v2_token_meta_select_column'; enumValues: 'denom' | 'rank'; };
-    'v2_token_meta_sources': { kind: 'OBJECT'; name: 'v2_token_meta_sources'; fields: { 'logo_uri': { name: 'logo_uri'; type: { kind: 'SCALAR'; name: 'String'; ofType: null; } }; 'name': { name: 'name'; type: { kind: 'SCALAR'; name: 'String'; ofType: null; } }; 'source_uri': { name: 'source_uri'; type: { kind: 'SCALAR'; name: 'String'; ofType: null; } }; }; };
-    'v2_token_meta_sources_bool_exp': { kind: 'INPUT_OBJECT'; name: 'v2_token_meta_sources_bool_exp'; isOneOf: false; inputFields: [{ name: '_and'; type: { kind: 'LIST'; name: never; ofType: { kind: 'NON_NULL'; name: never; ofType: { kind: 'INPUT_OBJECT'; name: 'v2_token_meta_sources_bool_exp'; ofType: null; }; }; }; defaultValue: null }, { name: '_not'; type: { kind: 'INPUT_OBJECT'; name: 'v2_token_meta_sources_bool_exp'; ofType: null; }; defaultValue: null }, { name: '_or'; type: { kind: 'LIST'; name: never; ofType: { kind: 'NON_NULL'; name: never; ofType: { kind: 'INPUT_OBJECT'; name: 'v2_token_meta_sources_bool_exp'; ofType: null; }; }; }; defaultValue: null }, { name: 'logo_uri'; type: { kind: 'INPUT_OBJECT'; name: 'String_comparison_exp'; ofType: null; }; defaultValue: null }, { name: 'name'; type: { kind: 'INPUT_OBJECT'; name: 'String_comparison_exp'; ofType: null; }; defaultValue: null }, { name: 'source_uri'; type: { kind: 'INPUT_OBJECT'; name: 'String_comparison_exp'; ofType: null; }; defaultValue: null }]; };
-    'v2_token_meta_sources_order_by': { kind: 'INPUT_OBJECT'; name: 'v2_token_meta_sources_order_by'; isOneOf: false; inputFields: [{ name: 'logo_uri'; type: { kind: 'ENUM'; name: 'order_by'; ofType: null; }; defaultValue: null }, { name: 'name'; type: { kind: 'ENUM'; name: 'order_by'; ofType: null; }; defaultValue: null }, { name: 'source_uri'; type: { kind: 'ENUM'; name: 'order_by'; ofType: null; }; defaultValue: null }]; };
-    'v2_token_meta_wrapping': { kind: 'OBJECT'; name: 'v2_token_meta_wrapping'; fields: { 'destination_channel_id': { name: 'destination_channel_id'; type: { kind: 'SCALAR'; name: 'Int'; ofType: null; } }; 'unwrapped_chain': { name: 'unwrapped_chain'; type: { kind: 'OBJECT'; name: 'v2_chains_view'; ofType: null; } }; 'unwrapped_denom': { name: 'unwrapped_denom'; type: { kind: 'SCALAR'; name: 'String'; ofType: null; } }; 'wrapped_chain': { name: 'wrapped_chain'; type: { kind: 'OBJECT'; name: 'v2_chains_view'; ofType: null; } }; 'wrapper': { name: 'wrapper'; type: { kind: 'SCALAR'; name: 'String'; ofType: null; } }; }; };
-    'v2_token_meta_wrapping_aggregate_order_by': { kind: 'INPUT_OBJECT'; name: 'v2_token_meta_wrapping_aggregate_order_by'; isOneOf: false; inputFields: [{ name: 'avg'; type: { kind: 'INPUT_OBJECT'; name: 'v2_token_meta_wrapping_avg_order_by'; ofType: null; }; defaultValue: null }, { name: 'count'; type: { kind: 'ENUM'; name: 'order_by'; ofType: null; }; defaultValue: null }, { name: 'max'; type: { kind: 'INPUT_OBJECT'; name: 'v2_token_meta_wrapping_max_order_by'; ofType: null; }; defaultValue: null }, { name: 'min'; type: { kind: 'INPUT_OBJECT'; name: 'v2_token_meta_wrapping_min_order_by'; ofType: null; }; defaultValue: null }, { name: 'stddev'; type: { kind: 'INPUT_OBJECT'; name: 'v2_token_meta_wrapping_stddev_order_by'; ofType: null; }; defaultValue: null }, { name: 'stddev_pop'; type: { kind: 'INPUT_OBJECT'; name: 'v2_token_meta_wrapping_stddev_pop_order_by'; ofType: null; }; defaultValue: null }, { name: 'stddev_samp'; type: { kind: 'INPUT_OBJECT'; name: 'v2_token_meta_wrapping_stddev_samp_order_by'; ofType: null; }; defaultValue: null }, { name: 'sum'; type: { kind: 'INPUT_OBJECT'; name: 'v2_token_meta_wrapping_sum_order_by'; ofType: null; }; defaultValue: null }, { name: 'var_pop'; type: { kind: 'INPUT_OBJECT'; name: 'v2_token_meta_wrapping_var_pop_order_by'; ofType: null; }; defaultValue: null }, { name: 'var_samp'; type: { kind: 'INPUT_OBJECT'; name: 'v2_token_meta_wrapping_var_samp_order_by'; ofType: null; }; defaultValue: null }, { name: 'variance'; type: { kind: 'INPUT_OBJECT'; name: 'v2_token_meta_wrapping_variance_order_by'; ofType: null; }; defaultValue: null }]; };
-    'v2_token_meta_wrapping_avg_order_by': { kind: 'INPUT_OBJECT'; name: 'v2_token_meta_wrapping_avg_order_by'; isOneOf: false; inputFields: [{ name: 'destination_channel_id'; type: { kind: 'ENUM'; name: 'order_by'; ofType: null; }; defaultValue: null }]; };
-    'v2_token_meta_wrapping_bool_exp': { kind: 'INPUT_OBJECT'; name: 'v2_token_meta_wrapping_bool_exp'; isOneOf: false; inputFields: [{ name: '_and'; type: { kind: 'LIST'; name: never; ofType: { kind: 'NON_NULL'; name: never; ofType: { kind: 'INPUT_OBJECT'; name: 'v2_token_meta_wrapping_bool_exp'; ofType: null; }; }; }; defaultValue: null }, { name: '_not'; type: { kind: 'INPUT_OBJECT'; name: 'v2_token_meta_wrapping_bool_exp'; ofType: null; }; defaultValue: null }, { name: '_or'; type: { kind: 'LIST'; name: never; ofType: { kind: 'NON_NULL'; name: never; ofType: { kind: 'INPUT_OBJECT'; name: 'v2_token_meta_wrapping_bool_exp'; ofType: null; }; }; }; defaultValue: null }, { name: 'destination_channel_id'; type: { kind: 'INPUT_OBJECT'; name: 'Int_comparison_exp'; ofType: null; }; defaultValue: null }, { name: 'unwrapped_chain'; type: { kind: 'INPUT_OBJECT'; name: 'v2_chains_view_bool_exp'; ofType: null; }; defaultValue: null }, { name: 'unwrapped_denom'; type: { kind: 'INPUT_OBJECT'; name: 'String_comparison_exp'; ofType: null; }; defaultValue: null }, { name: 'wrapped_chain'; type: { kind: 'INPUT_OBJECT'; name: 'v2_chains_view_bool_exp'; ofType: null; }; defaultValue: null }, { name: 'wrapper'; type: { kind: 'INPUT_OBJECT'; name: 'String_comparison_exp'; ofType: null; }; defaultValue: null }]; };
-    'v2_token_meta_wrapping_max_order_by': { kind: 'INPUT_OBJECT'; name: 'v2_token_meta_wrapping_max_order_by'; isOneOf: false; inputFields: [{ name: 'destination_channel_id'; type: { kind: 'ENUM'; name: 'order_by'; ofType: null; }; defaultValue: null }, { name: 'unwrapped_denom'; type: { kind: 'ENUM'; name: 'order_by'; ofType: null; }; defaultValue: null }, { name: 'wrapper'; type: { kind: 'ENUM'; name: 'order_by'; ofType: null; }; defaultValue: null }]; };
-    'v2_token_meta_wrapping_min_order_by': { kind: 'INPUT_OBJECT'; name: 'v2_token_meta_wrapping_min_order_by'; isOneOf: false; inputFields: [{ name: 'destination_channel_id'; type: { kind: 'ENUM'; name: 'order_by'; ofType: null; }; defaultValue: null }, { name: 'unwrapped_denom'; type: { kind: 'ENUM'; name: 'order_by'; ofType: null; }; defaultValue: null }, { name: 'wrapper'; type: { kind: 'ENUM'; name: 'order_by'; ofType: null; }; defaultValue: null }]; };
-    'v2_token_meta_wrapping_order_by': { kind: 'INPUT_OBJECT'; name: 'v2_token_meta_wrapping_order_by'; isOneOf: false; inputFields: [{ name: 'destination_channel_id'; type: { kind: 'ENUM'; name: 'order_by'; ofType: null; }; defaultValue: null }, { name: 'unwrapped_chain'; type: { kind: 'INPUT_OBJECT'; name: 'v2_chains_view_order_by'; ofType: null; }; defaultValue: null }, { name: 'unwrapped_denom'; type: { kind: 'ENUM'; name: 'order_by'; ofType: null; }; defaultValue: null }, { name: 'wrapped_chain'; type: { kind: 'INPUT_OBJECT'; name: 'v2_chains_view_order_by'; ofType: null; }; defaultValue: null }, { name: 'wrapper'; type: { kind: 'ENUM'; name: 'order_by'; ofType: null; }; defaultValue: null }]; };
-    'v2_token_meta_wrapping_select_column': { name: 'v2_token_meta_wrapping_select_column'; enumValues: 'destination_channel_id' | 'unwrapped_denom' | 'wrapper'; };
-    'v2_token_meta_wrapping_stddev_order_by': { kind: 'INPUT_OBJECT'; name: 'v2_token_meta_wrapping_stddev_order_by'; isOneOf: false; inputFields: [{ name: 'destination_channel_id'; type: { kind: 'ENUM'; name: 'order_by'; ofType: null; }; defaultValue: null }]; };
-    'v2_token_meta_wrapping_stddev_pop_order_by': { kind: 'INPUT_OBJECT'; name: 'v2_token_meta_wrapping_stddev_pop_order_by'; isOneOf: false; inputFields: [{ name: 'destination_channel_id'; type: { kind: 'ENUM'; name: 'order_by'; ofType: null; }; defaultValue: null }]; };
-    'v2_token_meta_wrapping_stddev_samp_order_by': { kind: 'INPUT_OBJECT'; name: 'v2_token_meta_wrapping_stddev_samp_order_by'; isOneOf: false; inputFields: [{ name: 'destination_channel_id'; type: { kind: 'ENUM'; name: 'order_by'; ofType: null; }; defaultValue: null }]; };
-    'v2_token_meta_wrapping_sum_order_by': { kind: 'INPUT_OBJECT'; name: 'v2_token_meta_wrapping_sum_order_by'; isOneOf: false; inputFields: [{ name: 'destination_channel_id'; type: { kind: 'ENUM'; name: 'order_by'; ofType: null; }; defaultValue: null }]; };
-    'v2_token_meta_wrapping_var_pop_order_by': { kind: 'INPUT_OBJECT'; name: 'v2_token_meta_wrapping_var_pop_order_by'; isOneOf: false; inputFields: [{ name: 'destination_channel_id'; type: { kind: 'ENUM'; name: 'order_by'; ofType: null; }; defaultValue: null }]; };
-    'v2_token_meta_wrapping_var_samp_order_by': { kind: 'INPUT_OBJECT'; name: 'v2_token_meta_wrapping_var_samp_order_by'; isOneOf: false; inputFields: [{ name: 'destination_channel_id'; type: { kind: 'ENUM'; name: 'order_by'; ofType: null; }; defaultValue: null }]; };
-    'v2_token_meta_wrapping_variance_order_by': { kind: 'INPUT_OBJECT'; name: 'v2_token_meta_wrapping_variance_order_by'; isOneOf: false; inputFields: [{ name: 'destination_channel_id'; type: { kind: 'ENUM'; name: 'order_by'; ofType: null; }; defaultValue: null }]; };
-    'v2_tokens_args': { kind: 'INPUT_OBJECT'; name: 'v2_tokens_args'; isOneOf: false; inputFields: [{ name: 'p_denom'; type: { kind: 'SCALAR'; name: 'String'; ofType: null; }; defaultValue: null }, { name: 'p_universal_chain_id'; type: { kind: 'SCALAR'; name: 'String'; ofType: null; }; defaultValue: null }, { name: 'p_whitelist'; type: { kind: 'SCALAR'; name: 'Boolean'; ofType: null; }; defaultValue: null }]; };
-    'v2_traces_type': { kind: 'OBJECT'; name: 'v2_traces_type'; fields: { 'block_hash': { name: 'block_hash'; type: { kind: 'SCALAR'; name: 'String'; ofType: null; } }; 'chain': { name: 'chain'; type: { kind: 'OBJECT'; name: 'v2_chains_view'; ofType: null; } }; 'event_index': { name: 'event_index'; type: { kind: 'SCALAR'; name: 'String'; ofType: null; } }; 'height': { name: 'height'; type: { kind: 'SCALAR'; name: 'String'; ofType: null; } }; 'timestamp': { name: 'timestamp'; type: { kind: 'SCALAR'; name: 'timestamptz'; ofType: null; } }; 'transaction_hash': { name: 'transaction_hash'; type: { kind: 'SCALAR'; name: 'String'; ofType: null; } }; 'type': { name: 'type'; type: { kind: 'SCALAR'; name: 'String'; ofType: null; } }; 'universal_chain_id': { name: 'universal_chain_id'; type: { kind: 'SCALAR'; name: 'String'; ofType: null; } }; }; };
-    'v2_traces_type_aggregate_order_by': { kind: 'INPUT_OBJECT'; name: 'v2_traces_type_aggregate_order_by'; isOneOf: false; inputFields: [{ name: 'count'; type: { kind: 'ENUM'; name: 'order_by'; ofType: null; }; defaultValue: null }, { name: 'max'; type: { kind: 'INPUT_OBJECT'; name: 'v2_traces_type_max_order_by'; ofType: null; }; defaultValue: null }, { name: 'min'; type: { kind: 'INPUT_OBJECT'; name: 'v2_traces_type_min_order_by'; ofType: null; }; defaultValue: null }]; };
-    'v2_traces_type_bool_exp': { kind: 'INPUT_OBJECT'; name: 'v2_traces_type_bool_exp'; isOneOf: false; inputFields: [{ name: '_and'; type: { kind: 'LIST'; name: never; ofType: { kind: 'NON_NULL'; name: never; ofType: { kind: 'INPUT_OBJECT'; name: 'v2_traces_type_bool_exp'; ofType: null; }; }; }; defaultValue: null }, { name: '_not'; type: { kind: 'INPUT_OBJECT'; name: 'v2_traces_type_bool_exp'; ofType: null; }; defaultValue: null }, { name: '_or'; type: { kind: 'LIST'; name: never; ofType: { kind: 'NON_NULL'; name: never; ofType: { kind: 'INPUT_OBJECT'; name: 'v2_traces_type_bool_exp'; ofType: null; }; }; }; defaultValue: null }, { name: 'block_hash'; type: { kind: 'INPUT_OBJECT'; name: 'String_comparison_exp'; ofType: null; }; defaultValue: null }, { name: 'chain'; type: { kind: 'INPUT_OBJECT'; name: 'v2_chains_view_bool_exp'; ofType: null; }; defaultValue: null }, { name: 'event_index'; type: { kind: 'INPUT_OBJECT'; name: 'String_comparison_exp'; ofType: null; }; defaultValue: null }, { name: 'height'; type: { kind: 'INPUT_OBJECT'; name: 'String_comparison_exp'; ofType: null; }; defaultValue: null }, { name: 'timestamp'; type: { kind: 'INPUT_OBJECT'; name: 'timestamptz_comparison_exp'; ofType: null; }; defaultValue: null }, { name: 'transaction_hash'; type: { kind: 'INPUT_OBJECT'; name: 'String_comparison_exp'; ofType: null; }; defaultValue: null }, { name: 'type'; type: { kind: 'INPUT_OBJECT'; name: 'String_comparison_exp'; ofType: null; }; defaultValue: null }, { name: 'universal_chain_id'; type: { kind: 'INPUT_OBJECT'; name: 'String_comparison_exp'; ofType: null; }; defaultValue: null }]; };
-    'v2_traces_type_max_order_by': { kind: 'INPUT_OBJECT'; name: 'v2_traces_type_max_order_by'; isOneOf: false; inputFields: [{ name: 'block_hash'; type: { kind: 'ENUM'; name: 'order_by'; ofType: null; }; defaultValue: null }, { name: 'event_index'; type: { kind: 'ENUM'; name: 'order_by'; ofType: null; }; defaultValue: null }, { name: 'height'; type: { kind: 'ENUM'; name: 'order_by'; ofType: null; }; defaultValue: null }, { name: 'timestamp'; type: { kind: 'ENUM'; name: 'order_by'; ofType: null; }; defaultValue: null }, { name: 'transaction_hash'; type: { kind: 'ENUM'; name: 'order_by'; ofType: null; }; defaultValue: null }, { name: 'type'; type: { kind: 'ENUM'; name: 'order_by'; ofType: null; }; defaultValue: null }, { name: 'universal_chain_id'; type: { kind: 'ENUM'; name: 'order_by'; ofType: null; }; defaultValue: null }]; };
-    'v2_traces_type_min_order_by': { kind: 'INPUT_OBJECT'; name: 'v2_traces_type_min_order_by'; isOneOf: false; inputFields: [{ name: 'block_hash'; type: { kind: 'ENUM'; name: 'order_by'; ofType: null; }; defaultValue: null }, { name: 'event_index'; type: { kind: 'ENUM'; name: 'order_by'; ofType: null; }; defaultValue: null }, { name: 'height'; type: { kind: 'ENUM'; name: 'order_by'; ofType: null; }; defaultValue: null }, { name: 'timestamp'; type: { kind: 'ENUM'; name: 'order_by'; ofType: null; }; defaultValue: null }, { name: 'transaction_hash'; type: { kind: 'ENUM'; name: 'order_by'; ofType: null; }; defaultValue: null }, { name: 'type'; type: { kind: 'ENUM'; name: 'order_by'; ofType: null; }; defaultValue: null }, { name: 'universal_chain_id'; type: { kind: 'ENUM'; name: 'order_by'; ofType: null; }; defaultValue: null }]; };
-    'v2_traces_type_order_by': { kind: 'INPUT_OBJECT'; name: 'v2_traces_type_order_by'; isOneOf: false; inputFields: [{ name: 'block_hash'; type: { kind: 'ENUM'; name: 'order_by'; ofType: null; }; defaultValue: null }, { name: 'chain'; type: { kind: 'INPUT_OBJECT'; name: 'v2_chains_view_order_by'; ofType: null; }; defaultValue: null }, { name: 'event_index'; type: { kind: 'ENUM'; name: 'order_by'; ofType: null; }; defaultValue: null }, { name: 'height'; type: { kind: 'ENUM'; name: 'order_by'; ofType: null; }; defaultValue: null }, { name: 'timestamp'; type: { kind: 'ENUM'; name: 'order_by'; ofType: null; }; defaultValue: null }, { name: 'transaction_hash'; type: { kind: 'ENUM'; name: 'order_by'; ofType: null; }; defaultValue: null }, { name: 'type'; type: { kind: 'ENUM'; name: 'order_by'; ofType: null; }; defaultValue: null }, { name: 'universal_chain_id'; type: { kind: 'ENUM'; name: 'order_by'; ofType: null; }; defaultValue: null }]; };
-    'v2_traces_type_select_column': { name: 'v2_traces_type_select_column'; enumValues: 'block_hash' | 'event_index' | 'height' | 'timestamp' | 'transaction_hash' | 'type' | 'universal_chain_id'; };
-    'v2_transfer_type': { kind: 'OBJECT'; name: 'v2_transfer_type'; fields: { 'base_amount': { name: 'base_amount'; type: { kind: 'SCALAR'; name: 'String'; ofType: null; } }; 'base_token': { name: 'base_token'; type: { kind: 'SCALAR'; name: 'String'; ofType: null; } }; 'base_token_decimals': { name: 'base_token_decimals'; type: { kind: 'SCALAR'; name: 'Int'; ofType: null; } }; 'base_token_meta': { name: 'base_token_meta'; type: { kind: 'OBJECT'; name: 'v2_token_meta'; ofType: null; } }; 'base_token_name': { name: 'base_token_name'; type: { kind: 'SCALAR'; name: 'String'; ofType: null; } }; 'base_token_path': { name: 'base_token_path'; type: { kind: 'SCALAR'; name: 'String'; ofType: null; } }; 'base_token_symbol': { name: 'base_token_symbol'; type: { kind: 'SCALAR'; name: 'String'; ofType: null; } }; 'destination_chain': { name: 'destination_chain'; type: { kind: 'OBJECT'; name: 'v2_chains_view'; ofType: null; } }; 'destination_universal_chain_id': { name: 'destination_universal_chain_id'; type: { kind: 'SCALAR'; name: 'String'; ofType: null; } }; 'fee_amount': { name: 'fee_amount'; type: { kind: 'SCALAR'; name: 'String'; ofType: null; } }; 'fee_token': { name: 'fee_token'; type: { kind: 'SCALAR'; name: 'String'; ofType: null; } }; 'fee_token_meta': { name: 'fee_token_meta'; type: { kind: 'OBJECT'; name: 'v2_token_meta'; ofType: null; } }; 'fee_type': { name: 'fee_type'; type: { kind: 'SCALAR'; name: 'String'; ofType: null; } }; 'packet_hash': { name: 'packet_hash'; type: { kind: 'SCALAR'; name: 'String'; ofType: null; } }; 'packet_shape': { name: 'packet_shape'; type: { kind: 'SCALAR'; name: 'String'; ofType: null; } }; 'quote_amount': { name: 'quote_amount'; type: { kind: 'SCALAR'; name: 'String'; ofType: null; } }; 'quote_token': { name: 'quote_token'; type: { kind: 'SCALAR'; name: 'String'; ofType: null; } }; 'quote_token_meta': { name: 'quote_token_meta'; type: { kind: 'OBJECT'; name: 'v2_token_meta'; ofType: null; } }; 'receiver_canonical': { name: 'receiver_canonical'; type: { kind: 'SCALAR'; name: 'String'; ofType: null; } }; 'receiver_display': { name: 'receiver_display'; type: { kind: 'SCALAR'; name: 'String'; ofType: null; } }; 'receiver_zkgm': { name: 'receiver_zkgm'; type: { kind: 'SCALAR'; name: 'String'; ofType: null; } }; 'sender_canonical': { name: 'sender_canonical'; type: { kind: 'SCALAR'; name: 'String'; ofType: null; } }; 'sender_display': { name: 'sender_display'; type: { kind: 'SCALAR'; name: 'String'; ofType: null; } }; 'sender_zkgm': { name: 'sender_zkgm'; type: { kind: 'SCALAR'; name: 'String'; ofType: null; } }; 'sort_order': { name: 'sort_order'; type: { kind: 'SCALAR'; name: 'String'; ofType: null; } }; 'source_chain': { name: 'source_chain'; type: { kind: 'OBJECT'; name: 'v2_chains_view'; ofType: null; } }; 'source_universal_chain_id': { name: 'source_universal_chain_id'; type: { kind: 'SCALAR'; name: 'String'; ofType: null; } }; 'success': { name: 'success'; type: { kind: 'SCALAR'; name: 'Boolean'; ofType: null; } }; 'traces': { name: 'traces'; type: { kind: 'LIST'; name: never; ofType: { kind: 'NON_NULL'; name: never; ofType: { kind: 'OBJECT'; name: 'v2_traces_type'; ofType: null; }; }; } }; 'transfer_index': { name: 'transfer_index'; type: { kind: 'SCALAR'; name: 'Int'; ofType: null; } }; 'transfer_recv_timestamp': { name: 'transfer_recv_timestamp'; type: { kind: 'SCALAR'; name: 'timestamptz'; ofType: null; } }; 'transfer_recv_transaction_hash': { name: 'transfer_recv_transaction_hash'; type: { kind: 'SCALAR'; name: 'String'; ofType: null; } }; 'transfer_send_timestamp': { name: 'transfer_send_timestamp'; type: { kind: 'SCALAR'; name: 'timestamptz'; ofType: null; } }; 'transfer_send_transaction_hash': { name: 'transfer_send_transaction_hash'; type: { kind: 'SCALAR'; name: 'String'; ofType: null; } }; 'transfer_timeout_timestamp': { name: 'transfer_timeout_timestamp'; type: { kind: 'SCALAR'; name: 'timestamptz'; ofType: null; } }; 'transfer_timeout_transaction_hash': { name: 'transfer_timeout_transaction_hash'; type: { kind: 'SCALAR'; name: 'String'; ofType: null; } }; 'wrap_direction': { name: 'wrap_direction'; type: { kind: 'SCALAR'; name: 'String'; ofType: null; } }; }; };
-    'v2_transfer_type_bool_exp': { kind: 'INPUT_OBJECT'; name: 'v2_transfer_type_bool_exp'; isOneOf: false; inputFields: [{ name: '_and'; type: { kind: 'LIST'; name: never; ofType: { kind: 'NON_NULL'; name: never; ofType: { kind: 'INPUT_OBJECT'; name: 'v2_transfer_type_bool_exp'; ofType: null; }; }; }; defaultValue: null }, { name: '_not'; type: { kind: 'INPUT_OBJECT'; name: 'v2_transfer_type_bool_exp'; ofType: null; }; defaultValue: null }, { name: '_or'; type: { kind: 'LIST'; name: never; ofType: { kind: 'NON_NULL'; name: never; ofType: { kind: 'INPUT_OBJECT'; name: 'v2_transfer_type_bool_exp'; ofType: null; }; }; }; defaultValue: null }, { name: 'base_amount'; type: { kind: 'INPUT_OBJECT'; name: 'String_comparison_exp'; ofType: null; }; defaultValue: null }, { name: 'base_token'; type: { kind: 'INPUT_OBJECT'; name: 'String_comparison_exp'; ofType: null; }; defaultValue: null }, { name: 'base_token_decimals'; type: { kind: 'INPUT_OBJECT'; name: 'Int_comparison_exp'; ofType: null; }; defaultValue: null }, { name: 'base_token_meta'; type: { kind: 'INPUT_OBJECT'; name: 'v2_token_meta_bool_exp'; ofType: null; }; defaultValue: null }, { name: 'base_token_name'; type: { kind: 'INPUT_OBJECT'; name: 'String_comparison_exp'; ofType: null; }; defaultValue: null }, { name: 'base_token_path'; type: { kind: 'INPUT_OBJECT'; name: 'String_comparison_exp'; ofType: null; }; defaultValue: null }, { name: 'base_token_symbol'; type: { kind: 'INPUT_OBJECT'; name: 'String_comparison_exp'; ofType: null; }; defaultValue: null }, { name: 'destination_chain'; type: { kind: 'INPUT_OBJECT'; name: 'v2_chains_view_bool_exp'; ofType: null; }; defaultValue: null }, { name: 'destination_universal_chain_id'; type: { kind: 'INPUT_OBJECT'; name: 'String_comparison_exp'; ofType: null; }; defaultValue: null }, { name: 'fee_amount'; type: { kind: 'INPUT_OBJECT'; name: 'String_comparison_exp'; ofType: null; }; defaultValue: null }, { name: 'fee_token'; type: { kind: 'INPUT_OBJECT'; name: 'String_comparison_exp'; ofType: null; }; defaultValue: null }, { name: 'fee_token_meta'; type: { kind: 'INPUT_OBJECT'; name: 'v2_token_meta_bool_exp'; ofType: null; }; defaultValue: null }, { name: 'fee_type'; type: { kind: 'INPUT_OBJECT'; name: 'String_comparison_exp'; ofType: null; }; defaultValue: null }, { name: 'packet_hash'; type: { kind: 'INPUT_OBJECT'; name: 'String_comparison_exp'; ofType: null; }; defaultValue: null }, { name: 'packet_shape'; type: { kind: 'INPUT_OBJECT'; name: 'String_comparison_exp'; ofType: null; }; defaultValue: null }, { name: 'quote_amount'; type: { kind: 'INPUT_OBJECT'; name: 'String_comparison_exp'; ofType: null; }; defaultValue: null }, { name: 'quote_token'; type: { kind: 'INPUT_OBJECT'; name: 'String_comparison_exp'; ofType: null; }; defaultValue: null }, { name: 'quote_token_meta'; type: { kind: 'INPUT_OBJECT'; name: 'v2_token_meta_bool_exp'; ofType: null; }; defaultValue: null }, { name: 'receiver_canonical'; type: { kind: 'INPUT_OBJECT'; name: 'String_comparison_exp'; ofType: null; }; defaultValue: null }, { name: 'receiver_display'; type: { kind: 'INPUT_OBJECT'; name: 'String_comparison_exp'; ofType: null; }; defaultValue: null }, { name: 'receiver_zkgm'; type: { kind: 'INPUT_OBJECT'; name: 'String_comparison_exp'; ofType: null; }; defaultValue: null }, { name: 'sender_canonical'; type: { kind: 'INPUT_OBJECT'; name: 'String_comparison_exp'; ofType: null; }; defaultValue: null }, { name: 'sender_display'; type: { kind: 'INPUT_OBJECT'; name: 'String_comparison_exp'; ofType: null; }; defaultValue: null }, { name: 'sender_zkgm'; type: { kind: 'INPUT_OBJECT'; name: 'String_comparison_exp'; ofType: null; }; defaultValue: null }, { name: 'sort_order'; type: { kind: 'INPUT_OBJECT'; name: 'String_comparison_exp'; ofType: null; }; defaultValue: null }, { name: 'source_chain'; type: { kind: 'INPUT_OBJECT'; name: 'v2_chains_view_bool_exp'; ofType: null; }; defaultValue: null }, { name: 'source_universal_chain_id'; type: { kind: 'INPUT_OBJECT'; name: 'String_comparison_exp'; ofType: null; }; defaultValue: null }, { name: 'success'; type: { kind: 'INPUT_OBJECT'; name: 'Boolean_comparison_exp'; ofType: null; }; defaultValue: null }, { name: 'traces'; type: { kind: 'INPUT_OBJECT'; name: 'v2_traces_type_bool_exp'; ofType: null; }; defaultValue: null }, { name: 'transfer_index'; type: { kind: 'INPUT_OBJECT'; name: 'Int_comparison_exp'; ofType: null; }; defaultValue: null }, { name: 'transfer_recv_timestamp'; type: { kind: 'INPUT_OBJECT'; name: 'timestamptz_comparison_exp'; ofType: null; }; defaultValue: null }, { name: 'transfer_recv_transaction_hash'; type: { kind: 'INPUT_OBJECT'; name: 'String_comparison_exp'; ofType: null; }; defaultValue: null }, { name: 'transfer_send_timestamp'; type: { kind: 'INPUT_OBJECT'; name: 'timestamptz_comparison_exp'; ofType: null; }; defaultValue: null }, { name: 'transfer_send_transaction_hash'; type: { kind: 'INPUT_OBJECT'; name: 'String_comparison_exp'; ofType: null; }; defaultValue: null }, { name: 'transfer_timeout_timestamp'; type: { kind: 'INPUT_OBJECT'; name: 'timestamptz_comparison_exp'; ofType: null; }; defaultValue: null }, { name: 'transfer_timeout_transaction_hash'; type: { kind: 'INPUT_OBJECT'; name: 'String_comparison_exp'; ofType: null; }; defaultValue: null }, { name: 'wrap_direction'; type: { kind: 'INPUT_OBJECT'; name: 'String_comparison_exp'; ofType: null; }; defaultValue: null }]; };
-    'v2_transfer_type_order_by': { kind: 'INPUT_OBJECT'; name: 'v2_transfer_type_order_by'; isOneOf: false; inputFields: [{ name: 'base_amount'; type: { kind: 'ENUM'; name: 'order_by'; ofType: null; }; defaultValue: null }, { name: 'base_token'; type: { kind: 'ENUM'; name: 'order_by'; ofType: null; }; defaultValue: null }, { name: 'base_token_decimals'; type: { kind: 'ENUM'; name: 'order_by'; ofType: null; }; defaultValue: null }, { name: 'base_token_meta'; type: { kind: 'INPUT_OBJECT'; name: 'v2_token_meta_order_by'; ofType: null; }; defaultValue: null }, { name: 'base_token_name'; type: { kind: 'ENUM'; name: 'order_by'; ofType: null; }; defaultValue: null }, { name: 'base_token_path'; type: { kind: 'ENUM'; name: 'order_by'; ofType: null; }; defaultValue: null }, { name: 'base_token_symbol'; type: { kind: 'ENUM'; name: 'order_by'; ofType: null; }; defaultValue: null }, { name: 'destination_chain'; type: { kind: 'INPUT_OBJECT'; name: 'v2_chains_view_order_by'; ofType: null; }; defaultValue: null }, { name: 'destination_universal_chain_id'; type: { kind: 'ENUM'; name: 'order_by'; ofType: null; }; defaultValue: null }, { name: 'fee_amount'; type: { kind: 'ENUM'; name: 'order_by'; ofType: null; }; defaultValue: null }, { name: 'fee_token'; type: { kind: 'ENUM'; name: 'order_by'; ofType: null; }; defaultValue: null }, { name: 'fee_token_meta'; type: { kind: 'INPUT_OBJECT'; name: 'v2_token_meta_order_by'; ofType: null; }; defaultValue: null }, { name: 'fee_type'; type: { kind: 'ENUM'; name: 'order_by'; ofType: null; }; defaultValue: null }, { name: 'packet_hash'; type: { kind: 'ENUM'; name: 'order_by'; ofType: null; }; defaultValue: null }, { name: 'packet_shape'; type: { kind: 'ENUM'; name: 'order_by'; ofType: null; }; defaultValue: null }, { name: 'quote_amount'; type: { kind: 'ENUM'; name: 'order_by'; ofType: null; }; defaultValue: null }, { name: 'quote_token'; type: { kind: 'ENUM'; name: 'order_by'; ofType: null; }; defaultValue: null }, { name: 'quote_token_meta'; type: { kind: 'INPUT_OBJECT'; name: 'v2_token_meta_order_by'; ofType: null; }; defaultValue: null }, { name: 'receiver_canonical'; type: { kind: 'ENUM'; name: 'order_by'; ofType: null; }; defaultValue: null }, { name: 'receiver_display'; type: { kind: 'ENUM'; name: 'order_by'; ofType: null; }; defaultValue: null }, { name: 'receiver_zkgm'; type: { kind: 'ENUM'; name: 'order_by'; ofType: null; }; defaultValue: null }, { name: 'sender_canonical'; type: { kind: 'ENUM'; name: 'order_by'; ofType: null; }; defaultValue: null }, { name: 'sender_display'; type: { kind: 'ENUM'; name: 'order_by'; ofType: null; }; defaultValue: null }, { name: 'sender_zkgm'; type: { kind: 'ENUM'; name: 'order_by'; ofType: null; }; defaultValue: null }, { name: 'sort_order'; type: { kind: 'ENUM'; name: 'order_by'; ofType: null; }; defaultValue: null }, { name: 'source_chain'; type: { kind: 'INPUT_OBJECT'; name: 'v2_chains_view_order_by'; ofType: null; }; defaultValue: null }, { name: 'source_universal_chain_id'; type: { kind: 'ENUM'; name: 'order_by'; ofType: null; }; defaultValue: null }, { name: 'success'; type: { kind: 'ENUM'; name: 'order_by'; ofType: null; }; defaultValue: null }, { name: 'traces_aggregate'; type: { kind: 'INPUT_OBJECT'; name: 'v2_traces_type_aggregate_order_by'; ofType: null; }; defaultValue: null }, { name: 'transfer_index'; type: { kind: 'ENUM'; name: 'order_by'; ofType: null; }; defaultValue: null }, { name: 'transfer_recv_timestamp'; type: { kind: 'ENUM'; name: 'order_by'; ofType: null; }; defaultValue: null }, { name: 'transfer_recv_transaction_hash'; type: { kind: 'ENUM'; name: 'order_by'; ofType: null; }; defaultValue: null }, { name: 'transfer_send_timestamp'; type: { kind: 'ENUM'; name: 'order_by'; ofType: null; }; defaultValue: null }, { name: 'transfer_send_transaction_hash'; type: { kind: 'ENUM'; name: 'order_by'; ofType: null; }; defaultValue: null }, { name: 'transfer_timeout_timestamp'; type: { kind: 'ENUM'; name: 'order_by'; ofType: null; }; defaultValue: null }, { name: 'transfer_timeout_transaction_hash'; type: { kind: 'ENUM'; name: 'order_by'; ofType: null; }; defaultValue: null }, { name: 'wrap_direction'; type: { kind: 'ENUM'; name: 'order_by'; ofType: null; }; defaultValue: null }]; };
-    'v2_transfer_type_select_column': { name: 'v2_transfer_type_select_column'; enumValues: 'base_amount' | 'base_token' | 'base_token_decimals' | 'base_token_name' | 'base_token_path' | 'base_token_symbol' | 'destination_universal_chain_id' | 'fee_amount' | 'fee_token' | 'fee_type' | 'packet_hash' | 'packet_shape' | 'quote_amount' | 'quote_token' | 'receiver_canonical' | 'receiver_display' | 'receiver_zkgm' | 'sender_canonical' | 'sender_display' | 'sender_zkgm' | 'sort_order' | 'source_universal_chain_id' | 'success' | 'transfer_index' | 'transfer_recv_timestamp' | 'transfer_recv_transaction_hash' | 'transfer_send_timestamp' | 'transfer_send_transaction_hash' | 'transfer_timeout_timestamp' | 'transfer_timeout_transaction_hash' | 'wrap_direction'; };
-    'v2_transfers_args': { kind: 'INPUT_OBJECT'; name: 'v2_transfers_args'; isOneOf: false; inputFields: [{ name: 'p_addresses_canonical'; type: { kind: 'SCALAR'; name: 'jsonb'; ofType: null; }; defaultValue: null }, { name: 'p_block_hash'; type: { kind: 'SCALAR'; name: 'String'; ofType: null; }; defaultValue: null }, { name: 'p_comparison'; type: { kind: 'SCALAR'; name: 'String'; ofType: null; }; defaultValue: null }, { name: 'p_destination_universal_chain_id'; type: { kind: 'SCALAR'; name: 'String'; ofType: null; }; defaultValue: null }, { name: 'p_limit'; type: { kind: 'SCALAR'; name: 'Int'; ofType: null; }; defaultValue: null }, { name: 'p_packet_hash'; type: { kind: 'SCALAR'; name: 'String'; ofType: null; }; defaultValue: null }, { name: 'p_sort_order'; type: { kind: 'SCALAR'; name: 'String'; ofType: null; }; defaultValue: null }, { name: 'p_source_universal_chain_id'; type: { kind: 'SCALAR'; name: 'String'; ofType: null; }; defaultValue: null }, { name: 'p_transaction_hash'; type: { kind: 'SCALAR'; name: 'String'; ofType: null; }; defaultValue: null }, { name: 'p_transfer_index'; type: { kind: 'SCALAR'; name: 'Int'; ofType: null; }; defaultValue: null }]; };
-    'v2_util_get_address_types_for_display_address_args': { kind: 'INPUT_OBJECT'; name: 'v2_util_get_address_types_for_display_address_args'; isOneOf: false; inputFields: [{ name: 'p_chain_type'; type: { kind: 'SCALAR'; name: 'String'; ofType: null; }; defaultValue: null }, { name: 'p_display_address'; type: { kind: 'SCALAR'; name: 'String'; ofType: null; }; defaultValue: null }]; };
-    'v2_util_get_address_types_for_display_address_type': { kind: 'OBJECT'; name: 'v2_util_get_address_types_for_display_address_type'; fields: { 'canonical': { name: 'canonical'; type: { kind: 'SCALAR'; name: 'String'; ofType: null; } }; 'display': { name: 'display'; type: { kind: 'SCALAR'; name: 'String'; ofType: null; } }; 'zkgm': { name: 'zkgm'; type: { kind: 'SCALAR'; name: 'String'; ofType: null; } }; }; };
-    'v2_util_get_address_types_for_display_address_type_bool_exp': { kind: 'INPUT_OBJECT'; name: 'v2_util_get_address_types_for_display_address_type_bool_exp'; isOneOf: false; inputFields: [{ name: '_and'; type: { kind: 'LIST'; name: never; ofType: { kind: 'NON_NULL'; name: never; ofType: { kind: 'INPUT_OBJECT'; name: 'v2_util_get_address_types_for_display_address_type_bool_exp'; ofType: null; }; }; }; defaultValue: null }, { name: '_not'; type: { kind: 'INPUT_OBJECT'; name: 'v2_util_get_address_types_for_display_address_type_bool_exp'; ofType: null; }; defaultValue: null }, { name: '_or'; type: { kind: 'LIST'; name: never; ofType: { kind: 'NON_NULL'; name: never; ofType: { kind: 'INPUT_OBJECT'; name: 'v2_util_get_address_types_for_display_address_type_bool_exp'; ofType: null; }; }; }; defaultValue: null }, { name: 'canonical'; type: { kind: 'INPUT_OBJECT'; name: 'String_comparison_exp'; ofType: null; }; defaultValue: null }, { name: 'display'; type: { kind: 'INPUT_OBJECT'; name: 'String_comparison_exp'; ofType: null; }; defaultValue: null }, { name: 'zkgm'; type: { kind: 'INPUT_OBJECT'; name: 'String_comparison_exp'; ofType: null; }; defaultValue: null }]; };
-    'v2_util_get_address_types_for_display_address_type_order_by': { kind: 'INPUT_OBJECT'; name: 'v2_util_get_address_types_for_display_address_type_order_by'; isOneOf: false; inputFields: [{ name: 'canonical'; type: { kind: 'ENUM'; name: 'order_by'; ofType: null; }; defaultValue: null }, { name: 'display'; type: { kind: 'ENUM'; name: 'order_by'; ofType: null; }; defaultValue: null }, { name: 'zkgm'; type: { kind: 'ENUM'; name: 'order_by'; ofType: null; }; defaultValue: null }]; };
-    'v2_util_get_address_types_for_display_address_type_select_column': { name: 'v2_util_get_address_types_for_display_address_type_select_column'; enumValues: 'canonical' | 'display' | 'zkgm'; };
-    'v2_util_get_transfer_request_details_args': { kind: 'INPUT_OBJECT'; name: 'v2_util_get_transfer_request_details_args'; isOneOf: false; inputFields: [{ name: 'p_base_token'; type: { kind: 'SCALAR'; name: 'String'; ofType: null; }; defaultValue: null }, { name: 'p_destination_universal_chain_id'; type: { kind: 'SCALAR'; name: 'String'; ofType: null; }; defaultValue: null }, { name: 'p_source_universal_chain_id'; type: { kind: 'SCALAR'; name: 'String'; ofType: null; }; defaultValue: null }]; };
-    'v2_util_get_transfer_request_details_type': { kind: 'OBJECT'; name: 'v2_util_get_transfer_request_details_type'; fields: { 'already_exists': { name: 'already_exists'; type: { kind: 'SCALAR'; name: 'Boolean'; ofType: null; } }; 'destination_channel_id': { name: 'destination_channel_id'; type: { kind: 'SCALAR'; name: 'Int'; ofType: null; } }; 'quote_token': { name: 'quote_token'; type: { kind: 'SCALAR'; name: 'String'; ofType: null; } }; 'source_channel_id': { name: 'source_channel_id'; type: { kind: 'SCALAR'; name: 'Int'; ofType: null; } }; 'wrap_direction': { name: 'wrap_direction'; type: { kind: 'SCALAR'; name: 'String'; ofType: null; } }; }; };
-    'v2_util_get_transfer_request_details_type_bool_exp': { kind: 'INPUT_OBJECT'; name: 'v2_util_get_transfer_request_details_type_bool_exp'; isOneOf: false; inputFields: [{ name: '_and'; type: { kind: 'LIST'; name: never; ofType: { kind: 'NON_NULL'; name: never; ofType: { kind: 'INPUT_OBJECT'; name: 'v2_util_get_transfer_request_details_type_bool_exp'; ofType: null; }; }; }; defaultValue: null }, { name: '_not'; type: { kind: 'INPUT_OBJECT'; name: 'v2_util_get_transfer_request_details_type_bool_exp'; ofType: null; }; defaultValue: null }, { name: '_or'; type: { kind: 'LIST'; name: never; ofType: { kind: 'NON_NULL'; name: never; ofType: { kind: 'INPUT_OBJECT'; name: 'v2_util_get_transfer_request_details_type_bool_exp'; ofType: null; }; }; }; defaultValue: null }, { name: 'already_exists'; type: { kind: 'INPUT_OBJECT'; name: 'Boolean_comparison_exp'; ofType: null; }; defaultValue: null }, { name: 'destination_channel_id'; type: { kind: 'INPUT_OBJECT'; name: 'Int_comparison_exp'; ofType: null; }; defaultValue: null }, { name: 'quote_token'; type: { kind: 'INPUT_OBJECT'; name: 'String_comparison_exp'; ofType: null; }; defaultValue: null }, { name: 'source_channel_id'; type: { kind: 'INPUT_OBJECT'; name: 'Int_comparison_exp'; ofType: null; }; defaultValue: null }, { name: 'wrap_direction'; type: { kind: 'INPUT_OBJECT'; name: 'String_comparison_exp'; ofType: null; }; defaultValue: null }]; };
-    'v2_util_get_transfer_request_details_type_order_by': { kind: 'INPUT_OBJECT'; name: 'v2_util_get_transfer_request_details_type_order_by'; isOneOf: false; inputFields: [{ name: 'already_exists'; type: { kind: 'ENUM'; name: 'order_by'; ofType: null; }; defaultValue: null }, { name: 'destination_channel_id'; type: { kind: 'ENUM'; name: 'order_by'; ofType: null; }; defaultValue: null }, { name: 'quote_token'; type: { kind: 'ENUM'; name: 'order_by'; ofType: null; }; defaultValue: null }, { name: 'source_channel_id'; type: { kind: 'ENUM'; name: 'order_by'; ofType: null; }; defaultValue: null }, { name: 'wrap_direction'; type: { kind: 'ENUM'; name: 'order_by'; ofType: null; }; defaultValue: null }]; };
-    'v2_util_get_transfer_request_details_type_select_column': { name: 'v2_util_get_transfer_request_details_type_select_column'; enumValues: 'already_exists' | 'destination_channel_id' | 'quote_token' | 'source_channel_id' | 'wrap_direction'; };
-};
-
 /** An IntrospectionQuery representation of your schema.
  *
  * @remarks
@@ -236,11 +10,17644 @@ export type introspection_types = {
  * instead save to a .ts instead of a .d.ts file.
  */
 export type introspection = {
-  name: never;
-  query: 'query_root';
-  mutation: 'mutation_root';
-  subscription: 'subscription_root';
-  types: introspection_types;
+  "__schema": {
+    "queryType": {
+      "name": "query_root"
+    },
+    "mutationType": {
+      "name": "mutation_root"
+    },
+    "subscriptionType": {
+      "name": "subscription_root"
+    },
+    "types": [
+      {
+        "kind": "SCALAR",
+        "name": "Boolean"
+      },
+      {
+        "kind": "INPUT_OBJECT",
+        "name": "Boolean_comparison_exp",
+        "inputFields": [
+          {
+            "name": "_eq",
+            "type": {
+              "kind": "SCALAR",
+              "name": "Boolean"
+            }
+          },
+          {
+            "name": "_gt",
+            "type": {
+              "kind": "SCALAR",
+              "name": "Boolean"
+            }
+          },
+          {
+            "name": "_gte",
+            "type": {
+              "kind": "SCALAR",
+              "name": "Boolean"
+            }
+          },
+          {
+            "name": "_in",
+            "type": {
+              "kind": "LIST",
+              "ofType": {
+                "kind": "NON_NULL",
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Boolean"
+                }
+              }
+            }
+          },
+          {
+            "name": "_is_null",
+            "type": {
+              "kind": "SCALAR",
+              "name": "Boolean"
+            }
+          },
+          {
+            "name": "_lt",
+            "type": {
+              "kind": "SCALAR",
+              "name": "Boolean"
+            }
+          },
+          {
+            "name": "_lte",
+            "type": {
+              "kind": "SCALAR",
+              "name": "Boolean"
+            }
+          },
+          {
+            "name": "_neq",
+            "type": {
+              "kind": "SCALAR",
+              "name": "Boolean"
+            }
+          },
+          {
+            "name": "_nin",
+            "type": {
+              "kind": "LIST",
+              "ofType": {
+                "kind": "NON_NULL",
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Boolean"
+                }
+              }
+            }
+          }
+        ],
+        "isOneOf": false
+      },
+      {
+        "kind": "SCALAR",
+        "name": "Int"
+      },
+      {
+        "kind": "INPUT_OBJECT",
+        "name": "Int_comparison_exp",
+        "inputFields": [
+          {
+            "name": "_eq",
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int"
+            }
+          },
+          {
+            "name": "_gt",
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int"
+            }
+          },
+          {
+            "name": "_gte",
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int"
+            }
+          },
+          {
+            "name": "_in",
+            "type": {
+              "kind": "LIST",
+              "ofType": {
+                "kind": "NON_NULL",
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Int"
+                }
+              }
+            }
+          },
+          {
+            "name": "_is_null",
+            "type": {
+              "kind": "SCALAR",
+              "name": "Boolean"
+            }
+          },
+          {
+            "name": "_lt",
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int"
+            }
+          },
+          {
+            "name": "_lte",
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int"
+            }
+          },
+          {
+            "name": "_neq",
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int"
+            }
+          },
+          {
+            "name": "_nin",
+            "type": {
+              "kind": "LIST",
+              "ofType": {
+                "kind": "NON_NULL",
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Int"
+                }
+              }
+            }
+          }
+        ],
+        "isOneOf": false
+      },
+      {
+        "kind": "OBJECT",
+        "name": "Request",
+        "fields": [
+          {
+            "name": "address",
+            "type": {
+              "kind": "NON_NULL",
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "String"
+              }
+            },
+            "args": [],
+            "isDeprecated": false
+          },
+          {
+            "name": "id",
+            "type": {
+              "kind": "NON_NULL",
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "Int"
+              }
+            },
+            "args": [],
+            "isDeprecated": false
+          },
+          {
+            "name": "time",
+            "type": {
+              "kind": "NON_NULL",
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "String"
+              }
+            },
+            "args": [],
+            "isDeprecated": false
+          },
+          {
+            "name": "txHash",
+            "type": {
+              "kind": "SCALAR",
+              "name": "String"
+            },
+            "args": [],
+            "isDeprecated": false
+          }
+        ],
+        "interfaces": []
+      },
+      {
+        "kind": "SCALAR",
+        "name": "String"
+      },
+      {
+        "kind": "INPUT_OBJECT",
+        "name": "String_array_comparison_exp",
+        "inputFields": [
+          {
+            "name": "_contained_in",
+            "type": {
+              "kind": "LIST",
+              "ofType": {
+                "kind": "NON_NULL",
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String"
+                }
+              }
+            }
+          },
+          {
+            "name": "_contains",
+            "type": {
+              "kind": "LIST",
+              "ofType": {
+                "kind": "NON_NULL",
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String"
+                }
+              }
+            }
+          },
+          {
+            "name": "_eq",
+            "type": {
+              "kind": "LIST",
+              "ofType": {
+                "kind": "NON_NULL",
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String"
+                }
+              }
+            }
+          },
+          {
+            "name": "_gt",
+            "type": {
+              "kind": "LIST",
+              "ofType": {
+                "kind": "NON_NULL",
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String"
+                }
+              }
+            }
+          },
+          {
+            "name": "_gte",
+            "type": {
+              "kind": "LIST",
+              "ofType": {
+                "kind": "NON_NULL",
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String"
+                }
+              }
+            }
+          },
+          {
+            "name": "_in",
+            "type": {
+              "kind": "LIST",
+              "ofType": {
+                "kind": "NON_NULL",
+                "ofType": {
+                  "kind": "LIST",
+                  "ofType": {
+                    "kind": "NON_NULL",
+                    "ofType": {
+                      "kind": "SCALAR",
+                      "name": "String"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          {
+            "name": "_is_null",
+            "type": {
+              "kind": "SCALAR",
+              "name": "Boolean"
+            }
+          },
+          {
+            "name": "_lt",
+            "type": {
+              "kind": "LIST",
+              "ofType": {
+                "kind": "NON_NULL",
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String"
+                }
+              }
+            }
+          },
+          {
+            "name": "_lte",
+            "type": {
+              "kind": "LIST",
+              "ofType": {
+                "kind": "NON_NULL",
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String"
+                }
+              }
+            }
+          },
+          {
+            "name": "_neq",
+            "type": {
+              "kind": "LIST",
+              "ofType": {
+                "kind": "NON_NULL",
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String"
+                }
+              }
+            }
+          },
+          {
+            "name": "_nin",
+            "type": {
+              "kind": "LIST",
+              "ofType": {
+                "kind": "NON_NULL",
+                "ofType": {
+                  "kind": "LIST",
+                  "ofType": {
+                    "kind": "NON_NULL",
+                    "ofType": {
+                      "kind": "SCALAR",
+                      "name": "String"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        ],
+        "isOneOf": false
+      },
+      {
+        "kind": "INPUT_OBJECT",
+        "name": "String_comparison_exp",
+        "inputFields": [
+          {
+            "name": "_eq",
+            "type": {
+              "kind": "SCALAR",
+              "name": "String"
+            }
+          },
+          {
+            "name": "_gt",
+            "type": {
+              "kind": "SCALAR",
+              "name": "String"
+            }
+          },
+          {
+            "name": "_gte",
+            "type": {
+              "kind": "SCALAR",
+              "name": "String"
+            }
+          },
+          {
+            "name": "_ilike",
+            "type": {
+              "kind": "SCALAR",
+              "name": "String"
+            }
+          },
+          {
+            "name": "_in",
+            "type": {
+              "kind": "LIST",
+              "ofType": {
+                "kind": "NON_NULL",
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String"
+                }
+              }
+            }
+          },
+          {
+            "name": "_iregex",
+            "type": {
+              "kind": "SCALAR",
+              "name": "String"
+            }
+          },
+          {
+            "name": "_is_null",
+            "type": {
+              "kind": "SCALAR",
+              "name": "Boolean"
+            }
+          },
+          {
+            "name": "_like",
+            "type": {
+              "kind": "SCALAR",
+              "name": "String"
+            }
+          },
+          {
+            "name": "_lt",
+            "type": {
+              "kind": "SCALAR",
+              "name": "String"
+            }
+          },
+          {
+            "name": "_lte",
+            "type": {
+              "kind": "SCALAR",
+              "name": "String"
+            }
+          },
+          {
+            "name": "_neq",
+            "type": {
+              "kind": "SCALAR",
+              "name": "String"
+            }
+          },
+          {
+            "name": "_nilike",
+            "type": {
+              "kind": "SCALAR",
+              "name": "String"
+            }
+          },
+          {
+            "name": "_nin",
+            "type": {
+              "kind": "LIST",
+              "ofType": {
+                "kind": "NON_NULL",
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String"
+                }
+              }
+            }
+          },
+          {
+            "name": "_niregex",
+            "type": {
+              "kind": "SCALAR",
+              "name": "String"
+            }
+          },
+          {
+            "name": "_nlike",
+            "type": {
+              "kind": "SCALAR",
+              "name": "String"
+            }
+          },
+          {
+            "name": "_nregex",
+            "type": {
+              "kind": "SCALAR",
+              "name": "String"
+            }
+          },
+          {
+            "name": "_nsimilar",
+            "type": {
+              "kind": "SCALAR",
+              "name": "String"
+            }
+          },
+          {
+            "name": "_regex",
+            "type": {
+              "kind": "SCALAR",
+              "name": "String"
+            }
+          },
+          {
+            "name": "_similar",
+            "type": {
+              "kind": "SCALAR",
+              "name": "String"
+            }
+          }
+        ],
+        "isOneOf": false
+      },
+      {
+        "kind": "ENUM",
+        "name": "cursor_ordering",
+        "enumValues": [
+          {
+            "name": "ASC",
+            "isDeprecated": false
+          },
+          {
+            "name": "DESC",
+            "isDeprecated": false
+          }
+        ]
+      },
+      {
+        "kind": "INPUT_OBJECT",
+        "name": "dashboard_balance_current_args",
+        "inputFields": [
+          {
+            "name": "p_contract_address_canonical",
+            "type": {
+              "kind": "SCALAR",
+              "name": "String"
+            }
+          },
+          {
+            "name": "p_phase",
+            "type": {
+              "kind": "SCALAR",
+              "name": "String"
+            }
+          },
+          {
+            "name": "p_universal_chain_id",
+            "type": {
+              "kind": "SCALAR",
+              "name": "String"
+            }
+          },
+          {
+            "name": "p_wallet_addresses_canonical",
+            "type": {
+              "kind": "SCALAR",
+              "name": "jsonb"
+            }
+          }
+        ],
+        "isOneOf": false
+      },
+      {
+        "kind": "OBJECT",
+        "name": "dashboard_balance_current_type",
+        "fields": [
+          {
+            "name": "balance",
+            "type": {
+              "kind": "SCALAR",
+              "name": "String"
+            },
+            "args": [],
+            "isDeprecated": false
+          },
+          {
+            "name": "balance_usd",
+            "type": {
+              "kind": "SCALAR",
+              "name": "String"
+            },
+            "args": [],
+            "isDeprecated": false
+          },
+          {
+            "name": "contract_address_canonical",
+            "type": {
+              "kind": "SCALAR",
+              "name": "String"
+            },
+            "args": [],
+            "isDeprecated": false
+          },
+          {
+            "name": "token",
+            "type": {
+              "kind": "SCALAR",
+              "name": "String"
+            },
+            "args": [],
+            "isDeprecated": false
+          },
+          {
+            "name": "universal_chain_id",
+            "type": {
+              "kind": "SCALAR",
+              "name": "String"
+            },
+            "args": [],
+            "isDeprecated": false
+          },
+          {
+            "name": "wallet_address_canonical",
+            "type": {
+              "kind": "SCALAR",
+              "name": "String"
+            },
+            "args": [],
+            "isDeprecated": false
+          },
+          {
+            "name": "weighted_balance",
+            "type": {
+              "kind": "SCALAR",
+              "name": "String"
+            },
+            "args": [],
+            "isDeprecated": false
+          },
+          {
+            "name": "weighted_balance_usd",
+            "type": {
+              "kind": "SCALAR",
+              "name": "String"
+            },
+            "args": [],
+            "isDeprecated": false
+          }
+        ],
+        "interfaces": []
+      },
+      {
+        "kind": "INPUT_OBJECT",
+        "name": "dashboard_balance_current_type_bool_exp",
+        "inputFields": [
+          {
+            "name": "_and",
+            "type": {
+              "kind": "LIST",
+              "ofType": {
+                "kind": "NON_NULL",
+                "ofType": {
+                  "kind": "INPUT_OBJECT",
+                  "name": "dashboard_balance_current_type_bool_exp"
+                }
+              }
+            }
+          },
+          {
+            "name": "_not",
+            "type": {
+              "kind": "INPUT_OBJECT",
+              "name": "dashboard_balance_current_type_bool_exp"
+            }
+          },
+          {
+            "name": "_or",
+            "type": {
+              "kind": "LIST",
+              "ofType": {
+                "kind": "NON_NULL",
+                "ofType": {
+                  "kind": "INPUT_OBJECT",
+                  "name": "dashboard_balance_current_type_bool_exp"
+                }
+              }
+            }
+          },
+          {
+            "name": "balance",
+            "type": {
+              "kind": "INPUT_OBJECT",
+              "name": "String_comparison_exp"
+            }
+          },
+          {
+            "name": "balance_usd",
+            "type": {
+              "kind": "INPUT_OBJECT",
+              "name": "String_comparison_exp"
+            }
+          },
+          {
+            "name": "contract_address_canonical",
+            "type": {
+              "kind": "INPUT_OBJECT",
+              "name": "String_comparison_exp"
+            }
+          },
+          {
+            "name": "token",
+            "type": {
+              "kind": "INPUT_OBJECT",
+              "name": "String_comparison_exp"
+            }
+          },
+          {
+            "name": "universal_chain_id",
+            "type": {
+              "kind": "INPUT_OBJECT",
+              "name": "String_comparison_exp"
+            }
+          },
+          {
+            "name": "wallet_address_canonical",
+            "type": {
+              "kind": "INPUT_OBJECT",
+              "name": "String_comparison_exp"
+            }
+          },
+          {
+            "name": "weighted_balance",
+            "type": {
+              "kind": "INPUT_OBJECT",
+              "name": "String_comparison_exp"
+            }
+          },
+          {
+            "name": "weighted_balance_usd",
+            "type": {
+              "kind": "INPUT_OBJECT",
+              "name": "String_comparison_exp"
+            }
+          }
+        ],
+        "isOneOf": false
+      },
+      {
+        "kind": "INPUT_OBJECT",
+        "name": "dashboard_balance_current_type_order_by",
+        "inputFields": [
+          {
+            "name": "balance",
+            "type": {
+              "kind": "ENUM",
+              "name": "order_by"
+            }
+          },
+          {
+            "name": "balance_usd",
+            "type": {
+              "kind": "ENUM",
+              "name": "order_by"
+            }
+          },
+          {
+            "name": "contract_address_canonical",
+            "type": {
+              "kind": "ENUM",
+              "name": "order_by"
+            }
+          },
+          {
+            "name": "token",
+            "type": {
+              "kind": "ENUM",
+              "name": "order_by"
+            }
+          },
+          {
+            "name": "universal_chain_id",
+            "type": {
+              "kind": "ENUM",
+              "name": "order_by"
+            }
+          },
+          {
+            "name": "wallet_address_canonical",
+            "type": {
+              "kind": "ENUM",
+              "name": "order_by"
+            }
+          },
+          {
+            "name": "weighted_balance",
+            "type": {
+              "kind": "ENUM",
+              "name": "order_by"
+            }
+          },
+          {
+            "name": "weighted_balance_usd",
+            "type": {
+              "kind": "ENUM",
+              "name": "order_by"
+            }
+          }
+        ],
+        "isOneOf": false
+      },
+      {
+        "kind": "ENUM",
+        "name": "dashboard_balance_current_type_select_column",
+        "enumValues": [
+          {
+            "name": "balance",
+            "isDeprecated": false
+          },
+          {
+            "name": "balance_usd",
+            "isDeprecated": false
+          },
+          {
+            "name": "contract_address_canonical",
+            "isDeprecated": false
+          },
+          {
+            "name": "token",
+            "isDeprecated": false
+          },
+          {
+            "name": "universal_chain_id",
+            "isDeprecated": false
+          },
+          {
+            "name": "wallet_address_canonical",
+            "isDeprecated": false
+          },
+          {
+            "name": "weighted_balance",
+            "isDeprecated": false
+          },
+          {
+            "name": "weighted_balance_usd",
+            "isDeprecated": false
+          }
+        ]
+      },
+      {
+        "kind": "OBJECT",
+        "name": "dashboard_count_by_chain_type",
+        "fields": [
+          {
+            "name": "count",
+            "type": {
+              "kind": "SCALAR",
+              "name": "String"
+            },
+            "args": [],
+            "isDeprecated": false
+          },
+          {
+            "name": "phase",
+            "type": {
+              "kind": "SCALAR",
+              "name": "String"
+            },
+            "args": [],
+            "isDeprecated": false
+          },
+          {
+            "name": "universal_chain_id",
+            "type": {
+              "kind": "SCALAR",
+              "name": "String"
+            },
+            "args": [],
+            "isDeprecated": false
+          }
+        ],
+        "interfaces": []
+      },
+      {
+        "kind": "INPUT_OBJECT",
+        "name": "dashboard_count_by_chain_type_bool_exp",
+        "inputFields": [
+          {
+            "name": "_and",
+            "type": {
+              "kind": "LIST",
+              "ofType": {
+                "kind": "NON_NULL",
+                "ofType": {
+                  "kind": "INPUT_OBJECT",
+                  "name": "dashboard_count_by_chain_type_bool_exp"
+                }
+              }
+            }
+          },
+          {
+            "name": "_not",
+            "type": {
+              "kind": "INPUT_OBJECT",
+              "name": "dashboard_count_by_chain_type_bool_exp"
+            }
+          },
+          {
+            "name": "_or",
+            "type": {
+              "kind": "LIST",
+              "ofType": {
+                "kind": "NON_NULL",
+                "ofType": {
+                  "kind": "INPUT_OBJECT",
+                  "name": "dashboard_count_by_chain_type_bool_exp"
+                }
+              }
+            }
+          },
+          {
+            "name": "count",
+            "type": {
+              "kind": "INPUT_OBJECT",
+              "name": "String_comparison_exp"
+            }
+          },
+          {
+            "name": "phase",
+            "type": {
+              "kind": "INPUT_OBJECT",
+              "name": "String_comparison_exp"
+            }
+          },
+          {
+            "name": "universal_chain_id",
+            "type": {
+              "kind": "INPUT_OBJECT",
+              "name": "String_comparison_exp"
+            }
+          }
+        ],
+        "isOneOf": false
+      },
+      {
+        "kind": "INPUT_OBJECT",
+        "name": "dashboard_count_by_chain_type_order_by",
+        "inputFields": [
+          {
+            "name": "count",
+            "type": {
+              "kind": "ENUM",
+              "name": "order_by"
+            }
+          },
+          {
+            "name": "phase",
+            "type": {
+              "kind": "ENUM",
+              "name": "order_by"
+            }
+          },
+          {
+            "name": "universal_chain_id",
+            "type": {
+              "kind": "ENUM",
+              "name": "order_by"
+            }
+          }
+        ],
+        "isOneOf": false
+      },
+      {
+        "kind": "ENUM",
+        "name": "dashboard_count_by_chain_type_select_column",
+        "enumValues": [
+          {
+            "name": "count",
+            "isDeprecated": false
+          },
+          {
+            "name": "phase",
+            "isDeprecated": false
+          },
+          {
+            "name": "universal_chain_id",
+            "isDeprecated": false
+          }
+        ]
+      },
+      {
+        "kind": "OBJECT",
+        "name": "dashboard_days_by_chain_type",
+        "fields": [
+          {
+            "name": "day_count",
+            "type": {
+              "kind": "SCALAR",
+              "name": "String"
+            },
+            "args": [],
+            "isDeprecated": false
+          },
+          {
+            "name": "universal_chain_id",
+            "type": {
+              "kind": "SCALAR",
+              "name": "String"
+            },
+            "args": [],
+            "isDeprecated": false
+          }
+        ],
+        "interfaces": []
+      },
+      {
+        "kind": "INPUT_OBJECT",
+        "name": "dashboard_days_by_chain_type_bool_exp",
+        "inputFields": [
+          {
+            "name": "_and",
+            "type": {
+              "kind": "LIST",
+              "ofType": {
+                "kind": "NON_NULL",
+                "ofType": {
+                  "kind": "INPUT_OBJECT",
+                  "name": "dashboard_days_by_chain_type_bool_exp"
+                }
+              }
+            }
+          },
+          {
+            "name": "_not",
+            "type": {
+              "kind": "INPUT_OBJECT",
+              "name": "dashboard_days_by_chain_type_bool_exp"
+            }
+          },
+          {
+            "name": "_or",
+            "type": {
+              "kind": "LIST",
+              "ofType": {
+                "kind": "NON_NULL",
+                "ofType": {
+                  "kind": "INPUT_OBJECT",
+                  "name": "dashboard_days_by_chain_type_bool_exp"
+                }
+              }
+            }
+          },
+          {
+            "name": "day_count",
+            "type": {
+              "kind": "INPUT_OBJECT",
+              "name": "String_comparison_exp"
+            }
+          },
+          {
+            "name": "universal_chain_id",
+            "type": {
+              "kind": "INPUT_OBJECT",
+              "name": "String_comparison_exp"
+            }
+          }
+        ],
+        "isOneOf": false
+      },
+      {
+        "kind": "INPUT_OBJECT",
+        "name": "dashboard_days_by_chain_type_order_by",
+        "inputFields": [
+          {
+            "name": "day_count",
+            "type": {
+              "kind": "ENUM",
+              "name": "order_by"
+            }
+          },
+          {
+            "name": "universal_chain_id",
+            "type": {
+              "kind": "ENUM",
+              "name": "order_by"
+            }
+          }
+        ],
+        "isOneOf": false
+      },
+      {
+        "kind": "ENUM",
+        "name": "dashboard_days_by_chain_type_select_column",
+        "enumValues": [
+          {
+            "name": "day_count",
+            "isDeprecated": false
+          },
+          {
+            "name": "universal_chain_id",
+            "isDeprecated": false
+          }
+        ]
+      },
+      {
+        "kind": "INPUT_OBJECT",
+        "name": "dashboard_transfer_count_by_chain_args",
+        "inputFields": [
+          {
+            "name": "p_addresses_dashboard",
+            "type": {
+              "kind": "SCALAR",
+              "name": "jsonb"
+            }
+          },
+          {
+            "name": "p_phase",
+            "type": {
+              "kind": "SCALAR",
+              "name": "String"
+            }
+          }
+        ],
+        "isOneOf": false
+      },
+      {
+        "kind": "INPUT_OBJECT",
+        "name": "dashboard_transfer_days_count_by_chain_args",
+        "inputFields": [
+          {
+            "name": "p_addresses_dashboard",
+            "type": {
+              "kind": "SCALAR",
+              "name": "jsonb"
+            }
+          }
+        ],
+        "isOneOf": false
+      },
+      {
+        "kind": "SCALAR",
+        "name": "date"
+      },
+      {
+        "kind": "INPUT_OBJECT",
+        "name": "date_comparison_exp",
+        "inputFields": [
+          {
+            "name": "_eq",
+            "type": {
+              "kind": "SCALAR",
+              "name": "date"
+            }
+          },
+          {
+            "name": "_gt",
+            "type": {
+              "kind": "SCALAR",
+              "name": "date"
+            }
+          },
+          {
+            "name": "_gte",
+            "type": {
+              "kind": "SCALAR",
+              "name": "date"
+            }
+          },
+          {
+            "name": "_in",
+            "type": {
+              "kind": "LIST",
+              "ofType": {
+                "kind": "NON_NULL",
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "date"
+                }
+              }
+            }
+          },
+          {
+            "name": "_is_null",
+            "type": {
+              "kind": "SCALAR",
+              "name": "Boolean"
+            }
+          },
+          {
+            "name": "_lt",
+            "type": {
+              "kind": "SCALAR",
+              "name": "date"
+            }
+          },
+          {
+            "name": "_lte",
+            "type": {
+              "kind": "SCALAR",
+              "name": "date"
+            }
+          },
+          {
+            "name": "_neq",
+            "type": {
+              "kind": "SCALAR",
+              "name": "date"
+            }
+          },
+          {
+            "name": "_nin",
+            "type": {
+              "kind": "LIST",
+              "ofType": {
+                "kind": "NON_NULL",
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "date"
+                }
+              }
+            }
+          }
+        ],
+        "isOneOf": false
+      },
+      {
+        "kind": "OBJECT",
+        "name": "drip_dropMutation",
+        "fields": [
+          {
+            "name": "send",
+            "type": {
+              "kind": "NON_NULL",
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "String"
+              }
+            },
+            "args": [
+              {
+                "name": "address",
+                "type": {
+                  "kind": "NON_NULL",
+                  "ofType": {
+                    "kind": "SCALAR",
+                    "name": "String"
+                  }
+                }
+              },
+              {
+                "name": "captchaToken",
+                "type": {
+                  "kind": "NON_NULL",
+                  "ofType": {
+                    "kind": "SCALAR",
+                    "name": "String"
+                  }
+                }
+              },
+              {
+                "name": "chainId",
+                "type": {
+                  "kind": "NON_NULL",
+                  "ofType": {
+                    "kind": "SCALAR",
+                    "name": "String"
+                  }
+                }
+              },
+              {
+                "name": "denom",
+                "type": {
+                  "kind": "NON_NULL",
+                  "ofType": {
+                    "kind": "SCALAR",
+                    "name": "String"
+                  }
+                }
+              }
+            ],
+            "isDeprecated": false
+          }
+        ],
+        "interfaces": []
+      },
+      {
+        "kind": "OBJECT",
+        "name": "drip_dropQuery",
+        "fields": [
+          {
+            "name": "handledTransfers",
+            "type": {
+              "kind": "NON_NULL",
+              "ofType": {
+                "kind": "LIST",
+                "ofType": {
+                  "kind": "NON_NULL",
+                  "ofType": {
+                    "kind": "OBJECT",
+                    "name": "Request"
+                  }
+                }
+              }
+            },
+            "args": [
+              {
+                "name": "limit",
+                "type": {
+                  "kind": "SCALAR",
+                  "name": "Int"
+                }
+              },
+              {
+                "name": "offsetTime",
+                "type": {
+                  "kind": "SCALAR",
+                  "name": "String"
+                }
+              }
+            ],
+            "isDeprecated": false
+          },
+          {
+            "name": "transfersForAddress",
+            "type": {
+              "kind": "NON_NULL",
+              "ofType": {
+                "kind": "LIST",
+                "ofType": {
+                  "kind": "NON_NULL",
+                  "ofType": {
+                    "kind": "OBJECT",
+                    "name": "Request"
+                  }
+                }
+              }
+            },
+            "args": [
+              {
+                "name": "address",
+                "type": {
+                  "kind": "NON_NULL",
+                  "ofType": {
+                    "kind": "SCALAR",
+                    "name": "String"
+                  }
+                }
+              },
+              {
+                "name": "limit",
+                "type": {
+                  "kind": "SCALAR",
+                  "name": "Int"
+                }
+              },
+              {
+                "name": "offsetTime",
+                "type": {
+                  "kind": "SCALAR",
+                  "name": "String"
+                }
+              }
+            ],
+            "isDeprecated": false
+          },
+          {
+            "name": "unhandledTransfers",
+            "type": {
+              "kind": "NON_NULL",
+              "ofType": {
+                "kind": "LIST",
+                "ofType": {
+                  "kind": "NON_NULL",
+                  "ofType": {
+                    "kind": "OBJECT",
+                    "name": "Request"
+                  }
+                }
+              }
+            },
+            "args": [
+              {
+                "name": "limit",
+                "type": {
+                  "kind": "SCALAR",
+                  "name": "Int"
+                }
+              },
+              {
+                "name": "offsetTime",
+                "type": {
+                  "kind": "SCALAR",
+                  "name": "String"
+                }
+              }
+            ],
+            "isDeprecated": false
+          }
+        ],
+        "interfaces": []
+      },
+      {
+        "kind": "SCALAR",
+        "name": "jsonb"
+      },
+      {
+        "kind": "INPUT_OBJECT",
+        "name": "jsonb_cast_exp",
+        "inputFields": [
+          {
+            "name": "String",
+            "type": {
+              "kind": "INPUT_OBJECT",
+              "name": "String_comparison_exp"
+            }
+          }
+        ],
+        "isOneOf": false
+      },
+      {
+        "kind": "INPUT_OBJECT",
+        "name": "jsonb_comparison_exp",
+        "inputFields": [
+          {
+            "name": "_cast",
+            "type": {
+              "kind": "INPUT_OBJECT",
+              "name": "jsonb_cast_exp"
+            }
+          },
+          {
+            "name": "_contained_in",
+            "type": {
+              "kind": "SCALAR",
+              "name": "jsonb"
+            }
+          },
+          {
+            "name": "_contains",
+            "type": {
+              "kind": "SCALAR",
+              "name": "jsonb"
+            }
+          },
+          {
+            "name": "_eq",
+            "type": {
+              "kind": "SCALAR",
+              "name": "jsonb"
+            }
+          },
+          {
+            "name": "_gt",
+            "type": {
+              "kind": "SCALAR",
+              "name": "jsonb"
+            }
+          },
+          {
+            "name": "_gte",
+            "type": {
+              "kind": "SCALAR",
+              "name": "jsonb"
+            }
+          },
+          {
+            "name": "_has_key",
+            "type": {
+              "kind": "SCALAR",
+              "name": "String"
+            }
+          },
+          {
+            "name": "_has_keys_all",
+            "type": {
+              "kind": "LIST",
+              "ofType": {
+                "kind": "NON_NULL",
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String"
+                }
+              }
+            }
+          },
+          {
+            "name": "_has_keys_any",
+            "type": {
+              "kind": "LIST",
+              "ofType": {
+                "kind": "NON_NULL",
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String"
+                }
+              }
+            }
+          },
+          {
+            "name": "_in",
+            "type": {
+              "kind": "LIST",
+              "ofType": {
+                "kind": "NON_NULL",
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "jsonb"
+                }
+              }
+            }
+          },
+          {
+            "name": "_is_null",
+            "type": {
+              "kind": "SCALAR",
+              "name": "Boolean"
+            }
+          },
+          {
+            "name": "_lt",
+            "type": {
+              "kind": "SCALAR",
+              "name": "jsonb"
+            }
+          },
+          {
+            "name": "_lte",
+            "type": {
+              "kind": "SCALAR",
+              "name": "jsonb"
+            }
+          },
+          {
+            "name": "_neq",
+            "type": {
+              "kind": "SCALAR",
+              "name": "jsonb"
+            }
+          },
+          {
+            "name": "_nin",
+            "type": {
+              "kind": "LIST",
+              "ofType": {
+                "kind": "NON_NULL",
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "jsonb"
+                }
+              }
+            }
+          }
+        ],
+        "isOneOf": false
+      },
+      {
+        "kind": "SCALAR",
+        "name": "latency_percentiles_scalar"
+      },
+      {
+        "kind": "INPUT_OBJECT",
+        "name": "latency_percentiles_scalar_comparison_exp",
+        "inputFields": [
+          {
+            "name": "_eq",
+            "type": {
+              "kind": "SCALAR",
+              "name": "latency_percentiles_scalar"
+            }
+          },
+          {
+            "name": "_gt",
+            "type": {
+              "kind": "SCALAR",
+              "name": "latency_percentiles_scalar"
+            }
+          },
+          {
+            "name": "_gte",
+            "type": {
+              "kind": "SCALAR",
+              "name": "latency_percentiles_scalar"
+            }
+          },
+          {
+            "name": "_in",
+            "type": {
+              "kind": "LIST",
+              "ofType": {
+                "kind": "NON_NULL",
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "latency_percentiles_scalar"
+                }
+              }
+            }
+          },
+          {
+            "name": "_is_null",
+            "type": {
+              "kind": "SCALAR",
+              "name": "Boolean"
+            }
+          },
+          {
+            "name": "_lt",
+            "type": {
+              "kind": "SCALAR",
+              "name": "latency_percentiles_scalar"
+            }
+          },
+          {
+            "name": "_lte",
+            "type": {
+              "kind": "SCALAR",
+              "name": "latency_percentiles_scalar"
+            }
+          },
+          {
+            "name": "_neq",
+            "type": {
+              "kind": "SCALAR",
+              "name": "latency_percentiles_scalar"
+            }
+          },
+          {
+            "name": "_nin",
+            "type": {
+              "kind": "LIST",
+              "ofType": {
+                "kind": "NON_NULL",
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "latency_percentiles_scalar"
+                }
+              }
+            }
+          }
+        ],
+        "isOneOf": false
+      },
+      {
+        "kind": "OBJECT",
+        "name": "mutation_root",
+        "fields": [
+          {
+            "name": "drip_drop",
+            "type": {
+              "kind": "OBJECT",
+              "name": "drip_dropMutation"
+            },
+            "args": [],
+            "isDeprecated": false
+          }
+        ],
+        "interfaces": []
+      },
+      {
+        "kind": "ENUM",
+        "name": "order_by",
+        "enumValues": [
+          {
+            "name": "asc",
+            "isDeprecated": false
+          },
+          {
+            "name": "asc_nulls_first",
+            "isDeprecated": false
+          },
+          {
+            "name": "asc_nulls_last",
+            "isDeprecated": false
+          },
+          {
+            "name": "desc",
+            "isDeprecated": false
+          },
+          {
+            "name": "desc_nulls_first",
+            "isDeprecated": false
+          },
+          {
+            "name": "desc_nulls_last",
+            "isDeprecated": false
+          }
+        ]
+      },
+      {
+        "kind": "OBJECT",
+        "name": "query_root",
+        "fields": [
+          {
+            "name": "dashboard_balance_current",
+            "type": {
+              "kind": "NON_NULL",
+              "ofType": {
+                "kind": "LIST",
+                "ofType": {
+                  "kind": "NON_NULL",
+                  "ofType": {
+                    "kind": "OBJECT",
+                    "name": "dashboard_balance_current_type"
+                  }
+                }
+              }
+            },
+            "args": [
+              {
+                "name": "args",
+                "type": {
+                  "kind": "INPUT_OBJECT",
+                  "name": "dashboard_balance_current_args"
+                }
+              },
+              {
+                "name": "distinct_on",
+                "type": {
+                  "kind": "LIST",
+                  "ofType": {
+                    "kind": "NON_NULL",
+                    "ofType": {
+                      "kind": "ENUM",
+                      "name": "dashboard_balance_current_type_select_column"
+                    }
+                  }
+                }
+              },
+              {
+                "name": "limit",
+                "type": {
+                  "kind": "SCALAR",
+                  "name": "Int"
+                }
+              },
+              {
+                "name": "offset",
+                "type": {
+                  "kind": "SCALAR",
+                  "name": "Int"
+                }
+              },
+              {
+                "name": "order_by",
+                "type": {
+                  "kind": "LIST",
+                  "ofType": {
+                    "kind": "NON_NULL",
+                    "ofType": {
+                      "kind": "INPUT_OBJECT",
+                      "name": "dashboard_balance_current_type_order_by"
+                    }
+                  }
+                }
+              },
+              {
+                "name": "where",
+                "type": {
+                  "kind": "INPUT_OBJECT",
+                  "name": "dashboard_balance_current_type_bool_exp"
+                }
+              }
+            ],
+            "isDeprecated": false
+          },
+          {
+            "name": "dashboard_transfer_count_by_chain",
+            "type": {
+              "kind": "NON_NULL",
+              "ofType": {
+                "kind": "LIST",
+                "ofType": {
+                  "kind": "NON_NULL",
+                  "ofType": {
+                    "kind": "OBJECT",
+                    "name": "dashboard_count_by_chain_type"
+                  }
+                }
+              }
+            },
+            "args": [
+              {
+                "name": "args",
+                "type": {
+                  "kind": "NON_NULL",
+                  "ofType": {
+                    "kind": "INPUT_OBJECT",
+                    "name": "dashboard_transfer_count_by_chain_args"
+                  }
+                }
+              },
+              {
+                "name": "distinct_on",
+                "type": {
+                  "kind": "LIST",
+                  "ofType": {
+                    "kind": "NON_NULL",
+                    "ofType": {
+                      "kind": "ENUM",
+                      "name": "dashboard_count_by_chain_type_select_column"
+                    }
+                  }
+                }
+              },
+              {
+                "name": "limit",
+                "type": {
+                  "kind": "SCALAR",
+                  "name": "Int"
+                }
+              },
+              {
+                "name": "offset",
+                "type": {
+                  "kind": "SCALAR",
+                  "name": "Int"
+                }
+              },
+              {
+                "name": "order_by",
+                "type": {
+                  "kind": "LIST",
+                  "ofType": {
+                    "kind": "NON_NULL",
+                    "ofType": {
+                      "kind": "INPUT_OBJECT",
+                      "name": "dashboard_count_by_chain_type_order_by"
+                    }
+                  }
+                }
+              },
+              {
+                "name": "where",
+                "type": {
+                  "kind": "INPUT_OBJECT",
+                  "name": "dashboard_count_by_chain_type_bool_exp"
+                }
+              }
+            ],
+            "isDeprecated": false
+          },
+          {
+            "name": "dashboard_transfer_days_count_by_chain",
+            "type": {
+              "kind": "NON_NULL",
+              "ofType": {
+                "kind": "LIST",
+                "ofType": {
+                  "kind": "NON_NULL",
+                  "ofType": {
+                    "kind": "OBJECT",
+                    "name": "dashboard_days_by_chain_type"
+                  }
+                }
+              }
+            },
+            "args": [
+              {
+                "name": "args",
+                "type": {
+                  "kind": "NON_NULL",
+                  "ofType": {
+                    "kind": "INPUT_OBJECT",
+                    "name": "dashboard_transfer_days_count_by_chain_args"
+                  }
+                }
+              },
+              {
+                "name": "distinct_on",
+                "type": {
+                  "kind": "LIST",
+                  "ofType": {
+                    "kind": "NON_NULL",
+                    "ofType": {
+                      "kind": "ENUM",
+                      "name": "dashboard_days_by_chain_type_select_column"
+                    }
+                  }
+                }
+              },
+              {
+                "name": "limit",
+                "type": {
+                  "kind": "SCALAR",
+                  "name": "Int"
+                }
+              },
+              {
+                "name": "offset",
+                "type": {
+                  "kind": "SCALAR",
+                  "name": "Int"
+                }
+              },
+              {
+                "name": "order_by",
+                "type": {
+                  "kind": "LIST",
+                  "ofType": {
+                    "kind": "NON_NULL",
+                    "ofType": {
+                      "kind": "INPUT_OBJECT",
+                      "name": "dashboard_days_by_chain_type_order_by"
+                    }
+                  }
+                }
+              },
+              {
+                "name": "where",
+                "type": {
+                  "kind": "INPUT_OBJECT",
+                  "name": "dashboard_days_by_chain_type_bool_exp"
+                }
+              }
+            ],
+            "isDeprecated": false
+          },
+          {
+            "name": "drip_drop",
+            "type": {
+              "kind": "OBJECT",
+              "name": "drip_dropQuery"
+            },
+            "args": [],
+            "isDeprecated": false
+          },
+          {
+            "name": "v2_chains",
+            "type": {
+              "kind": "NON_NULL",
+              "ofType": {
+                "kind": "LIST",
+                "ofType": {
+                  "kind": "NON_NULL",
+                  "ofType": {
+                    "kind": "OBJECT",
+                    "name": "v2_chain_type"
+                  }
+                }
+              }
+            },
+            "args": [
+              {
+                "name": "args",
+                "type": {
+                  "kind": "INPUT_OBJECT",
+                  "name": "v2_chains_args"
+                }
+              },
+              {
+                "name": "distinct_on",
+                "type": {
+                  "kind": "LIST",
+                  "ofType": {
+                    "kind": "NON_NULL",
+                    "ofType": {
+                      "kind": "ENUM",
+                      "name": "v2_chain_type_select_column"
+                    }
+                  }
+                }
+              },
+              {
+                "name": "limit",
+                "type": {
+                  "kind": "SCALAR",
+                  "name": "Int"
+                }
+              },
+              {
+                "name": "offset",
+                "type": {
+                  "kind": "SCALAR",
+                  "name": "Int"
+                }
+              },
+              {
+                "name": "order_by",
+                "type": {
+                  "kind": "LIST",
+                  "ofType": {
+                    "kind": "NON_NULL",
+                    "ofType": {
+                      "kind": "INPUT_OBJECT",
+                      "name": "v2_chain_type_order_by"
+                    }
+                  }
+                }
+              },
+              {
+                "name": "where",
+                "type": {
+                  "kind": "INPUT_OBJECT",
+                  "name": "v2_chain_type_bool_exp"
+                }
+              }
+            ],
+            "isDeprecated": false
+          },
+          {
+            "name": "v2_channels",
+            "type": {
+              "kind": "NON_NULL",
+              "ofType": {
+                "kind": "LIST",
+                "ofType": {
+                  "kind": "NON_NULL",
+                  "ofType": {
+                    "kind": "OBJECT",
+                    "name": "v2_channel_type"
+                  }
+                }
+              }
+            },
+            "args": [
+              {
+                "name": "args",
+                "type": {
+                  "kind": "INPUT_OBJECT",
+                  "name": "v2_channels_args"
+                }
+              },
+              {
+                "name": "distinct_on",
+                "type": {
+                  "kind": "LIST",
+                  "ofType": {
+                    "kind": "NON_NULL",
+                    "ofType": {
+                      "kind": "ENUM",
+                      "name": "v2_channel_type_select_column"
+                    }
+                  }
+                }
+              },
+              {
+                "name": "limit",
+                "type": {
+                  "kind": "SCALAR",
+                  "name": "Int"
+                }
+              },
+              {
+                "name": "offset",
+                "type": {
+                  "kind": "SCALAR",
+                  "name": "Int"
+                }
+              },
+              {
+                "name": "order_by",
+                "type": {
+                  "kind": "LIST",
+                  "ofType": {
+                    "kind": "NON_NULL",
+                    "ofType": {
+                      "kind": "INPUT_OBJECT",
+                      "name": "v2_channel_type_order_by"
+                    }
+                  }
+                }
+              },
+              {
+                "name": "where",
+                "type": {
+                  "kind": "INPUT_OBJECT",
+                  "name": "v2_channel_type_bool_exp"
+                }
+              }
+            ],
+            "isDeprecated": false
+          },
+          {
+            "name": "v2_clients",
+            "type": {
+              "kind": "NON_NULL",
+              "ofType": {
+                "kind": "LIST",
+                "ofType": {
+                  "kind": "NON_NULL",
+                  "ofType": {
+                    "kind": "OBJECT",
+                    "name": "v2_client_type"
+                  }
+                }
+              }
+            },
+            "args": [
+              {
+                "name": "args",
+                "type": {
+                  "kind": "INPUT_OBJECT",
+                  "name": "v2_clients_args"
+                }
+              },
+              {
+                "name": "distinct_on",
+                "type": {
+                  "kind": "LIST",
+                  "ofType": {
+                    "kind": "NON_NULL",
+                    "ofType": {
+                      "kind": "ENUM",
+                      "name": "v2_client_type_select_column"
+                    }
+                  }
+                }
+              },
+              {
+                "name": "limit",
+                "type": {
+                  "kind": "SCALAR",
+                  "name": "Int"
+                }
+              },
+              {
+                "name": "offset",
+                "type": {
+                  "kind": "SCALAR",
+                  "name": "Int"
+                }
+              },
+              {
+                "name": "order_by",
+                "type": {
+                  "kind": "LIST",
+                  "ofType": {
+                    "kind": "NON_NULL",
+                    "ofType": {
+                      "kind": "INPUT_OBJECT",
+                      "name": "v2_client_type_order_by"
+                    }
+                  }
+                }
+              },
+              {
+                "name": "where",
+                "type": {
+                  "kind": "INPUT_OBJECT",
+                  "name": "v2_client_type_bool_exp"
+                }
+              }
+            ],
+            "isDeprecated": false
+          },
+          {
+            "name": "v2_connections",
+            "type": {
+              "kind": "NON_NULL",
+              "ofType": {
+                "kind": "LIST",
+                "ofType": {
+                  "kind": "NON_NULL",
+                  "ofType": {
+                    "kind": "OBJECT",
+                    "name": "v2_connection_type"
+                  }
+                }
+              }
+            },
+            "args": [
+              {
+                "name": "args",
+                "type": {
+                  "kind": "INPUT_OBJECT",
+                  "name": "v2_connections_args"
+                }
+              },
+              {
+                "name": "distinct_on",
+                "type": {
+                  "kind": "LIST",
+                  "ofType": {
+                    "kind": "NON_NULL",
+                    "ofType": {
+                      "kind": "ENUM",
+                      "name": "v2_connection_type_select_column"
+                    }
+                  }
+                }
+              },
+              {
+                "name": "limit",
+                "type": {
+                  "kind": "SCALAR",
+                  "name": "Int"
+                }
+              },
+              {
+                "name": "offset",
+                "type": {
+                  "kind": "SCALAR",
+                  "name": "Int"
+                }
+              },
+              {
+                "name": "order_by",
+                "type": {
+                  "kind": "LIST",
+                  "ofType": {
+                    "kind": "NON_NULL",
+                    "ofType": {
+                      "kind": "INPUT_OBJECT",
+                      "name": "v2_connection_type_order_by"
+                    }
+                  }
+                }
+              },
+              {
+                "name": "where",
+                "type": {
+                  "kind": "INPUT_OBJECT",
+                  "name": "v2_connection_type_bool_exp"
+                }
+              }
+            ],
+            "isDeprecated": false
+          },
+          {
+            "name": "v2_error_type",
+            "type": {
+              "kind": "NON_NULL",
+              "ofType": {
+                "kind": "LIST",
+                "ofType": {
+                  "kind": "NON_NULL",
+                  "ofType": {
+                    "kind": "OBJECT",
+                    "name": "v2_error_type"
+                  }
+                }
+              }
+            },
+            "args": [
+              {
+                "name": "distinct_on",
+                "type": {
+                  "kind": "LIST",
+                  "ofType": {
+                    "kind": "NON_NULL",
+                    "ofType": {
+                      "kind": "ENUM",
+                      "name": "v2_error_type_select_column"
+                    }
+                  }
+                }
+              },
+              {
+                "name": "limit",
+                "type": {
+                  "kind": "SCALAR",
+                  "name": "Int"
+                }
+              },
+              {
+                "name": "offset",
+                "type": {
+                  "kind": "SCALAR",
+                  "name": "Int"
+                }
+              },
+              {
+                "name": "order_by",
+                "type": {
+                  "kind": "LIST",
+                  "ofType": {
+                    "kind": "NON_NULL",
+                    "ofType": {
+                      "kind": "INPUT_OBJECT",
+                      "name": "v2_error_type_order_by"
+                    }
+                  }
+                }
+              },
+              {
+                "name": "where",
+                "type": {
+                  "kind": "INPUT_OBJECT",
+                  "name": "v2_error_type_bool_exp"
+                }
+              }
+            ],
+            "isDeprecated": false
+          },
+          {
+            "name": "v2_errors",
+            "type": {
+              "kind": "NON_NULL",
+              "ofType": {
+                "kind": "LIST",
+                "ofType": {
+                  "kind": "NON_NULL",
+                  "ofType": {
+                    "kind": "OBJECT",
+                    "name": "v2_error_type"
+                  }
+                }
+              }
+            },
+            "args": [
+              {
+                "name": "distinct_on",
+                "type": {
+                  "kind": "LIST",
+                  "ofType": {
+                    "kind": "NON_NULL",
+                    "ofType": {
+                      "kind": "ENUM",
+                      "name": "v2_error_type_select_column"
+                    }
+                  }
+                }
+              },
+              {
+                "name": "limit",
+                "type": {
+                  "kind": "SCALAR",
+                  "name": "Int"
+                }
+              },
+              {
+                "name": "offset",
+                "type": {
+                  "kind": "SCALAR",
+                  "name": "Int"
+                }
+              },
+              {
+                "name": "order_by",
+                "type": {
+                  "kind": "LIST",
+                  "ofType": {
+                    "kind": "NON_NULL",
+                    "ofType": {
+                      "kind": "INPUT_OBJECT",
+                      "name": "v2_error_type_order_by"
+                    }
+                  }
+                }
+              },
+              {
+                "name": "where",
+                "type": {
+                  "kind": "INPUT_OBJECT",
+                  "name": "v2_error_type_bool_exp"
+                }
+              }
+            ],
+            "isDeprecated": false
+          },
+          {
+            "name": "v2_health_check",
+            "type": {
+              "kind": "NON_NULL",
+              "ofType": {
+                "kind": "LIST",
+                "ofType": {
+                  "kind": "NON_NULL",
+                  "ofType": {
+                    "kind": "OBJECT",
+                    "name": "v2_health_check_type"
+                  }
+                }
+              }
+            },
+            "args": [
+              {
+                "name": "distinct_on",
+                "type": {
+                  "kind": "LIST",
+                  "ofType": {
+                    "kind": "NON_NULL",
+                    "ofType": {
+                      "kind": "ENUM",
+                      "name": "v2_health_check_type_select_column"
+                    }
+                  }
+                }
+              },
+              {
+                "name": "limit",
+                "type": {
+                  "kind": "SCALAR",
+                  "name": "Int"
+                }
+              },
+              {
+                "name": "offset",
+                "type": {
+                  "kind": "SCALAR",
+                  "name": "Int"
+                }
+              },
+              {
+                "name": "order_by",
+                "type": {
+                  "kind": "LIST",
+                  "ofType": {
+                    "kind": "NON_NULL",
+                    "ofType": {
+                      "kind": "INPUT_OBJECT",
+                      "name": "v2_health_check_type_order_by"
+                    }
+                  }
+                }
+              },
+              {
+                "name": "where",
+                "type": {
+                  "kind": "INPUT_OBJECT",
+                  "name": "v2_health_check_type_bool_exp"
+                }
+              }
+            ],
+            "isDeprecated": false
+          },
+          {
+            "name": "v2_instructions",
+            "type": {
+              "kind": "NON_NULL",
+              "ofType": {
+                "kind": "LIST",
+                "ofType": {
+                  "kind": "NON_NULL",
+                  "ofType": {
+                    "kind": "OBJECT",
+                    "name": "v2_instruction_type"
+                  }
+                }
+              }
+            },
+            "args": [
+              {
+                "name": "args",
+                "type": {
+                  "kind": "INPUT_OBJECT",
+                  "name": "v2_instructions_args"
+                }
+              },
+              {
+                "name": "distinct_on",
+                "type": {
+                  "kind": "LIST",
+                  "ofType": {
+                    "kind": "NON_NULL",
+                    "ofType": {
+                      "kind": "ENUM",
+                      "name": "v2_instruction_type_select_column"
+                    }
+                  }
+                }
+              },
+              {
+                "name": "limit",
+                "type": {
+                  "kind": "SCALAR",
+                  "name": "Int"
+                }
+              },
+              {
+                "name": "offset",
+                "type": {
+                  "kind": "SCALAR",
+                  "name": "Int"
+                }
+              },
+              {
+                "name": "order_by",
+                "type": {
+                  "kind": "LIST",
+                  "ofType": {
+                    "kind": "NON_NULL",
+                    "ofType": {
+                      "kind": "INPUT_OBJECT",
+                      "name": "v2_instruction_type_order_by"
+                    }
+                  }
+                }
+              },
+              {
+                "name": "where",
+                "type": {
+                  "kind": "INPUT_OBJECT",
+                  "name": "v2_instruction_type_bool_exp"
+                }
+              }
+            ],
+            "isDeprecated": false
+          },
+          {
+            "name": "v2_packets",
+            "type": {
+              "kind": "NON_NULL",
+              "ofType": {
+                "kind": "LIST",
+                "ofType": {
+                  "kind": "NON_NULL",
+                  "ofType": {
+                    "kind": "OBJECT",
+                    "name": "v2_packet_type"
+                  }
+                }
+              }
+            },
+            "args": [
+              {
+                "name": "args",
+                "type": {
+                  "kind": "INPUT_OBJECT",
+                  "name": "v2_packets_args"
+                }
+              },
+              {
+                "name": "distinct_on",
+                "type": {
+                  "kind": "LIST",
+                  "ofType": {
+                    "kind": "NON_NULL",
+                    "ofType": {
+                      "kind": "ENUM",
+                      "name": "v2_packet_type_select_column"
+                    }
+                  }
+                }
+              },
+              {
+                "name": "limit",
+                "type": {
+                  "kind": "SCALAR",
+                  "name": "Int"
+                }
+              },
+              {
+                "name": "offset",
+                "type": {
+                  "kind": "SCALAR",
+                  "name": "Int"
+                }
+              },
+              {
+                "name": "order_by",
+                "type": {
+                  "kind": "LIST",
+                  "ofType": {
+                    "kind": "NON_NULL",
+                    "ofType": {
+                      "kind": "INPUT_OBJECT",
+                      "name": "v2_packet_type_order_by"
+                    }
+                  }
+                }
+              },
+              {
+                "name": "where",
+                "type": {
+                  "kind": "INPUT_OBJECT",
+                  "name": "v2_packet_type_bool_exp"
+                }
+              }
+            ],
+            "isDeprecated": false
+          },
+          {
+            "name": "v2_stats_count",
+            "type": {
+              "kind": "NON_NULL",
+              "ofType": {
+                "kind": "LIST",
+                "ofType": {
+                  "kind": "NON_NULL",
+                  "ofType": {
+                    "kind": "OBJECT",
+                    "name": "v2_stats_type"
+                  }
+                }
+              }
+            },
+            "args": [
+              {
+                "name": "distinct_on",
+                "type": {
+                  "kind": "LIST",
+                  "ofType": {
+                    "kind": "NON_NULL",
+                    "ofType": {
+                      "kind": "ENUM",
+                      "name": "v2_stats_type_select_column"
+                    }
+                  }
+                }
+              },
+              {
+                "name": "limit",
+                "type": {
+                  "kind": "SCALAR",
+                  "name": "Int"
+                }
+              },
+              {
+                "name": "offset",
+                "type": {
+                  "kind": "SCALAR",
+                  "name": "Int"
+                }
+              },
+              {
+                "name": "order_by",
+                "type": {
+                  "kind": "LIST",
+                  "ofType": {
+                    "kind": "NON_NULL",
+                    "ofType": {
+                      "kind": "INPUT_OBJECT",
+                      "name": "v2_stats_type_order_by"
+                    }
+                  }
+                }
+              },
+              {
+                "name": "where",
+                "type": {
+                  "kind": "INPUT_OBJECT",
+                  "name": "v2_stats_type_bool_exp"
+                }
+              }
+            ],
+            "isDeprecated": false
+          },
+          {
+            "name": "v2_stats_latency",
+            "type": {
+              "kind": "NON_NULL",
+              "ofType": {
+                "kind": "LIST",
+                "ofType": {
+                  "kind": "NON_NULL",
+                  "ofType": {
+                    "kind": "OBJECT",
+                    "name": "v2_stats_latency_type"
+                  }
+                }
+              }
+            },
+            "args": [
+              {
+                "name": "args",
+                "type": {
+                  "kind": "NON_NULL",
+                  "ofType": {
+                    "kind": "INPUT_OBJECT",
+                    "name": "v2_stats_latency_args"
+                  }
+                }
+              },
+              {
+                "name": "distinct_on",
+                "type": {
+                  "kind": "LIST",
+                  "ofType": {
+                    "kind": "NON_NULL",
+                    "ofType": {
+                      "kind": "ENUM",
+                      "name": "v2_stats_latency_type_select_column"
+                    }
+                  }
+                }
+              },
+              {
+                "name": "limit",
+                "type": {
+                  "kind": "SCALAR",
+                  "name": "Int"
+                }
+              },
+              {
+                "name": "offset",
+                "type": {
+                  "kind": "SCALAR",
+                  "name": "Int"
+                }
+              },
+              {
+                "name": "order_by",
+                "type": {
+                  "kind": "LIST",
+                  "ofType": {
+                    "kind": "NON_NULL",
+                    "ofType": {
+                      "kind": "INPUT_OBJECT",
+                      "name": "v2_stats_latency_type_order_by"
+                    }
+                  }
+                }
+              },
+              {
+                "name": "where",
+                "type": {
+                  "kind": "INPUT_OBJECT",
+                  "name": "v2_stats_latency_type_bool_exp"
+                }
+              }
+            ],
+            "isDeprecated": false
+          },
+          {
+            "name": "v2_stats_packets_chain",
+            "type": {
+              "kind": "NON_NULL",
+              "ofType": {
+                "kind": "LIST",
+                "ofType": {
+                  "kind": "NON_NULL",
+                  "ofType": {
+                    "kind": "OBJECT",
+                    "name": "v2_stats_packets_chain_type"
+                  }
+                }
+              }
+            },
+            "args": [
+              {
+                "name": "args",
+                "type": {
+                  "kind": "INPUT_OBJECT",
+                  "name": "v2_stats_packets_chain_args"
+                }
+              },
+              {
+                "name": "distinct_on",
+                "type": {
+                  "kind": "LIST",
+                  "ofType": {
+                    "kind": "NON_NULL",
+                    "ofType": {
+                      "kind": "ENUM",
+                      "name": "v2_stats_packets_chain_type_select_column"
+                    }
+                  }
+                }
+              },
+              {
+                "name": "limit",
+                "type": {
+                  "kind": "SCALAR",
+                  "name": "Int"
+                }
+              },
+              {
+                "name": "offset",
+                "type": {
+                  "kind": "SCALAR",
+                  "name": "Int"
+                }
+              },
+              {
+                "name": "order_by",
+                "type": {
+                  "kind": "LIST",
+                  "ofType": {
+                    "kind": "NON_NULL",
+                    "ofType": {
+                      "kind": "INPUT_OBJECT",
+                      "name": "v2_stats_packets_chain_type_order_by"
+                    }
+                  }
+                }
+              },
+              {
+                "name": "where",
+                "type": {
+                  "kind": "INPUT_OBJECT",
+                  "name": "v2_stats_packets_chain_type_bool_exp"
+                }
+              }
+            ],
+            "isDeprecated": false
+          },
+          {
+            "name": "v2_stats_packets_daily_count",
+            "type": {
+              "kind": "NON_NULL",
+              "ofType": {
+                "kind": "LIST",
+                "ofType": {
+                  "kind": "NON_NULL",
+                  "ofType": {
+                    "kind": "OBJECT",
+                    "name": "v2_stats_daily_count_type"
+                  }
+                }
+              }
+            },
+            "args": [
+              {
+                "name": "args",
+                "type": {
+                  "kind": "INPUT_OBJECT",
+                  "name": "v2_stats_packets_daily_count_args"
+                }
+              },
+              {
+                "name": "distinct_on",
+                "type": {
+                  "kind": "LIST",
+                  "ofType": {
+                    "kind": "NON_NULL",
+                    "ofType": {
+                      "kind": "ENUM",
+                      "name": "v2_stats_daily_count_type_select_column"
+                    }
+                  }
+                }
+              },
+              {
+                "name": "limit",
+                "type": {
+                  "kind": "SCALAR",
+                  "name": "Int"
+                }
+              },
+              {
+                "name": "offset",
+                "type": {
+                  "kind": "SCALAR",
+                  "name": "Int"
+                }
+              },
+              {
+                "name": "order_by",
+                "type": {
+                  "kind": "LIST",
+                  "ofType": {
+                    "kind": "NON_NULL",
+                    "ofType": {
+                      "kind": "INPUT_OBJECT",
+                      "name": "v2_stats_daily_count_type_order_by"
+                    }
+                  }
+                }
+              },
+              {
+                "name": "where",
+                "type": {
+                  "kind": "INPUT_OBJECT",
+                  "name": "v2_stats_daily_count_type_bool_exp"
+                }
+              }
+            ],
+            "isDeprecated": false
+          },
+          {
+            "name": "v2_stats_transfers_address",
+            "type": {
+              "kind": "NON_NULL",
+              "ofType": {
+                "kind": "LIST",
+                "ofType": {
+                  "kind": "NON_NULL",
+                  "ofType": {
+                    "kind": "OBJECT",
+                    "name": "v2_stats_transfers_address_type"
+                  }
+                }
+              }
+            },
+            "args": [
+              {
+                "name": "args",
+                "type": {
+                  "kind": "NON_NULL",
+                  "ofType": {
+                    "kind": "INPUT_OBJECT",
+                    "name": "v2_stats_transfers_address_args"
+                  }
+                }
+              },
+              {
+                "name": "distinct_on",
+                "type": {
+                  "kind": "LIST",
+                  "ofType": {
+                    "kind": "NON_NULL",
+                    "ofType": {
+                      "kind": "ENUM",
+                      "name": "v2_stats_transfers_address_type_select_column"
+                    }
+                  }
+                }
+              },
+              {
+                "name": "limit",
+                "type": {
+                  "kind": "SCALAR",
+                  "name": "Int"
+                }
+              },
+              {
+                "name": "offset",
+                "type": {
+                  "kind": "SCALAR",
+                  "name": "Int"
+                }
+              },
+              {
+                "name": "order_by",
+                "type": {
+                  "kind": "LIST",
+                  "ofType": {
+                    "kind": "NON_NULL",
+                    "ofType": {
+                      "kind": "INPUT_OBJECT",
+                      "name": "v2_stats_transfers_address_type_order_by"
+                    }
+                  }
+                }
+              },
+              {
+                "name": "where",
+                "type": {
+                  "kind": "INPUT_OBJECT",
+                  "name": "v2_stats_transfers_address_type_bool_exp"
+                }
+              }
+            ],
+            "isDeprecated": false
+          },
+          {
+            "name": "v2_stats_transfers_chain",
+            "type": {
+              "kind": "NON_NULL",
+              "ofType": {
+                "kind": "LIST",
+                "ofType": {
+                  "kind": "NON_NULL",
+                  "ofType": {
+                    "kind": "OBJECT",
+                    "name": "v2_stats_transfers_chain_type"
+                  }
+                }
+              }
+            },
+            "args": [
+              {
+                "name": "args",
+                "type": {
+                  "kind": "INPUT_OBJECT",
+                  "name": "v2_stats_transfers_chain_args"
+                }
+              },
+              {
+                "name": "distinct_on",
+                "type": {
+                  "kind": "LIST",
+                  "ofType": {
+                    "kind": "NON_NULL",
+                    "ofType": {
+                      "kind": "ENUM",
+                      "name": "v2_stats_transfers_chain_type_select_column"
+                    }
+                  }
+                }
+              },
+              {
+                "name": "limit",
+                "type": {
+                  "kind": "SCALAR",
+                  "name": "Int"
+                }
+              },
+              {
+                "name": "offset",
+                "type": {
+                  "kind": "SCALAR",
+                  "name": "Int"
+                }
+              },
+              {
+                "name": "order_by",
+                "type": {
+                  "kind": "LIST",
+                  "ofType": {
+                    "kind": "NON_NULL",
+                    "ofType": {
+                      "kind": "INPUT_OBJECT",
+                      "name": "v2_stats_transfers_chain_type_order_by"
+                    }
+                  }
+                }
+              },
+              {
+                "name": "where",
+                "type": {
+                  "kind": "INPUT_OBJECT",
+                  "name": "v2_stats_transfers_chain_type_bool_exp"
+                }
+              }
+            ],
+            "isDeprecated": false
+          },
+          {
+            "name": "v2_stats_transfers_daily_count",
+            "type": {
+              "kind": "NON_NULL",
+              "ofType": {
+                "kind": "LIST",
+                "ofType": {
+                  "kind": "NON_NULL",
+                  "ofType": {
+                    "kind": "OBJECT",
+                    "name": "v2_stats_daily_count_type"
+                  }
+                }
+              }
+            },
+            "args": [
+              {
+                "name": "args",
+                "type": {
+                  "kind": "INPUT_OBJECT",
+                  "name": "v2_stats_transfers_daily_count_args"
+                }
+              },
+              {
+                "name": "distinct_on",
+                "type": {
+                  "kind": "LIST",
+                  "ofType": {
+                    "kind": "NON_NULL",
+                    "ofType": {
+                      "kind": "ENUM",
+                      "name": "v2_stats_daily_count_type_select_column"
+                    }
+                  }
+                }
+              },
+              {
+                "name": "limit",
+                "type": {
+                  "kind": "SCALAR",
+                  "name": "Int"
+                }
+              },
+              {
+                "name": "offset",
+                "type": {
+                  "kind": "SCALAR",
+                  "name": "Int"
+                }
+              },
+              {
+                "name": "order_by",
+                "type": {
+                  "kind": "LIST",
+                  "ofType": {
+                    "kind": "NON_NULL",
+                    "ofType": {
+                      "kind": "INPUT_OBJECT",
+                      "name": "v2_stats_daily_count_type_order_by"
+                    }
+                  }
+                }
+              },
+              {
+                "name": "where",
+                "type": {
+                  "kind": "INPUT_OBJECT",
+                  "name": "v2_stats_daily_count_type_bool_exp"
+                }
+              }
+            ],
+            "isDeprecated": false
+          },
+          {
+            "name": "v2_tokens",
+            "type": {
+              "kind": "NON_NULL",
+              "ofType": {
+                "kind": "LIST",
+                "ofType": {
+                  "kind": "NON_NULL",
+                  "ofType": {
+                    "kind": "OBJECT",
+                    "name": "v2_token_meta"
+                  }
+                }
+              }
+            },
+            "args": [
+              {
+                "name": "args",
+                "type": {
+                  "kind": "INPUT_OBJECT",
+                  "name": "v2_tokens_args"
+                }
+              },
+              {
+                "name": "distinct_on",
+                "type": {
+                  "kind": "LIST",
+                  "ofType": {
+                    "kind": "NON_NULL",
+                    "ofType": {
+                      "kind": "ENUM",
+                      "name": "v2_token_meta_select_column"
+                    }
+                  }
+                }
+              },
+              {
+                "name": "limit",
+                "type": {
+                  "kind": "SCALAR",
+                  "name": "Int"
+                }
+              },
+              {
+                "name": "offset",
+                "type": {
+                  "kind": "SCALAR",
+                  "name": "Int"
+                }
+              },
+              {
+                "name": "order_by",
+                "type": {
+                  "kind": "LIST",
+                  "ofType": {
+                    "kind": "NON_NULL",
+                    "ofType": {
+                      "kind": "INPUT_OBJECT",
+                      "name": "v2_token_meta_order_by"
+                    }
+                  }
+                }
+              },
+              {
+                "name": "where",
+                "type": {
+                  "kind": "INPUT_OBJECT",
+                  "name": "v2_token_meta_bool_exp"
+                }
+              }
+            ],
+            "isDeprecated": false
+          },
+          {
+            "name": "v2_transfers",
+            "type": {
+              "kind": "NON_NULL",
+              "ofType": {
+                "kind": "LIST",
+                "ofType": {
+                  "kind": "NON_NULL",
+                  "ofType": {
+                    "kind": "OBJECT",
+                    "name": "v2_transfer_type"
+                  }
+                }
+              }
+            },
+            "args": [
+              {
+                "name": "args",
+                "type": {
+                  "kind": "INPUT_OBJECT",
+                  "name": "v2_transfers_args"
+                }
+              },
+              {
+                "name": "distinct_on",
+                "type": {
+                  "kind": "LIST",
+                  "ofType": {
+                    "kind": "NON_NULL",
+                    "ofType": {
+                      "kind": "ENUM",
+                      "name": "v2_transfer_type_select_column"
+                    }
+                  }
+                }
+              },
+              {
+                "name": "limit",
+                "type": {
+                  "kind": "SCALAR",
+                  "name": "Int"
+                }
+              },
+              {
+                "name": "offset",
+                "type": {
+                  "kind": "SCALAR",
+                  "name": "Int"
+                }
+              },
+              {
+                "name": "order_by",
+                "type": {
+                  "kind": "LIST",
+                  "ofType": {
+                    "kind": "NON_NULL",
+                    "ofType": {
+                      "kind": "INPUT_OBJECT",
+                      "name": "v2_transfer_type_order_by"
+                    }
+                  }
+                }
+              },
+              {
+                "name": "where",
+                "type": {
+                  "kind": "INPUT_OBJECT",
+                  "name": "v2_transfer_type_bool_exp"
+                }
+              }
+            ],
+            "isDeprecated": false
+          },
+          {
+            "name": "v2_util_get_address_types_for_display_address",
+            "type": {
+              "kind": "NON_NULL",
+              "ofType": {
+                "kind": "LIST",
+                "ofType": {
+                  "kind": "NON_NULL",
+                  "ofType": {
+                    "kind": "OBJECT",
+                    "name": "v2_util_get_address_types_for_display_address_type"
+                  }
+                }
+              }
+            },
+            "args": [
+              {
+                "name": "args",
+                "type": {
+                  "kind": "NON_NULL",
+                  "ofType": {
+                    "kind": "INPUT_OBJECT",
+                    "name": "v2_util_get_address_types_for_display_address_args"
+                  }
+                }
+              },
+              {
+                "name": "distinct_on",
+                "type": {
+                  "kind": "LIST",
+                  "ofType": {
+                    "kind": "NON_NULL",
+                    "ofType": {
+                      "kind": "ENUM",
+                      "name": "v2_util_get_address_types_for_display_address_type_select_column"
+                    }
+                  }
+                }
+              },
+              {
+                "name": "limit",
+                "type": {
+                  "kind": "SCALAR",
+                  "name": "Int"
+                }
+              },
+              {
+                "name": "offset",
+                "type": {
+                  "kind": "SCALAR",
+                  "name": "Int"
+                }
+              },
+              {
+                "name": "order_by",
+                "type": {
+                  "kind": "LIST",
+                  "ofType": {
+                    "kind": "NON_NULL",
+                    "ofType": {
+                      "kind": "INPUT_OBJECT",
+                      "name": "v2_util_get_address_types_for_display_address_type_order_by"
+                    }
+                  }
+                }
+              },
+              {
+                "name": "where",
+                "type": {
+                  "kind": "INPUT_OBJECT",
+                  "name": "v2_util_get_address_types_for_display_address_type_bool_exp"
+                }
+              }
+            ],
+            "isDeprecated": false
+          },
+          {
+            "name": "v2_util_get_transfer_request_details",
+            "type": {
+              "kind": "NON_NULL",
+              "ofType": {
+                "kind": "LIST",
+                "ofType": {
+                  "kind": "NON_NULL",
+                  "ofType": {
+                    "kind": "OBJECT",
+                    "name": "v2_util_get_transfer_request_details_type"
+                  }
+                }
+              }
+            },
+            "args": [
+              {
+                "name": "args",
+                "type": {
+                  "kind": "NON_NULL",
+                  "ofType": {
+                    "kind": "INPUT_OBJECT",
+                    "name": "v2_util_get_transfer_request_details_args"
+                  }
+                }
+              },
+              {
+                "name": "distinct_on",
+                "type": {
+                  "kind": "LIST",
+                  "ofType": {
+                    "kind": "NON_NULL",
+                    "ofType": {
+                      "kind": "ENUM",
+                      "name": "v2_util_get_transfer_request_details_type_select_column"
+                    }
+                  }
+                }
+              },
+              {
+                "name": "limit",
+                "type": {
+                  "kind": "SCALAR",
+                  "name": "Int"
+                }
+              },
+              {
+                "name": "offset",
+                "type": {
+                  "kind": "SCALAR",
+                  "name": "Int"
+                }
+              },
+              {
+                "name": "order_by",
+                "type": {
+                  "kind": "LIST",
+                  "ofType": {
+                    "kind": "NON_NULL",
+                    "ofType": {
+                      "kind": "INPUT_OBJECT",
+                      "name": "v2_util_get_transfer_request_details_type_order_by"
+                    }
+                  }
+                }
+              },
+              {
+                "name": "where",
+                "type": {
+                  "kind": "INPUT_OBJECT",
+                  "name": "v2_util_get_transfer_request_details_type_bool_exp"
+                }
+              }
+            ],
+            "isDeprecated": false
+          }
+        ],
+        "interfaces": []
+      },
+      {
+        "kind": "OBJECT",
+        "name": "subscription_root",
+        "fields": [
+          {
+            "name": "dashboard_balance_current",
+            "type": {
+              "kind": "NON_NULL",
+              "ofType": {
+                "kind": "LIST",
+                "ofType": {
+                  "kind": "NON_NULL",
+                  "ofType": {
+                    "kind": "OBJECT",
+                    "name": "dashboard_balance_current_type"
+                  }
+                }
+              }
+            },
+            "args": [
+              {
+                "name": "args",
+                "type": {
+                  "kind": "INPUT_OBJECT",
+                  "name": "dashboard_balance_current_args"
+                }
+              },
+              {
+                "name": "distinct_on",
+                "type": {
+                  "kind": "LIST",
+                  "ofType": {
+                    "kind": "NON_NULL",
+                    "ofType": {
+                      "kind": "ENUM",
+                      "name": "dashboard_balance_current_type_select_column"
+                    }
+                  }
+                }
+              },
+              {
+                "name": "limit",
+                "type": {
+                  "kind": "SCALAR",
+                  "name": "Int"
+                }
+              },
+              {
+                "name": "offset",
+                "type": {
+                  "kind": "SCALAR",
+                  "name": "Int"
+                }
+              },
+              {
+                "name": "order_by",
+                "type": {
+                  "kind": "LIST",
+                  "ofType": {
+                    "kind": "NON_NULL",
+                    "ofType": {
+                      "kind": "INPUT_OBJECT",
+                      "name": "dashboard_balance_current_type_order_by"
+                    }
+                  }
+                }
+              },
+              {
+                "name": "where",
+                "type": {
+                  "kind": "INPUT_OBJECT",
+                  "name": "dashboard_balance_current_type_bool_exp"
+                }
+              }
+            ],
+            "isDeprecated": false
+          },
+          {
+            "name": "dashboard_transfer_count_by_chain",
+            "type": {
+              "kind": "NON_NULL",
+              "ofType": {
+                "kind": "LIST",
+                "ofType": {
+                  "kind": "NON_NULL",
+                  "ofType": {
+                    "kind": "OBJECT",
+                    "name": "dashboard_count_by_chain_type"
+                  }
+                }
+              }
+            },
+            "args": [
+              {
+                "name": "args",
+                "type": {
+                  "kind": "NON_NULL",
+                  "ofType": {
+                    "kind": "INPUT_OBJECT",
+                    "name": "dashboard_transfer_count_by_chain_args"
+                  }
+                }
+              },
+              {
+                "name": "distinct_on",
+                "type": {
+                  "kind": "LIST",
+                  "ofType": {
+                    "kind": "NON_NULL",
+                    "ofType": {
+                      "kind": "ENUM",
+                      "name": "dashboard_count_by_chain_type_select_column"
+                    }
+                  }
+                }
+              },
+              {
+                "name": "limit",
+                "type": {
+                  "kind": "SCALAR",
+                  "name": "Int"
+                }
+              },
+              {
+                "name": "offset",
+                "type": {
+                  "kind": "SCALAR",
+                  "name": "Int"
+                }
+              },
+              {
+                "name": "order_by",
+                "type": {
+                  "kind": "LIST",
+                  "ofType": {
+                    "kind": "NON_NULL",
+                    "ofType": {
+                      "kind": "INPUT_OBJECT",
+                      "name": "dashboard_count_by_chain_type_order_by"
+                    }
+                  }
+                }
+              },
+              {
+                "name": "where",
+                "type": {
+                  "kind": "INPUT_OBJECT",
+                  "name": "dashboard_count_by_chain_type_bool_exp"
+                }
+              }
+            ],
+            "isDeprecated": false
+          },
+          {
+            "name": "dashboard_transfer_days_count_by_chain",
+            "type": {
+              "kind": "NON_NULL",
+              "ofType": {
+                "kind": "LIST",
+                "ofType": {
+                  "kind": "NON_NULL",
+                  "ofType": {
+                    "kind": "OBJECT",
+                    "name": "dashboard_days_by_chain_type"
+                  }
+                }
+              }
+            },
+            "args": [
+              {
+                "name": "args",
+                "type": {
+                  "kind": "NON_NULL",
+                  "ofType": {
+                    "kind": "INPUT_OBJECT",
+                    "name": "dashboard_transfer_days_count_by_chain_args"
+                  }
+                }
+              },
+              {
+                "name": "distinct_on",
+                "type": {
+                  "kind": "LIST",
+                  "ofType": {
+                    "kind": "NON_NULL",
+                    "ofType": {
+                      "kind": "ENUM",
+                      "name": "dashboard_days_by_chain_type_select_column"
+                    }
+                  }
+                }
+              },
+              {
+                "name": "limit",
+                "type": {
+                  "kind": "SCALAR",
+                  "name": "Int"
+                }
+              },
+              {
+                "name": "offset",
+                "type": {
+                  "kind": "SCALAR",
+                  "name": "Int"
+                }
+              },
+              {
+                "name": "order_by",
+                "type": {
+                  "kind": "LIST",
+                  "ofType": {
+                    "kind": "NON_NULL",
+                    "ofType": {
+                      "kind": "INPUT_OBJECT",
+                      "name": "dashboard_days_by_chain_type_order_by"
+                    }
+                  }
+                }
+              },
+              {
+                "name": "where",
+                "type": {
+                  "kind": "INPUT_OBJECT",
+                  "name": "dashboard_days_by_chain_type_bool_exp"
+                }
+              }
+            ],
+            "isDeprecated": false
+          },
+          {
+            "name": "v2_chains",
+            "type": {
+              "kind": "NON_NULL",
+              "ofType": {
+                "kind": "LIST",
+                "ofType": {
+                  "kind": "NON_NULL",
+                  "ofType": {
+                    "kind": "OBJECT",
+                    "name": "v2_chain_type"
+                  }
+                }
+              }
+            },
+            "args": [
+              {
+                "name": "args",
+                "type": {
+                  "kind": "INPUT_OBJECT",
+                  "name": "v2_chains_args"
+                }
+              },
+              {
+                "name": "distinct_on",
+                "type": {
+                  "kind": "LIST",
+                  "ofType": {
+                    "kind": "NON_NULL",
+                    "ofType": {
+                      "kind": "ENUM",
+                      "name": "v2_chain_type_select_column"
+                    }
+                  }
+                }
+              },
+              {
+                "name": "limit",
+                "type": {
+                  "kind": "SCALAR",
+                  "name": "Int"
+                }
+              },
+              {
+                "name": "offset",
+                "type": {
+                  "kind": "SCALAR",
+                  "name": "Int"
+                }
+              },
+              {
+                "name": "order_by",
+                "type": {
+                  "kind": "LIST",
+                  "ofType": {
+                    "kind": "NON_NULL",
+                    "ofType": {
+                      "kind": "INPUT_OBJECT",
+                      "name": "v2_chain_type_order_by"
+                    }
+                  }
+                }
+              },
+              {
+                "name": "where",
+                "type": {
+                  "kind": "INPUT_OBJECT",
+                  "name": "v2_chain_type_bool_exp"
+                }
+              }
+            ],
+            "isDeprecated": false
+          },
+          {
+            "name": "v2_channels",
+            "type": {
+              "kind": "NON_NULL",
+              "ofType": {
+                "kind": "LIST",
+                "ofType": {
+                  "kind": "NON_NULL",
+                  "ofType": {
+                    "kind": "OBJECT",
+                    "name": "v2_channel_type"
+                  }
+                }
+              }
+            },
+            "args": [
+              {
+                "name": "args",
+                "type": {
+                  "kind": "INPUT_OBJECT",
+                  "name": "v2_channels_args"
+                }
+              },
+              {
+                "name": "distinct_on",
+                "type": {
+                  "kind": "LIST",
+                  "ofType": {
+                    "kind": "NON_NULL",
+                    "ofType": {
+                      "kind": "ENUM",
+                      "name": "v2_channel_type_select_column"
+                    }
+                  }
+                }
+              },
+              {
+                "name": "limit",
+                "type": {
+                  "kind": "SCALAR",
+                  "name": "Int"
+                }
+              },
+              {
+                "name": "offset",
+                "type": {
+                  "kind": "SCALAR",
+                  "name": "Int"
+                }
+              },
+              {
+                "name": "order_by",
+                "type": {
+                  "kind": "LIST",
+                  "ofType": {
+                    "kind": "NON_NULL",
+                    "ofType": {
+                      "kind": "INPUT_OBJECT",
+                      "name": "v2_channel_type_order_by"
+                    }
+                  }
+                }
+              },
+              {
+                "name": "where",
+                "type": {
+                  "kind": "INPUT_OBJECT",
+                  "name": "v2_channel_type_bool_exp"
+                }
+              }
+            ],
+            "isDeprecated": false
+          },
+          {
+            "name": "v2_clients",
+            "type": {
+              "kind": "NON_NULL",
+              "ofType": {
+                "kind": "LIST",
+                "ofType": {
+                  "kind": "NON_NULL",
+                  "ofType": {
+                    "kind": "OBJECT",
+                    "name": "v2_client_type"
+                  }
+                }
+              }
+            },
+            "args": [
+              {
+                "name": "args",
+                "type": {
+                  "kind": "INPUT_OBJECT",
+                  "name": "v2_clients_args"
+                }
+              },
+              {
+                "name": "distinct_on",
+                "type": {
+                  "kind": "LIST",
+                  "ofType": {
+                    "kind": "NON_NULL",
+                    "ofType": {
+                      "kind": "ENUM",
+                      "name": "v2_client_type_select_column"
+                    }
+                  }
+                }
+              },
+              {
+                "name": "limit",
+                "type": {
+                  "kind": "SCALAR",
+                  "name": "Int"
+                }
+              },
+              {
+                "name": "offset",
+                "type": {
+                  "kind": "SCALAR",
+                  "name": "Int"
+                }
+              },
+              {
+                "name": "order_by",
+                "type": {
+                  "kind": "LIST",
+                  "ofType": {
+                    "kind": "NON_NULL",
+                    "ofType": {
+                      "kind": "INPUT_OBJECT",
+                      "name": "v2_client_type_order_by"
+                    }
+                  }
+                }
+              },
+              {
+                "name": "where",
+                "type": {
+                  "kind": "INPUT_OBJECT",
+                  "name": "v2_client_type_bool_exp"
+                }
+              }
+            ],
+            "isDeprecated": false
+          },
+          {
+            "name": "v2_connections",
+            "type": {
+              "kind": "NON_NULL",
+              "ofType": {
+                "kind": "LIST",
+                "ofType": {
+                  "kind": "NON_NULL",
+                  "ofType": {
+                    "kind": "OBJECT",
+                    "name": "v2_connection_type"
+                  }
+                }
+              }
+            },
+            "args": [
+              {
+                "name": "args",
+                "type": {
+                  "kind": "INPUT_OBJECT",
+                  "name": "v2_connections_args"
+                }
+              },
+              {
+                "name": "distinct_on",
+                "type": {
+                  "kind": "LIST",
+                  "ofType": {
+                    "kind": "NON_NULL",
+                    "ofType": {
+                      "kind": "ENUM",
+                      "name": "v2_connection_type_select_column"
+                    }
+                  }
+                }
+              },
+              {
+                "name": "limit",
+                "type": {
+                  "kind": "SCALAR",
+                  "name": "Int"
+                }
+              },
+              {
+                "name": "offset",
+                "type": {
+                  "kind": "SCALAR",
+                  "name": "Int"
+                }
+              },
+              {
+                "name": "order_by",
+                "type": {
+                  "kind": "LIST",
+                  "ofType": {
+                    "kind": "NON_NULL",
+                    "ofType": {
+                      "kind": "INPUT_OBJECT",
+                      "name": "v2_connection_type_order_by"
+                    }
+                  }
+                }
+              },
+              {
+                "name": "where",
+                "type": {
+                  "kind": "INPUT_OBJECT",
+                  "name": "v2_connection_type_bool_exp"
+                }
+              }
+            ],
+            "isDeprecated": false
+          },
+          {
+            "name": "v2_error_type",
+            "type": {
+              "kind": "NON_NULL",
+              "ofType": {
+                "kind": "LIST",
+                "ofType": {
+                  "kind": "NON_NULL",
+                  "ofType": {
+                    "kind": "OBJECT",
+                    "name": "v2_error_type"
+                  }
+                }
+              }
+            },
+            "args": [
+              {
+                "name": "distinct_on",
+                "type": {
+                  "kind": "LIST",
+                  "ofType": {
+                    "kind": "NON_NULL",
+                    "ofType": {
+                      "kind": "ENUM",
+                      "name": "v2_error_type_select_column"
+                    }
+                  }
+                }
+              },
+              {
+                "name": "limit",
+                "type": {
+                  "kind": "SCALAR",
+                  "name": "Int"
+                }
+              },
+              {
+                "name": "offset",
+                "type": {
+                  "kind": "SCALAR",
+                  "name": "Int"
+                }
+              },
+              {
+                "name": "order_by",
+                "type": {
+                  "kind": "LIST",
+                  "ofType": {
+                    "kind": "NON_NULL",
+                    "ofType": {
+                      "kind": "INPUT_OBJECT",
+                      "name": "v2_error_type_order_by"
+                    }
+                  }
+                }
+              },
+              {
+                "name": "where",
+                "type": {
+                  "kind": "INPUT_OBJECT",
+                  "name": "v2_error_type_bool_exp"
+                }
+              }
+            ],
+            "isDeprecated": false
+          },
+          {
+            "name": "v2_error_type_stream",
+            "type": {
+              "kind": "NON_NULL",
+              "ofType": {
+                "kind": "LIST",
+                "ofType": {
+                  "kind": "NON_NULL",
+                  "ofType": {
+                    "kind": "OBJECT",
+                    "name": "v2_error_type"
+                  }
+                }
+              }
+            },
+            "args": [
+              {
+                "name": "batch_size",
+                "type": {
+                  "kind": "NON_NULL",
+                  "ofType": {
+                    "kind": "SCALAR",
+                    "name": "Int"
+                  }
+                }
+              },
+              {
+                "name": "cursor",
+                "type": {
+                  "kind": "NON_NULL",
+                  "ofType": {
+                    "kind": "LIST",
+                    "ofType": {
+                      "kind": "INPUT_OBJECT",
+                      "name": "v2_error_type_stream_cursor_input"
+                    }
+                  }
+                }
+              },
+              {
+                "name": "where",
+                "type": {
+                  "kind": "INPUT_OBJECT",
+                  "name": "v2_error_type_bool_exp"
+                }
+              }
+            ],
+            "isDeprecated": false
+          },
+          {
+            "name": "v2_errors",
+            "type": {
+              "kind": "NON_NULL",
+              "ofType": {
+                "kind": "LIST",
+                "ofType": {
+                  "kind": "NON_NULL",
+                  "ofType": {
+                    "kind": "OBJECT",
+                    "name": "v2_error_type"
+                  }
+                }
+              }
+            },
+            "args": [
+              {
+                "name": "distinct_on",
+                "type": {
+                  "kind": "LIST",
+                  "ofType": {
+                    "kind": "NON_NULL",
+                    "ofType": {
+                      "kind": "ENUM",
+                      "name": "v2_error_type_select_column"
+                    }
+                  }
+                }
+              },
+              {
+                "name": "limit",
+                "type": {
+                  "kind": "SCALAR",
+                  "name": "Int"
+                }
+              },
+              {
+                "name": "offset",
+                "type": {
+                  "kind": "SCALAR",
+                  "name": "Int"
+                }
+              },
+              {
+                "name": "order_by",
+                "type": {
+                  "kind": "LIST",
+                  "ofType": {
+                    "kind": "NON_NULL",
+                    "ofType": {
+                      "kind": "INPUT_OBJECT",
+                      "name": "v2_error_type_order_by"
+                    }
+                  }
+                }
+              },
+              {
+                "name": "where",
+                "type": {
+                  "kind": "INPUT_OBJECT",
+                  "name": "v2_error_type_bool_exp"
+                }
+              }
+            ],
+            "isDeprecated": false
+          },
+          {
+            "name": "v2_health_check",
+            "type": {
+              "kind": "NON_NULL",
+              "ofType": {
+                "kind": "LIST",
+                "ofType": {
+                  "kind": "NON_NULL",
+                  "ofType": {
+                    "kind": "OBJECT",
+                    "name": "v2_health_check_type"
+                  }
+                }
+              }
+            },
+            "args": [
+              {
+                "name": "distinct_on",
+                "type": {
+                  "kind": "LIST",
+                  "ofType": {
+                    "kind": "NON_NULL",
+                    "ofType": {
+                      "kind": "ENUM",
+                      "name": "v2_health_check_type_select_column"
+                    }
+                  }
+                }
+              },
+              {
+                "name": "limit",
+                "type": {
+                  "kind": "SCALAR",
+                  "name": "Int"
+                }
+              },
+              {
+                "name": "offset",
+                "type": {
+                  "kind": "SCALAR",
+                  "name": "Int"
+                }
+              },
+              {
+                "name": "order_by",
+                "type": {
+                  "kind": "LIST",
+                  "ofType": {
+                    "kind": "NON_NULL",
+                    "ofType": {
+                      "kind": "INPUT_OBJECT",
+                      "name": "v2_health_check_type_order_by"
+                    }
+                  }
+                }
+              },
+              {
+                "name": "where",
+                "type": {
+                  "kind": "INPUT_OBJECT",
+                  "name": "v2_health_check_type_bool_exp"
+                }
+              }
+            ],
+            "isDeprecated": false
+          },
+          {
+            "name": "v2_instructions",
+            "type": {
+              "kind": "NON_NULL",
+              "ofType": {
+                "kind": "LIST",
+                "ofType": {
+                  "kind": "NON_NULL",
+                  "ofType": {
+                    "kind": "OBJECT",
+                    "name": "v2_instruction_type"
+                  }
+                }
+              }
+            },
+            "args": [
+              {
+                "name": "args",
+                "type": {
+                  "kind": "INPUT_OBJECT",
+                  "name": "v2_instructions_args"
+                }
+              },
+              {
+                "name": "distinct_on",
+                "type": {
+                  "kind": "LIST",
+                  "ofType": {
+                    "kind": "NON_NULL",
+                    "ofType": {
+                      "kind": "ENUM",
+                      "name": "v2_instruction_type_select_column"
+                    }
+                  }
+                }
+              },
+              {
+                "name": "limit",
+                "type": {
+                  "kind": "SCALAR",
+                  "name": "Int"
+                }
+              },
+              {
+                "name": "offset",
+                "type": {
+                  "kind": "SCALAR",
+                  "name": "Int"
+                }
+              },
+              {
+                "name": "order_by",
+                "type": {
+                  "kind": "LIST",
+                  "ofType": {
+                    "kind": "NON_NULL",
+                    "ofType": {
+                      "kind": "INPUT_OBJECT",
+                      "name": "v2_instruction_type_order_by"
+                    }
+                  }
+                }
+              },
+              {
+                "name": "where",
+                "type": {
+                  "kind": "INPUT_OBJECT",
+                  "name": "v2_instruction_type_bool_exp"
+                }
+              }
+            ],
+            "isDeprecated": false
+          },
+          {
+            "name": "v2_packets",
+            "type": {
+              "kind": "NON_NULL",
+              "ofType": {
+                "kind": "LIST",
+                "ofType": {
+                  "kind": "NON_NULL",
+                  "ofType": {
+                    "kind": "OBJECT",
+                    "name": "v2_packet_type"
+                  }
+                }
+              }
+            },
+            "args": [
+              {
+                "name": "args",
+                "type": {
+                  "kind": "INPUT_OBJECT",
+                  "name": "v2_packets_args"
+                }
+              },
+              {
+                "name": "distinct_on",
+                "type": {
+                  "kind": "LIST",
+                  "ofType": {
+                    "kind": "NON_NULL",
+                    "ofType": {
+                      "kind": "ENUM",
+                      "name": "v2_packet_type_select_column"
+                    }
+                  }
+                }
+              },
+              {
+                "name": "limit",
+                "type": {
+                  "kind": "SCALAR",
+                  "name": "Int"
+                }
+              },
+              {
+                "name": "offset",
+                "type": {
+                  "kind": "SCALAR",
+                  "name": "Int"
+                }
+              },
+              {
+                "name": "order_by",
+                "type": {
+                  "kind": "LIST",
+                  "ofType": {
+                    "kind": "NON_NULL",
+                    "ofType": {
+                      "kind": "INPUT_OBJECT",
+                      "name": "v2_packet_type_order_by"
+                    }
+                  }
+                }
+              },
+              {
+                "name": "where",
+                "type": {
+                  "kind": "INPUT_OBJECT",
+                  "name": "v2_packet_type_bool_exp"
+                }
+              }
+            ],
+            "isDeprecated": false
+          },
+          {
+            "name": "v2_stats_count",
+            "type": {
+              "kind": "NON_NULL",
+              "ofType": {
+                "kind": "LIST",
+                "ofType": {
+                  "kind": "NON_NULL",
+                  "ofType": {
+                    "kind": "OBJECT",
+                    "name": "v2_stats_type"
+                  }
+                }
+              }
+            },
+            "args": [
+              {
+                "name": "distinct_on",
+                "type": {
+                  "kind": "LIST",
+                  "ofType": {
+                    "kind": "NON_NULL",
+                    "ofType": {
+                      "kind": "ENUM",
+                      "name": "v2_stats_type_select_column"
+                    }
+                  }
+                }
+              },
+              {
+                "name": "limit",
+                "type": {
+                  "kind": "SCALAR",
+                  "name": "Int"
+                }
+              },
+              {
+                "name": "offset",
+                "type": {
+                  "kind": "SCALAR",
+                  "name": "Int"
+                }
+              },
+              {
+                "name": "order_by",
+                "type": {
+                  "kind": "LIST",
+                  "ofType": {
+                    "kind": "NON_NULL",
+                    "ofType": {
+                      "kind": "INPUT_OBJECT",
+                      "name": "v2_stats_type_order_by"
+                    }
+                  }
+                }
+              },
+              {
+                "name": "where",
+                "type": {
+                  "kind": "INPUT_OBJECT",
+                  "name": "v2_stats_type_bool_exp"
+                }
+              }
+            ],
+            "isDeprecated": false
+          },
+          {
+            "name": "v2_stats_latency",
+            "type": {
+              "kind": "NON_NULL",
+              "ofType": {
+                "kind": "LIST",
+                "ofType": {
+                  "kind": "NON_NULL",
+                  "ofType": {
+                    "kind": "OBJECT",
+                    "name": "v2_stats_latency_type"
+                  }
+                }
+              }
+            },
+            "args": [
+              {
+                "name": "args",
+                "type": {
+                  "kind": "NON_NULL",
+                  "ofType": {
+                    "kind": "INPUT_OBJECT",
+                    "name": "v2_stats_latency_args"
+                  }
+                }
+              },
+              {
+                "name": "distinct_on",
+                "type": {
+                  "kind": "LIST",
+                  "ofType": {
+                    "kind": "NON_NULL",
+                    "ofType": {
+                      "kind": "ENUM",
+                      "name": "v2_stats_latency_type_select_column"
+                    }
+                  }
+                }
+              },
+              {
+                "name": "limit",
+                "type": {
+                  "kind": "SCALAR",
+                  "name": "Int"
+                }
+              },
+              {
+                "name": "offset",
+                "type": {
+                  "kind": "SCALAR",
+                  "name": "Int"
+                }
+              },
+              {
+                "name": "order_by",
+                "type": {
+                  "kind": "LIST",
+                  "ofType": {
+                    "kind": "NON_NULL",
+                    "ofType": {
+                      "kind": "INPUT_OBJECT",
+                      "name": "v2_stats_latency_type_order_by"
+                    }
+                  }
+                }
+              },
+              {
+                "name": "where",
+                "type": {
+                  "kind": "INPUT_OBJECT",
+                  "name": "v2_stats_latency_type_bool_exp"
+                }
+              }
+            ],
+            "isDeprecated": false
+          },
+          {
+            "name": "v2_stats_packets_chain",
+            "type": {
+              "kind": "NON_NULL",
+              "ofType": {
+                "kind": "LIST",
+                "ofType": {
+                  "kind": "NON_NULL",
+                  "ofType": {
+                    "kind": "OBJECT",
+                    "name": "v2_stats_packets_chain_type"
+                  }
+                }
+              }
+            },
+            "args": [
+              {
+                "name": "args",
+                "type": {
+                  "kind": "INPUT_OBJECT",
+                  "name": "v2_stats_packets_chain_args"
+                }
+              },
+              {
+                "name": "distinct_on",
+                "type": {
+                  "kind": "LIST",
+                  "ofType": {
+                    "kind": "NON_NULL",
+                    "ofType": {
+                      "kind": "ENUM",
+                      "name": "v2_stats_packets_chain_type_select_column"
+                    }
+                  }
+                }
+              },
+              {
+                "name": "limit",
+                "type": {
+                  "kind": "SCALAR",
+                  "name": "Int"
+                }
+              },
+              {
+                "name": "offset",
+                "type": {
+                  "kind": "SCALAR",
+                  "name": "Int"
+                }
+              },
+              {
+                "name": "order_by",
+                "type": {
+                  "kind": "LIST",
+                  "ofType": {
+                    "kind": "NON_NULL",
+                    "ofType": {
+                      "kind": "INPUT_OBJECT",
+                      "name": "v2_stats_packets_chain_type_order_by"
+                    }
+                  }
+                }
+              },
+              {
+                "name": "where",
+                "type": {
+                  "kind": "INPUT_OBJECT",
+                  "name": "v2_stats_packets_chain_type_bool_exp"
+                }
+              }
+            ],
+            "isDeprecated": false
+          },
+          {
+            "name": "v2_stats_packets_daily_count",
+            "type": {
+              "kind": "NON_NULL",
+              "ofType": {
+                "kind": "LIST",
+                "ofType": {
+                  "kind": "NON_NULL",
+                  "ofType": {
+                    "kind": "OBJECT",
+                    "name": "v2_stats_daily_count_type"
+                  }
+                }
+              }
+            },
+            "args": [
+              {
+                "name": "args",
+                "type": {
+                  "kind": "INPUT_OBJECT",
+                  "name": "v2_stats_packets_daily_count_args"
+                }
+              },
+              {
+                "name": "distinct_on",
+                "type": {
+                  "kind": "LIST",
+                  "ofType": {
+                    "kind": "NON_NULL",
+                    "ofType": {
+                      "kind": "ENUM",
+                      "name": "v2_stats_daily_count_type_select_column"
+                    }
+                  }
+                }
+              },
+              {
+                "name": "limit",
+                "type": {
+                  "kind": "SCALAR",
+                  "name": "Int"
+                }
+              },
+              {
+                "name": "offset",
+                "type": {
+                  "kind": "SCALAR",
+                  "name": "Int"
+                }
+              },
+              {
+                "name": "order_by",
+                "type": {
+                  "kind": "LIST",
+                  "ofType": {
+                    "kind": "NON_NULL",
+                    "ofType": {
+                      "kind": "INPUT_OBJECT",
+                      "name": "v2_stats_daily_count_type_order_by"
+                    }
+                  }
+                }
+              },
+              {
+                "name": "where",
+                "type": {
+                  "kind": "INPUT_OBJECT",
+                  "name": "v2_stats_daily_count_type_bool_exp"
+                }
+              }
+            ],
+            "isDeprecated": false
+          },
+          {
+            "name": "v2_stats_transfers_address",
+            "type": {
+              "kind": "NON_NULL",
+              "ofType": {
+                "kind": "LIST",
+                "ofType": {
+                  "kind": "NON_NULL",
+                  "ofType": {
+                    "kind": "OBJECT",
+                    "name": "v2_stats_transfers_address_type"
+                  }
+                }
+              }
+            },
+            "args": [
+              {
+                "name": "args",
+                "type": {
+                  "kind": "NON_NULL",
+                  "ofType": {
+                    "kind": "INPUT_OBJECT",
+                    "name": "v2_stats_transfers_address_args"
+                  }
+                }
+              },
+              {
+                "name": "distinct_on",
+                "type": {
+                  "kind": "LIST",
+                  "ofType": {
+                    "kind": "NON_NULL",
+                    "ofType": {
+                      "kind": "ENUM",
+                      "name": "v2_stats_transfers_address_type_select_column"
+                    }
+                  }
+                }
+              },
+              {
+                "name": "limit",
+                "type": {
+                  "kind": "SCALAR",
+                  "name": "Int"
+                }
+              },
+              {
+                "name": "offset",
+                "type": {
+                  "kind": "SCALAR",
+                  "name": "Int"
+                }
+              },
+              {
+                "name": "order_by",
+                "type": {
+                  "kind": "LIST",
+                  "ofType": {
+                    "kind": "NON_NULL",
+                    "ofType": {
+                      "kind": "INPUT_OBJECT",
+                      "name": "v2_stats_transfers_address_type_order_by"
+                    }
+                  }
+                }
+              },
+              {
+                "name": "where",
+                "type": {
+                  "kind": "INPUT_OBJECT",
+                  "name": "v2_stats_transfers_address_type_bool_exp"
+                }
+              }
+            ],
+            "isDeprecated": false
+          },
+          {
+            "name": "v2_stats_transfers_chain",
+            "type": {
+              "kind": "NON_NULL",
+              "ofType": {
+                "kind": "LIST",
+                "ofType": {
+                  "kind": "NON_NULL",
+                  "ofType": {
+                    "kind": "OBJECT",
+                    "name": "v2_stats_transfers_chain_type"
+                  }
+                }
+              }
+            },
+            "args": [
+              {
+                "name": "args",
+                "type": {
+                  "kind": "INPUT_OBJECT",
+                  "name": "v2_stats_transfers_chain_args"
+                }
+              },
+              {
+                "name": "distinct_on",
+                "type": {
+                  "kind": "LIST",
+                  "ofType": {
+                    "kind": "NON_NULL",
+                    "ofType": {
+                      "kind": "ENUM",
+                      "name": "v2_stats_transfers_chain_type_select_column"
+                    }
+                  }
+                }
+              },
+              {
+                "name": "limit",
+                "type": {
+                  "kind": "SCALAR",
+                  "name": "Int"
+                }
+              },
+              {
+                "name": "offset",
+                "type": {
+                  "kind": "SCALAR",
+                  "name": "Int"
+                }
+              },
+              {
+                "name": "order_by",
+                "type": {
+                  "kind": "LIST",
+                  "ofType": {
+                    "kind": "NON_NULL",
+                    "ofType": {
+                      "kind": "INPUT_OBJECT",
+                      "name": "v2_stats_transfers_chain_type_order_by"
+                    }
+                  }
+                }
+              },
+              {
+                "name": "where",
+                "type": {
+                  "kind": "INPUT_OBJECT",
+                  "name": "v2_stats_transfers_chain_type_bool_exp"
+                }
+              }
+            ],
+            "isDeprecated": false
+          },
+          {
+            "name": "v2_stats_transfers_daily_count",
+            "type": {
+              "kind": "NON_NULL",
+              "ofType": {
+                "kind": "LIST",
+                "ofType": {
+                  "kind": "NON_NULL",
+                  "ofType": {
+                    "kind": "OBJECT",
+                    "name": "v2_stats_daily_count_type"
+                  }
+                }
+              }
+            },
+            "args": [
+              {
+                "name": "args",
+                "type": {
+                  "kind": "INPUT_OBJECT",
+                  "name": "v2_stats_transfers_daily_count_args"
+                }
+              },
+              {
+                "name": "distinct_on",
+                "type": {
+                  "kind": "LIST",
+                  "ofType": {
+                    "kind": "NON_NULL",
+                    "ofType": {
+                      "kind": "ENUM",
+                      "name": "v2_stats_daily_count_type_select_column"
+                    }
+                  }
+                }
+              },
+              {
+                "name": "limit",
+                "type": {
+                  "kind": "SCALAR",
+                  "name": "Int"
+                }
+              },
+              {
+                "name": "offset",
+                "type": {
+                  "kind": "SCALAR",
+                  "name": "Int"
+                }
+              },
+              {
+                "name": "order_by",
+                "type": {
+                  "kind": "LIST",
+                  "ofType": {
+                    "kind": "NON_NULL",
+                    "ofType": {
+                      "kind": "INPUT_OBJECT",
+                      "name": "v2_stats_daily_count_type_order_by"
+                    }
+                  }
+                }
+              },
+              {
+                "name": "where",
+                "type": {
+                  "kind": "INPUT_OBJECT",
+                  "name": "v2_stats_daily_count_type_bool_exp"
+                }
+              }
+            ],
+            "isDeprecated": false
+          },
+          {
+            "name": "v2_tokens",
+            "type": {
+              "kind": "NON_NULL",
+              "ofType": {
+                "kind": "LIST",
+                "ofType": {
+                  "kind": "NON_NULL",
+                  "ofType": {
+                    "kind": "OBJECT",
+                    "name": "v2_token_meta"
+                  }
+                }
+              }
+            },
+            "args": [
+              {
+                "name": "args",
+                "type": {
+                  "kind": "INPUT_OBJECT",
+                  "name": "v2_tokens_args"
+                }
+              },
+              {
+                "name": "distinct_on",
+                "type": {
+                  "kind": "LIST",
+                  "ofType": {
+                    "kind": "NON_NULL",
+                    "ofType": {
+                      "kind": "ENUM",
+                      "name": "v2_token_meta_select_column"
+                    }
+                  }
+                }
+              },
+              {
+                "name": "limit",
+                "type": {
+                  "kind": "SCALAR",
+                  "name": "Int"
+                }
+              },
+              {
+                "name": "offset",
+                "type": {
+                  "kind": "SCALAR",
+                  "name": "Int"
+                }
+              },
+              {
+                "name": "order_by",
+                "type": {
+                  "kind": "LIST",
+                  "ofType": {
+                    "kind": "NON_NULL",
+                    "ofType": {
+                      "kind": "INPUT_OBJECT",
+                      "name": "v2_token_meta_order_by"
+                    }
+                  }
+                }
+              },
+              {
+                "name": "where",
+                "type": {
+                  "kind": "INPUT_OBJECT",
+                  "name": "v2_token_meta_bool_exp"
+                }
+              }
+            ],
+            "isDeprecated": false
+          },
+          {
+            "name": "v2_transfers",
+            "type": {
+              "kind": "NON_NULL",
+              "ofType": {
+                "kind": "LIST",
+                "ofType": {
+                  "kind": "NON_NULL",
+                  "ofType": {
+                    "kind": "OBJECT",
+                    "name": "v2_transfer_type"
+                  }
+                }
+              }
+            },
+            "args": [
+              {
+                "name": "args",
+                "type": {
+                  "kind": "INPUT_OBJECT",
+                  "name": "v2_transfers_args"
+                }
+              },
+              {
+                "name": "distinct_on",
+                "type": {
+                  "kind": "LIST",
+                  "ofType": {
+                    "kind": "NON_NULL",
+                    "ofType": {
+                      "kind": "ENUM",
+                      "name": "v2_transfer_type_select_column"
+                    }
+                  }
+                }
+              },
+              {
+                "name": "limit",
+                "type": {
+                  "kind": "SCALAR",
+                  "name": "Int"
+                }
+              },
+              {
+                "name": "offset",
+                "type": {
+                  "kind": "SCALAR",
+                  "name": "Int"
+                }
+              },
+              {
+                "name": "order_by",
+                "type": {
+                  "kind": "LIST",
+                  "ofType": {
+                    "kind": "NON_NULL",
+                    "ofType": {
+                      "kind": "INPUT_OBJECT",
+                      "name": "v2_transfer_type_order_by"
+                    }
+                  }
+                }
+              },
+              {
+                "name": "where",
+                "type": {
+                  "kind": "INPUT_OBJECT",
+                  "name": "v2_transfer_type_bool_exp"
+                }
+              }
+            ],
+            "isDeprecated": false
+          },
+          {
+            "name": "v2_util_get_address_types_for_display_address",
+            "type": {
+              "kind": "NON_NULL",
+              "ofType": {
+                "kind": "LIST",
+                "ofType": {
+                  "kind": "NON_NULL",
+                  "ofType": {
+                    "kind": "OBJECT",
+                    "name": "v2_util_get_address_types_for_display_address_type"
+                  }
+                }
+              }
+            },
+            "args": [
+              {
+                "name": "args",
+                "type": {
+                  "kind": "NON_NULL",
+                  "ofType": {
+                    "kind": "INPUT_OBJECT",
+                    "name": "v2_util_get_address_types_for_display_address_args"
+                  }
+                }
+              },
+              {
+                "name": "distinct_on",
+                "type": {
+                  "kind": "LIST",
+                  "ofType": {
+                    "kind": "NON_NULL",
+                    "ofType": {
+                      "kind": "ENUM",
+                      "name": "v2_util_get_address_types_for_display_address_type_select_column"
+                    }
+                  }
+                }
+              },
+              {
+                "name": "limit",
+                "type": {
+                  "kind": "SCALAR",
+                  "name": "Int"
+                }
+              },
+              {
+                "name": "offset",
+                "type": {
+                  "kind": "SCALAR",
+                  "name": "Int"
+                }
+              },
+              {
+                "name": "order_by",
+                "type": {
+                  "kind": "LIST",
+                  "ofType": {
+                    "kind": "NON_NULL",
+                    "ofType": {
+                      "kind": "INPUT_OBJECT",
+                      "name": "v2_util_get_address_types_for_display_address_type_order_by"
+                    }
+                  }
+                }
+              },
+              {
+                "name": "where",
+                "type": {
+                  "kind": "INPUT_OBJECT",
+                  "name": "v2_util_get_address_types_for_display_address_type_bool_exp"
+                }
+              }
+            ],
+            "isDeprecated": false
+          },
+          {
+            "name": "v2_util_get_transfer_request_details",
+            "type": {
+              "kind": "NON_NULL",
+              "ofType": {
+                "kind": "LIST",
+                "ofType": {
+                  "kind": "NON_NULL",
+                  "ofType": {
+                    "kind": "OBJECT",
+                    "name": "v2_util_get_transfer_request_details_type"
+                  }
+                }
+              }
+            },
+            "args": [
+              {
+                "name": "args",
+                "type": {
+                  "kind": "NON_NULL",
+                  "ofType": {
+                    "kind": "INPUT_OBJECT",
+                    "name": "v2_util_get_transfer_request_details_args"
+                  }
+                }
+              },
+              {
+                "name": "distinct_on",
+                "type": {
+                  "kind": "LIST",
+                  "ofType": {
+                    "kind": "NON_NULL",
+                    "ofType": {
+                      "kind": "ENUM",
+                      "name": "v2_util_get_transfer_request_details_type_select_column"
+                    }
+                  }
+                }
+              },
+              {
+                "name": "limit",
+                "type": {
+                  "kind": "SCALAR",
+                  "name": "Int"
+                }
+              },
+              {
+                "name": "offset",
+                "type": {
+                  "kind": "SCALAR",
+                  "name": "Int"
+                }
+              },
+              {
+                "name": "order_by",
+                "type": {
+                  "kind": "LIST",
+                  "ofType": {
+                    "kind": "NON_NULL",
+                    "ofType": {
+                      "kind": "INPUT_OBJECT",
+                      "name": "v2_util_get_transfer_request_details_type_order_by"
+                    }
+                  }
+                }
+              },
+              {
+                "name": "where",
+                "type": {
+                  "kind": "INPUT_OBJECT",
+                  "name": "v2_util_get_transfer_request_details_type_bool_exp"
+                }
+              }
+            ],
+            "isDeprecated": false
+          }
+        ],
+        "interfaces": []
+      },
+      {
+        "kind": "SCALAR",
+        "name": "timestamptz"
+      },
+      {
+        "kind": "INPUT_OBJECT",
+        "name": "timestamptz_comparison_exp",
+        "inputFields": [
+          {
+            "name": "_eq",
+            "type": {
+              "kind": "SCALAR",
+              "name": "timestamptz"
+            }
+          },
+          {
+            "name": "_gt",
+            "type": {
+              "kind": "SCALAR",
+              "name": "timestamptz"
+            }
+          },
+          {
+            "name": "_gte",
+            "type": {
+              "kind": "SCALAR",
+              "name": "timestamptz"
+            }
+          },
+          {
+            "name": "_in",
+            "type": {
+              "kind": "LIST",
+              "ofType": {
+                "kind": "NON_NULL",
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "timestamptz"
+                }
+              }
+            }
+          },
+          {
+            "name": "_is_null",
+            "type": {
+              "kind": "SCALAR",
+              "name": "Boolean"
+            }
+          },
+          {
+            "name": "_lt",
+            "type": {
+              "kind": "SCALAR",
+              "name": "timestamptz"
+            }
+          },
+          {
+            "name": "_lte",
+            "type": {
+              "kind": "SCALAR",
+              "name": "timestamptz"
+            }
+          },
+          {
+            "name": "_neq",
+            "type": {
+              "kind": "SCALAR",
+              "name": "timestamptz"
+            }
+          },
+          {
+            "name": "_nin",
+            "type": {
+              "kind": "LIST",
+              "ofType": {
+                "kind": "NON_NULL",
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "timestamptz"
+                }
+              }
+            }
+          }
+        ],
+        "isOneOf": false
+      },
+      {
+        "kind": "OBJECT",
+        "name": "v2_chain_editions",
+        "fields": [
+          {
+            "name": "environment",
+            "type": {
+              "kind": "SCALAR",
+              "name": "String"
+            },
+            "args": [],
+            "isDeprecated": false
+          },
+          {
+            "name": "name",
+            "type": {
+              "kind": "SCALAR",
+              "name": "String"
+            },
+            "args": [],
+            "isDeprecated": false
+          }
+        ],
+        "interfaces": []
+      },
+      {
+        "kind": "INPUT_OBJECT",
+        "name": "v2_chain_editions_aggregate_order_by",
+        "inputFields": [
+          {
+            "name": "count",
+            "type": {
+              "kind": "ENUM",
+              "name": "order_by"
+            }
+          },
+          {
+            "name": "max",
+            "type": {
+              "kind": "INPUT_OBJECT",
+              "name": "v2_chain_editions_max_order_by"
+            }
+          },
+          {
+            "name": "min",
+            "type": {
+              "kind": "INPUT_OBJECT",
+              "name": "v2_chain_editions_min_order_by"
+            }
+          }
+        ],
+        "isOneOf": false
+      },
+      {
+        "kind": "INPUT_OBJECT",
+        "name": "v2_chain_editions_bool_exp",
+        "inputFields": [
+          {
+            "name": "_and",
+            "type": {
+              "kind": "LIST",
+              "ofType": {
+                "kind": "NON_NULL",
+                "ofType": {
+                  "kind": "INPUT_OBJECT",
+                  "name": "v2_chain_editions_bool_exp"
+                }
+              }
+            }
+          },
+          {
+            "name": "_not",
+            "type": {
+              "kind": "INPUT_OBJECT",
+              "name": "v2_chain_editions_bool_exp"
+            }
+          },
+          {
+            "name": "_or",
+            "type": {
+              "kind": "LIST",
+              "ofType": {
+                "kind": "NON_NULL",
+                "ofType": {
+                  "kind": "INPUT_OBJECT",
+                  "name": "v2_chain_editions_bool_exp"
+                }
+              }
+            }
+          },
+          {
+            "name": "environment",
+            "type": {
+              "kind": "INPUT_OBJECT",
+              "name": "String_comparison_exp"
+            }
+          },
+          {
+            "name": "name",
+            "type": {
+              "kind": "INPUT_OBJECT",
+              "name": "String_comparison_exp"
+            }
+          }
+        ],
+        "isOneOf": false
+      },
+      {
+        "kind": "INPUT_OBJECT",
+        "name": "v2_chain_editions_max_order_by",
+        "inputFields": [
+          {
+            "name": "environment",
+            "type": {
+              "kind": "ENUM",
+              "name": "order_by"
+            }
+          },
+          {
+            "name": "name",
+            "type": {
+              "kind": "ENUM",
+              "name": "order_by"
+            }
+          }
+        ],
+        "isOneOf": false
+      },
+      {
+        "kind": "INPUT_OBJECT",
+        "name": "v2_chain_editions_min_order_by",
+        "inputFields": [
+          {
+            "name": "environment",
+            "type": {
+              "kind": "ENUM",
+              "name": "order_by"
+            }
+          },
+          {
+            "name": "name",
+            "type": {
+              "kind": "ENUM",
+              "name": "order_by"
+            }
+          }
+        ],
+        "isOneOf": false
+      },
+      {
+        "kind": "INPUT_OBJECT",
+        "name": "v2_chain_editions_order_by",
+        "inputFields": [
+          {
+            "name": "environment",
+            "type": {
+              "kind": "ENUM",
+              "name": "order_by"
+            }
+          },
+          {
+            "name": "name",
+            "type": {
+              "kind": "ENUM",
+              "name": "order_by"
+            }
+          }
+        ],
+        "isOneOf": false
+      },
+      {
+        "kind": "ENUM",
+        "name": "v2_chain_editions_select_column",
+        "enumValues": [
+          {
+            "name": "environment",
+            "isDeprecated": false
+          },
+          {
+            "name": "name",
+            "isDeprecated": false
+          }
+        ]
+      },
+      {
+        "kind": "OBJECT",
+        "name": "v2_chain_features",
+        "fields": [
+          {
+            "name": "channel_list",
+            "type": {
+              "kind": "SCALAR",
+              "name": "Boolean"
+            },
+            "args": [],
+            "isDeprecated": false
+          },
+          {
+            "name": "connection_list",
+            "type": {
+              "kind": "SCALAR",
+              "name": "Boolean"
+            },
+            "args": [],
+            "isDeprecated": false
+          },
+          {
+            "name": "environment",
+            "type": {
+              "kind": "SCALAR",
+              "name": "String"
+            },
+            "args": [],
+            "isDeprecated": false
+          },
+          {
+            "name": "index_status",
+            "type": {
+              "kind": "SCALAR",
+              "name": "Boolean"
+            },
+            "args": [],
+            "isDeprecated": false
+          },
+          {
+            "name": "packet_list",
+            "type": {
+              "kind": "SCALAR",
+              "name": "Boolean"
+            },
+            "args": [],
+            "isDeprecated": false
+          },
+          {
+            "name": "transfer_list",
+            "type": {
+              "kind": "SCALAR",
+              "name": "Boolean"
+            },
+            "args": [],
+            "isDeprecated": false
+          },
+          {
+            "name": "transfer_submission",
+            "type": {
+              "kind": "SCALAR",
+              "name": "Boolean"
+            },
+            "args": [],
+            "isDeprecated": false
+          }
+        ],
+        "interfaces": []
+      },
+      {
+        "kind": "INPUT_OBJECT",
+        "name": "v2_chain_features_aggregate_order_by",
+        "inputFields": [
+          {
+            "name": "count",
+            "type": {
+              "kind": "ENUM",
+              "name": "order_by"
+            }
+          },
+          {
+            "name": "max",
+            "type": {
+              "kind": "INPUT_OBJECT",
+              "name": "v2_chain_features_max_order_by"
+            }
+          },
+          {
+            "name": "min",
+            "type": {
+              "kind": "INPUT_OBJECT",
+              "name": "v2_chain_features_min_order_by"
+            }
+          }
+        ],
+        "isOneOf": false
+      },
+      {
+        "kind": "INPUT_OBJECT",
+        "name": "v2_chain_features_bool_exp",
+        "inputFields": [
+          {
+            "name": "_and",
+            "type": {
+              "kind": "LIST",
+              "ofType": {
+                "kind": "NON_NULL",
+                "ofType": {
+                  "kind": "INPUT_OBJECT",
+                  "name": "v2_chain_features_bool_exp"
+                }
+              }
+            }
+          },
+          {
+            "name": "_not",
+            "type": {
+              "kind": "INPUT_OBJECT",
+              "name": "v2_chain_features_bool_exp"
+            }
+          },
+          {
+            "name": "_or",
+            "type": {
+              "kind": "LIST",
+              "ofType": {
+                "kind": "NON_NULL",
+                "ofType": {
+                  "kind": "INPUT_OBJECT",
+                  "name": "v2_chain_features_bool_exp"
+                }
+              }
+            }
+          },
+          {
+            "name": "channel_list",
+            "type": {
+              "kind": "INPUT_OBJECT",
+              "name": "Boolean_comparison_exp"
+            }
+          },
+          {
+            "name": "connection_list",
+            "type": {
+              "kind": "INPUT_OBJECT",
+              "name": "Boolean_comparison_exp"
+            }
+          },
+          {
+            "name": "environment",
+            "type": {
+              "kind": "INPUT_OBJECT",
+              "name": "String_comparison_exp"
+            }
+          },
+          {
+            "name": "index_status",
+            "type": {
+              "kind": "INPUT_OBJECT",
+              "name": "Boolean_comparison_exp"
+            }
+          },
+          {
+            "name": "packet_list",
+            "type": {
+              "kind": "INPUT_OBJECT",
+              "name": "Boolean_comparison_exp"
+            }
+          },
+          {
+            "name": "transfer_list",
+            "type": {
+              "kind": "INPUT_OBJECT",
+              "name": "Boolean_comparison_exp"
+            }
+          },
+          {
+            "name": "transfer_submission",
+            "type": {
+              "kind": "INPUT_OBJECT",
+              "name": "Boolean_comparison_exp"
+            }
+          }
+        ],
+        "isOneOf": false
+      },
+      {
+        "kind": "INPUT_OBJECT",
+        "name": "v2_chain_features_max_order_by",
+        "inputFields": [
+          {
+            "name": "environment",
+            "type": {
+              "kind": "ENUM",
+              "name": "order_by"
+            }
+          }
+        ],
+        "isOneOf": false
+      },
+      {
+        "kind": "INPUT_OBJECT",
+        "name": "v2_chain_features_min_order_by",
+        "inputFields": [
+          {
+            "name": "environment",
+            "type": {
+              "kind": "ENUM",
+              "name": "order_by"
+            }
+          }
+        ],
+        "isOneOf": false
+      },
+      {
+        "kind": "INPUT_OBJECT",
+        "name": "v2_chain_features_order_by",
+        "inputFields": [
+          {
+            "name": "channel_list",
+            "type": {
+              "kind": "ENUM",
+              "name": "order_by"
+            }
+          },
+          {
+            "name": "connection_list",
+            "type": {
+              "kind": "ENUM",
+              "name": "order_by"
+            }
+          },
+          {
+            "name": "environment",
+            "type": {
+              "kind": "ENUM",
+              "name": "order_by"
+            }
+          },
+          {
+            "name": "index_status",
+            "type": {
+              "kind": "ENUM",
+              "name": "order_by"
+            }
+          },
+          {
+            "name": "packet_list",
+            "type": {
+              "kind": "ENUM",
+              "name": "order_by"
+            }
+          },
+          {
+            "name": "transfer_list",
+            "type": {
+              "kind": "ENUM",
+              "name": "order_by"
+            }
+          },
+          {
+            "name": "transfer_submission",
+            "type": {
+              "kind": "ENUM",
+              "name": "order_by"
+            }
+          }
+        ],
+        "isOneOf": false
+      },
+      {
+        "kind": "ENUM",
+        "name": "v2_chain_features_select_column",
+        "enumValues": [
+          {
+            "name": "channel_list",
+            "isDeprecated": false
+          },
+          {
+            "name": "connection_list",
+            "isDeprecated": false
+          },
+          {
+            "name": "environment",
+            "isDeprecated": false
+          },
+          {
+            "name": "index_status",
+            "isDeprecated": false
+          },
+          {
+            "name": "packet_list",
+            "isDeprecated": false
+          },
+          {
+            "name": "transfer_list",
+            "isDeprecated": false
+          },
+          {
+            "name": "transfer_submission",
+            "isDeprecated": false
+          }
+        ]
+      },
+      {
+        "kind": "OBJECT",
+        "name": "v2_chain_status_type",
+        "fields": [
+          {
+            "name": "height",
+            "type": {
+              "kind": "SCALAR",
+              "name": "String"
+            },
+            "args": [],
+            "isDeprecated": false
+          },
+          {
+            "name": "status",
+            "type": {
+              "kind": "SCALAR",
+              "name": "String"
+            },
+            "args": [],
+            "isDeprecated": false
+          },
+          {
+            "name": "timestamp",
+            "type": {
+              "kind": "SCALAR",
+              "name": "timestamptz"
+            },
+            "args": [],
+            "isDeprecated": false
+          },
+          {
+            "name": "tip_age_seconds",
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int"
+            },
+            "args": [],
+            "isDeprecated": false
+          }
+        ],
+        "interfaces": []
+      },
+      {
+        "kind": "INPUT_OBJECT",
+        "name": "v2_chain_status_type_aggregate_order_by",
+        "inputFields": [
+          {
+            "name": "avg",
+            "type": {
+              "kind": "INPUT_OBJECT",
+              "name": "v2_chain_status_type_avg_order_by"
+            }
+          },
+          {
+            "name": "count",
+            "type": {
+              "kind": "ENUM",
+              "name": "order_by"
+            }
+          },
+          {
+            "name": "max",
+            "type": {
+              "kind": "INPUT_OBJECT",
+              "name": "v2_chain_status_type_max_order_by"
+            }
+          },
+          {
+            "name": "min",
+            "type": {
+              "kind": "INPUT_OBJECT",
+              "name": "v2_chain_status_type_min_order_by"
+            }
+          },
+          {
+            "name": "stddev",
+            "type": {
+              "kind": "INPUT_OBJECT",
+              "name": "v2_chain_status_type_stddev_order_by"
+            }
+          },
+          {
+            "name": "stddev_pop",
+            "type": {
+              "kind": "INPUT_OBJECT",
+              "name": "v2_chain_status_type_stddev_pop_order_by"
+            }
+          },
+          {
+            "name": "stddev_samp",
+            "type": {
+              "kind": "INPUT_OBJECT",
+              "name": "v2_chain_status_type_stddev_samp_order_by"
+            }
+          },
+          {
+            "name": "sum",
+            "type": {
+              "kind": "INPUT_OBJECT",
+              "name": "v2_chain_status_type_sum_order_by"
+            }
+          },
+          {
+            "name": "var_pop",
+            "type": {
+              "kind": "INPUT_OBJECT",
+              "name": "v2_chain_status_type_var_pop_order_by"
+            }
+          },
+          {
+            "name": "var_samp",
+            "type": {
+              "kind": "INPUT_OBJECT",
+              "name": "v2_chain_status_type_var_samp_order_by"
+            }
+          },
+          {
+            "name": "variance",
+            "type": {
+              "kind": "INPUT_OBJECT",
+              "name": "v2_chain_status_type_variance_order_by"
+            }
+          }
+        ],
+        "isOneOf": false
+      },
+      {
+        "kind": "INPUT_OBJECT",
+        "name": "v2_chain_status_type_avg_order_by",
+        "inputFields": [
+          {
+            "name": "tip_age_seconds",
+            "type": {
+              "kind": "ENUM",
+              "name": "order_by"
+            }
+          }
+        ],
+        "isOneOf": false
+      },
+      {
+        "kind": "INPUT_OBJECT",
+        "name": "v2_chain_status_type_bool_exp",
+        "inputFields": [
+          {
+            "name": "_and",
+            "type": {
+              "kind": "LIST",
+              "ofType": {
+                "kind": "NON_NULL",
+                "ofType": {
+                  "kind": "INPUT_OBJECT",
+                  "name": "v2_chain_status_type_bool_exp"
+                }
+              }
+            }
+          },
+          {
+            "name": "_not",
+            "type": {
+              "kind": "INPUT_OBJECT",
+              "name": "v2_chain_status_type_bool_exp"
+            }
+          },
+          {
+            "name": "_or",
+            "type": {
+              "kind": "LIST",
+              "ofType": {
+                "kind": "NON_NULL",
+                "ofType": {
+                  "kind": "INPUT_OBJECT",
+                  "name": "v2_chain_status_type_bool_exp"
+                }
+              }
+            }
+          },
+          {
+            "name": "height",
+            "type": {
+              "kind": "INPUT_OBJECT",
+              "name": "String_comparison_exp"
+            }
+          },
+          {
+            "name": "status",
+            "type": {
+              "kind": "INPUT_OBJECT",
+              "name": "String_comparison_exp"
+            }
+          },
+          {
+            "name": "timestamp",
+            "type": {
+              "kind": "INPUT_OBJECT",
+              "name": "timestamptz_comparison_exp"
+            }
+          },
+          {
+            "name": "tip_age_seconds",
+            "type": {
+              "kind": "INPUT_OBJECT",
+              "name": "Int_comparison_exp"
+            }
+          }
+        ],
+        "isOneOf": false
+      },
+      {
+        "kind": "INPUT_OBJECT",
+        "name": "v2_chain_status_type_max_order_by",
+        "inputFields": [
+          {
+            "name": "height",
+            "type": {
+              "kind": "ENUM",
+              "name": "order_by"
+            }
+          },
+          {
+            "name": "status",
+            "type": {
+              "kind": "ENUM",
+              "name": "order_by"
+            }
+          },
+          {
+            "name": "timestamp",
+            "type": {
+              "kind": "ENUM",
+              "name": "order_by"
+            }
+          },
+          {
+            "name": "tip_age_seconds",
+            "type": {
+              "kind": "ENUM",
+              "name": "order_by"
+            }
+          }
+        ],
+        "isOneOf": false
+      },
+      {
+        "kind": "INPUT_OBJECT",
+        "name": "v2_chain_status_type_min_order_by",
+        "inputFields": [
+          {
+            "name": "height",
+            "type": {
+              "kind": "ENUM",
+              "name": "order_by"
+            }
+          },
+          {
+            "name": "status",
+            "type": {
+              "kind": "ENUM",
+              "name": "order_by"
+            }
+          },
+          {
+            "name": "timestamp",
+            "type": {
+              "kind": "ENUM",
+              "name": "order_by"
+            }
+          },
+          {
+            "name": "tip_age_seconds",
+            "type": {
+              "kind": "ENUM",
+              "name": "order_by"
+            }
+          }
+        ],
+        "isOneOf": false
+      },
+      {
+        "kind": "INPUT_OBJECT",
+        "name": "v2_chain_status_type_order_by",
+        "inputFields": [
+          {
+            "name": "height",
+            "type": {
+              "kind": "ENUM",
+              "name": "order_by"
+            }
+          },
+          {
+            "name": "status",
+            "type": {
+              "kind": "ENUM",
+              "name": "order_by"
+            }
+          },
+          {
+            "name": "timestamp",
+            "type": {
+              "kind": "ENUM",
+              "name": "order_by"
+            }
+          },
+          {
+            "name": "tip_age_seconds",
+            "type": {
+              "kind": "ENUM",
+              "name": "order_by"
+            }
+          }
+        ],
+        "isOneOf": false
+      },
+      {
+        "kind": "ENUM",
+        "name": "v2_chain_status_type_select_column",
+        "enumValues": [
+          {
+            "name": "height",
+            "isDeprecated": false
+          },
+          {
+            "name": "status",
+            "isDeprecated": false
+          },
+          {
+            "name": "timestamp",
+            "isDeprecated": false
+          },
+          {
+            "name": "tip_age_seconds",
+            "isDeprecated": false
+          }
+        ]
+      },
+      {
+        "kind": "INPUT_OBJECT",
+        "name": "v2_chain_status_type_stddev_order_by",
+        "inputFields": [
+          {
+            "name": "tip_age_seconds",
+            "type": {
+              "kind": "ENUM",
+              "name": "order_by"
+            }
+          }
+        ],
+        "isOneOf": false
+      },
+      {
+        "kind": "INPUT_OBJECT",
+        "name": "v2_chain_status_type_stddev_pop_order_by",
+        "inputFields": [
+          {
+            "name": "tip_age_seconds",
+            "type": {
+              "kind": "ENUM",
+              "name": "order_by"
+            }
+          }
+        ],
+        "isOneOf": false
+      },
+      {
+        "kind": "INPUT_OBJECT",
+        "name": "v2_chain_status_type_stddev_samp_order_by",
+        "inputFields": [
+          {
+            "name": "tip_age_seconds",
+            "type": {
+              "kind": "ENUM",
+              "name": "order_by"
+            }
+          }
+        ],
+        "isOneOf": false
+      },
+      {
+        "kind": "INPUT_OBJECT",
+        "name": "v2_chain_status_type_sum_order_by",
+        "inputFields": [
+          {
+            "name": "tip_age_seconds",
+            "type": {
+              "kind": "ENUM",
+              "name": "order_by"
+            }
+          }
+        ],
+        "isOneOf": false
+      },
+      {
+        "kind": "INPUT_OBJECT",
+        "name": "v2_chain_status_type_var_pop_order_by",
+        "inputFields": [
+          {
+            "name": "tip_age_seconds",
+            "type": {
+              "kind": "ENUM",
+              "name": "order_by"
+            }
+          }
+        ],
+        "isOneOf": false
+      },
+      {
+        "kind": "INPUT_OBJECT",
+        "name": "v2_chain_status_type_var_samp_order_by",
+        "inputFields": [
+          {
+            "name": "tip_age_seconds",
+            "type": {
+              "kind": "ENUM",
+              "name": "order_by"
+            }
+          }
+        ],
+        "isOneOf": false
+      },
+      {
+        "kind": "INPUT_OBJECT",
+        "name": "v2_chain_status_type_variance_order_by",
+        "inputFields": [
+          {
+            "name": "tip_age_seconds",
+            "type": {
+              "kind": "ENUM",
+              "name": "order_by"
+            }
+          }
+        ],
+        "isOneOf": false
+      },
+      {
+        "kind": "OBJECT",
+        "name": "v2_chain_type",
+        "fields": [
+          {
+            "name": "addr_prefix",
+            "type": {
+              "kind": "SCALAR",
+              "name": "String"
+            },
+            "args": [],
+            "isDeprecated": false
+          },
+          {
+            "name": "chain_id",
+            "type": {
+              "kind": "SCALAR",
+              "name": "String"
+            },
+            "args": [],
+            "isDeprecated": false
+          },
+          {
+            "name": "display_name",
+            "type": {
+              "kind": "SCALAR",
+              "name": "String"
+            },
+            "args": [],
+            "isDeprecated": false
+          },
+          {
+            "name": "editions",
+            "type": {
+              "kind": "NON_NULL",
+              "ofType": {
+                "kind": "LIST",
+                "ofType": {
+                  "kind": "NON_NULL",
+                  "ofType": {
+                    "kind": "OBJECT",
+                    "name": "v2_chain_editions"
+                  }
+                }
+              }
+            },
+            "args": [
+              {
+                "name": "distinct_on",
+                "type": {
+                  "kind": "LIST",
+                  "ofType": {
+                    "kind": "NON_NULL",
+                    "ofType": {
+                      "kind": "ENUM",
+                      "name": "v2_chain_editions_select_column"
+                    }
+                  }
+                }
+              },
+              {
+                "name": "limit",
+                "type": {
+                  "kind": "SCALAR",
+                  "name": "Int"
+                }
+              },
+              {
+                "name": "offset",
+                "type": {
+                  "kind": "SCALAR",
+                  "name": "Int"
+                }
+              },
+              {
+                "name": "order_by",
+                "type": {
+                  "kind": "LIST",
+                  "ofType": {
+                    "kind": "NON_NULL",
+                    "ofType": {
+                      "kind": "INPUT_OBJECT",
+                      "name": "v2_chain_editions_order_by"
+                    }
+                  }
+                }
+              },
+              {
+                "name": "where",
+                "type": {
+                  "kind": "INPUT_OBJECT",
+                  "name": "v2_chain_editions_bool_exp"
+                }
+              }
+            ],
+            "isDeprecated": false
+          },
+          {
+            "name": "explorers",
+            "type": {
+              "kind": "NON_NULL",
+              "ofType": {
+                "kind": "LIST",
+                "ofType": {
+                  "kind": "NON_NULL",
+                  "ofType": {
+                    "kind": "OBJECT",
+                    "name": "v2_explorers"
+                  }
+                }
+              }
+            },
+            "args": [
+              {
+                "name": "distinct_on",
+                "type": {
+                  "kind": "LIST",
+                  "ofType": {
+                    "kind": "NON_NULL",
+                    "ofType": {
+                      "kind": "ENUM",
+                      "name": "v2_explorers_select_column"
+                    }
+                  }
+                }
+              },
+              {
+                "name": "limit",
+                "type": {
+                  "kind": "SCALAR",
+                  "name": "Int"
+                }
+              },
+              {
+                "name": "offset",
+                "type": {
+                  "kind": "SCALAR",
+                  "name": "Int"
+                }
+              },
+              {
+                "name": "order_by",
+                "type": {
+                  "kind": "LIST",
+                  "ofType": {
+                    "kind": "NON_NULL",
+                    "ofType": {
+                      "kind": "INPUT_OBJECT",
+                      "name": "v2_explorers_order_by"
+                    }
+                  }
+                }
+              },
+              {
+                "name": "where",
+                "type": {
+                  "kind": "INPUT_OBJECT",
+                  "name": "v2_explorers_bool_exp"
+                }
+              }
+            ],
+            "isDeprecated": false
+          },
+          {
+            "name": "features",
+            "type": {
+              "kind": "NON_NULL",
+              "ofType": {
+                "kind": "LIST",
+                "ofType": {
+                  "kind": "NON_NULL",
+                  "ofType": {
+                    "kind": "OBJECT",
+                    "name": "v2_chain_features"
+                  }
+                }
+              }
+            },
+            "args": [
+              {
+                "name": "distinct_on",
+                "type": {
+                  "kind": "LIST",
+                  "ofType": {
+                    "kind": "NON_NULL",
+                    "ofType": {
+                      "kind": "ENUM",
+                      "name": "v2_chain_features_select_column"
+                    }
+                  }
+                }
+              },
+              {
+                "name": "limit",
+                "type": {
+                  "kind": "SCALAR",
+                  "name": "Int"
+                }
+              },
+              {
+                "name": "offset",
+                "type": {
+                  "kind": "SCALAR",
+                  "name": "Int"
+                }
+              },
+              {
+                "name": "order_by",
+                "type": {
+                  "kind": "LIST",
+                  "ofType": {
+                    "kind": "NON_NULL",
+                    "ofType": {
+                      "kind": "INPUT_OBJECT",
+                      "name": "v2_chain_features_order_by"
+                    }
+                  }
+                }
+              },
+              {
+                "name": "where",
+                "type": {
+                  "kind": "INPUT_OBJECT",
+                  "name": "v2_chain_features_bool_exp"
+                }
+              }
+            ],
+            "isDeprecated": false
+          },
+          {
+            "name": "logo_uri",
+            "type": {
+              "kind": "SCALAR",
+              "name": "String"
+            },
+            "args": [],
+            "isDeprecated": false
+          },
+          {
+            "name": "minter_address_display",
+            "type": {
+              "kind": "SCALAR",
+              "name": "String"
+            },
+            "args": [],
+            "isDeprecated": false
+          },
+          {
+            "name": "rpc_type",
+            "type": {
+              "kind": "SCALAR",
+              "name": "String"
+            },
+            "args": [],
+            "isDeprecated": false
+          },
+          {
+            "name": "rpcs",
+            "type": {
+              "kind": "NON_NULL",
+              "ofType": {
+                "kind": "LIST",
+                "ofType": {
+                  "kind": "NON_NULL",
+                  "ofType": {
+                    "kind": "OBJECT",
+                    "name": "v2_rpcs"
+                  }
+                }
+              }
+            },
+            "args": [
+              {
+                "name": "distinct_on",
+                "type": {
+                  "kind": "LIST",
+                  "ofType": {
+                    "kind": "NON_NULL",
+                    "ofType": {
+                      "kind": "ENUM",
+                      "name": "v2_rpcs_select_column"
+                    }
+                  }
+                }
+              },
+              {
+                "name": "limit",
+                "type": {
+                  "kind": "SCALAR",
+                  "name": "Int"
+                }
+              },
+              {
+                "name": "offset",
+                "type": {
+                  "kind": "SCALAR",
+                  "name": "Int"
+                }
+              },
+              {
+                "name": "order_by",
+                "type": {
+                  "kind": "LIST",
+                  "ofType": {
+                    "kind": "NON_NULL",
+                    "ofType": {
+                      "kind": "INPUT_OBJECT",
+                      "name": "v2_rpcs_order_by"
+                    }
+                  }
+                }
+              },
+              {
+                "name": "where",
+                "type": {
+                  "kind": "INPUT_OBJECT",
+                  "name": "v2_rpcs_bool_exp"
+                }
+              }
+            ],
+            "isDeprecated": false
+          },
+          {
+            "name": "status",
+            "type": {
+              "kind": "LIST",
+              "ofType": {
+                "kind": "NON_NULL",
+                "ofType": {
+                  "kind": "OBJECT",
+                  "name": "v2_chain_status_type"
+                }
+              }
+            },
+            "args": [
+              {
+                "name": "distinct_on",
+                "type": {
+                  "kind": "LIST",
+                  "ofType": {
+                    "kind": "NON_NULL",
+                    "ofType": {
+                      "kind": "ENUM",
+                      "name": "v2_chain_status_type_select_column"
+                    }
+                  }
+                }
+              },
+              {
+                "name": "limit",
+                "type": {
+                  "kind": "SCALAR",
+                  "name": "Int"
+                }
+              },
+              {
+                "name": "offset",
+                "type": {
+                  "kind": "SCALAR",
+                  "name": "Int"
+                }
+              },
+              {
+                "name": "order_by",
+                "type": {
+                  "kind": "LIST",
+                  "ofType": {
+                    "kind": "NON_NULL",
+                    "ofType": {
+                      "kind": "INPUT_OBJECT",
+                      "name": "v2_chain_status_type_order_by"
+                    }
+                  }
+                }
+              },
+              {
+                "name": "where",
+                "type": {
+                  "kind": "INPUT_OBJECT",
+                  "name": "v2_chain_status_type_bool_exp"
+                }
+              }
+            ],
+            "isDeprecated": false
+          },
+          {
+            "name": "testnet",
+            "type": {
+              "kind": "SCALAR",
+              "name": "Boolean"
+            },
+            "args": [],
+            "isDeprecated": false
+          },
+          {
+            "name": "universal_chain_id",
+            "type": {
+              "kind": "SCALAR",
+              "name": "String"
+            },
+            "args": [],
+            "isDeprecated": false
+          }
+        ],
+        "interfaces": []
+      },
+      {
+        "kind": "INPUT_OBJECT",
+        "name": "v2_chain_type_bool_exp",
+        "inputFields": [
+          {
+            "name": "_and",
+            "type": {
+              "kind": "LIST",
+              "ofType": {
+                "kind": "NON_NULL",
+                "ofType": {
+                  "kind": "INPUT_OBJECT",
+                  "name": "v2_chain_type_bool_exp"
+                }
+              }
+            }
+          },
+          {
+            "name": "_not",
+            "type": {
+              "kind": "INPUT_OBJECT",
+              "name": "v2_chain_type_bool_exp"
+            }
+          },
+          {
+            "name": "_or",
+            "type": {
+              "kind": "LIST",
+              "ofType": {
+                "kind": "NON_NULL",
+                "ofType": {
+                  "kind": "INPUT_OBJECT",
+                  "name": "v2_chain_type_bool_exp"
+                }
+              }
+            }
+          },
+          {
+            "name": "addr_prefix",
+            "type": {
+              "kind": "INPUT_OBJECT",
+              "name": "String_comparison_exp"
+            }
+          },
+          {
+            "name": "chain_id",
+            "type": {
+              "kind": "INPUT_OBJECT",
+              "name": "String_comparison_exp"
+            }
+          },
+          {
+            "name": "display_name",
+            "type": {
+              "kind": "INPUT_OBJECT",
+              "name": "String_comparison_exp"
+            }
+          },
+          {
+            "name": "editions",
+            "type": {
+              "kind": "INPUT_OBJECT",
+              "name": "v2_chain_editions_bool_exp"
+            }
+          },
+          {
+            "name": "explorers",
+            "type": {
+              "kind": "INPUT_OBJECT",
+              "name": "v2_explorers_bool_exp"
+            }
+          },
+          {
+            "name": "features",
+            "type": {
+              "kind": "INPUT_OBJECT",
+              "name": "v2_chain_features_bool_exp"
+            }
+          },
+          {
+            "name": "logo_uri",
+            "type": {
+              "kind": "INPUT_OBJECT",
+              "name": "String_comparison_exp"
+            }
+          },
+          {
+            "name": "minter_address_display",
+            "type": {
+              "kind": "INPUT_OBJECT",
+              "name": "String_comparison_exp"
+            }
+          },
+          {
+            "name": "rpc_type",
+            "type": {
+              "kind": "INPUT_OBJECT",
+              "name": "String_comparison_exp"
+            }
+          },
+          {
+            "name": "rpcs",
+            "type": {
+              "kind": "INPUT_OBJECT",
+              "name": "v2_rpcs_bool_exp"
+            }
+          },
+          {
+            "name": "status",
+            "type": {
+              "kind": "INPUT_OBJECT",
+              "name": "v2_chain_status_type_bool_exp"
+            }
+          },
+          {
+            "name": "testnet",
+            "type": {
+              "kind": "INPUT_OBJECT",
+              "name": "Boolean_comparison_exp"
+            }
+          },
+          {
+            "name": "universal_chain_id",
+            "type": {
+              "kind": "INPUT_OBJECT",
+              "name": "String_comparison_exp"
+            }
+          }
+        ],
+        "isOneOf": false
+      },
+      {
+        "kind": "INPUT_OBJECT",
+        "name": "v2_chain_type_order_by",
+        "inputFields": [
+          {
+            "name": "addr_prefix",
+            "type": {
+              "kind": "ENUM",
+              "name": "order_by"
+            }
+          },
+          {
+            "name": "chain_id",
+            "type": {
+              "kind": "ENUM",
+              "name": "order_by"
+            }
+          },
+          {
+            "name": "display_name",
+            "type": {
+              "kind": "ENUM",
+              "name": "order_by"
+            }
+          },
+          {
+            "name": "editions_aggregate",
+            "type": {
+              "kind": "INPUT_OBJECT",
+              "name": "v2_chain_editions_aggregate_order_by"
+            }
+          },
+          {
+            "name": "explorers_aggregate",
+            "type": {
+              "kind": "INPUT_OBJECT",
+              "name": "v2_explorers_aggregate_order_by"
+            }
+          },
+          {
+            "name": "features_aggregate",
+            "type": {
+              "kind": "INPUT_OBJECT",
+              "name": "v2_chain_features_aggregate_order_by"
+            }
+          },
+          {
+            "name": "logo_uri",
+            "type": {
+              "kind": "ENUM",
+              "name": "order_by"
+            }
+          },
+          {
+            "name": "minter_address_display",
+            "type": {
+              "kind": "ENUM",
+              "name": "order_by"
+            }
+          },
+          {
+            "name": "rpc_type",
+            "type": {
+              "kind": "ENUM",
+              "name": "order_by"
+            }
+          },
+          {
+            "name": "rpcs_aggregate",
+            "type": {
+              "kind": "INPUT_OBJECT",
+              "name": "v2_rpcs_aggregate_order_by"
+            }
+          },
+          {
+            "name": "status_aggregate",
+            "type": {
+              "kind": "INPUT_OBJECT",
+              "name": "v2_chain_status_type_aggregate_order_by"
+            }
+          },
+          {
+            "name": "testnet",
+            "type": {
+              "kind": "ENUM",
+              "name": "order_by"
+            }
+          },
+          {
+            "name": "universal_chain_id",
+            "type": {
+              "kind": "ENUM",
+              "name": "order_by"
+            }
+          }
+        ],
+        "isOneOf": false
+      },
+      {
+        "kind": "ENUM",
+        "name": "v2_chain_type_select_column",
+        "enumValues": [
+          {
+            "name": "addr_prefix",
+            "isDeprecated": false
+          },
+          {
+            "name": "chain_id",
+            "isDeprecated": false
+          },
+          {
+            "name": "display_name",
+            "isDeprecated": false
+          },
+          {
+            "name": "logo_uri",
+            "isDeprecated": false
+          },
+          {
+            "name": "minter_address_display",
+            "isDeprecated": false
+          },
+          {
+            "name": "rpc_type",
+            "isDeprecated": false
+          },
+          {
+            "name": "testnet",
+            "isDeprecated": false
+          },
+          {
+            "name": "universal_chain_id",
+            "isDeprecated": false
+          }
+        ]
+      },
+      {
+        "kind": "INPUT_OBJECT",
+        "name": "v2_chains_args",
+        "inputFields": [
+          {
+            "name": "p_comparison",
+            "type": {
+              "kind": "SCALAR",
+              "name": "String"
+            }
+          },
+          {
+            "name": "p_limit",
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int"
+            }
+          },
+          {
+            "name": "p_sort_order",
+            "type": {
+              "kind": "SCALAR",
+              "name": "String"
+            }
+          },
+          {
+            "name": "p_universal_chain_id",
+            "type": {
+              "kind": "SCALAR",
+              "name": "String"
+            }
+          }
+        ],
+        "isOneOf": false
+      },
+      {
+        "kind": "OBJECT",
+        "name": "v2_chains_view",
+        "fields": [
+          {
+            "name": "addr_prefix",
+            "type": {
+              "kind": "SCALAR",
+              "name": "String"
+            },
+            "args": [],
+            "isDeprecated": false
+          },
+          {
+            "name": "chain_id",
+            "type": {
+              "kind": "SCALAR",
+              "name": "String"
+            },
+            "args": [],
+            "isDeprecated": false
+          },
+          {
+            "name": "display_name",
+            "type": {
+              "kind": "SCALAR",
+              "name": "String"
+            },
+            "args": [],
+            "isDeprecated": false
+          },
+          {
+            "name": "logo_uri",
+            "type": {
+              "kind": "SCALAR",
+              "name": "String"
+            },
+            "args": [],
+            "isDeprecated": false
+          },
+          {
+            "name": "rpc_type",
+            "type": {
+              "kind": "SCALAR",
+              "name": "String"
+            },
+            "args": [],
+            "isDeprecated": false
+          },
+          {
+            "name": "testnet",
+            "type": {
+              "kind": "SCALAR",
+              "name": "Boolean"
+            },
+            "args": [],
+            "isDeprecated": false
+          },
+          {
+            "name": "universal_chain_id",
+            "type": {
+              "kind": "SCALAR",
+              "name": "String"
+            },
+            "args": [],
+            "isDeprecated": false
+          }
+        ],
+        "interfaces": []
+      },
+      {
+        "kind": "INPUT_OBJECT",
+        "name": "v2_chains_view_bool_exp",
+        "inputFields": [
+          {
+            "name": "_and",
+            "type": {
+              "kind": "LIST",
+              "ofType": {
+                "kind": "NON_NULL",
+                "ofType": {
+                  "kind": "INPUT_OBJECT",
+                  "name": "v2_chains_view_bool_exp"
+                }
+              }
+            }
+          },
+          {
+            "name": "_not",
+            "type": {
+              "kind": "INPUT_OBJECT",
+              "name": "v2_chains_view_bool_exp"
+            }
+          },
+          {
+            "name": "_or",
+            "type": {
+              "kind": "LIST",
+              "ofType": {
+                "kind": "NON_NULL",
+                "ofType": {
+                  "kind": "INPUT_OBJECT",
+                  "name": "v2_chains_view_bool_exp"
+                }
+              }
+            }
+          },
+          {
+            "name": "addr_prefix",
+            "type": {
+              "kind": "INPUT_OBJECT",
+              "name": "String_comparison_exp"
+            }
+          },
+          {
+            "name": "chain_id",
+            "type": {
+              "kind": "INPUT_OBJECT",
+              "name": "String_comparison_exp"
+            }
+          },
+          {
+            "name": "display_name",
+            "type": {
+              "kind": "INPUT_OBJECT",
+              "name": "String_comparison_exp"
+            }
+          },
+          {
+            "name": "logo_uri",
+            "type": {
+              "kind": "INPUT_OBJECT",
+              "name": "String_comparison_exp"
+            }
+          },
+          {
+            "name": "rpc_type",
+            "type": {
+              "kind": "INPUT_OBJECT",
+              "name": "String_comparison_exp"
+            }
+          },
+          {
+            "name": "testnet",
+            "type": {
+              "kind": "INPUT_OBJECT",
+              "name": "Boolean_comparison_exp"
+            }
+          },
+          {
+            "name": "universal_chain_id",
+            "type": {
+              "kind": "INPUT_OBJECT",
+              "name": "String_comparison_exp"
+            }
+          }
+        ],
+        "isOneOf": false
+      },
+      {
+        "kind": "INPUT_OBJECT",
+        "name": "v2_chains_view_order_by",
+        "inputFields": [
+          {
+            "name": "addr_prefix",
+            "type": {
+              "kind": "ENUM",
+              "name": "order_by"
+            }
+          },
+          {
+            "name": "chain_id",
+            "type": {
+              "kind": "ENUM",
+              "name": "order_by"
+            }
+          },
+          {
+            "name": "display_name",
+            "type": {
+              "kind": "ENUM",
+              "name": "order_by"
+            }
+          },
+          {
+            "name": "logo_uri",
+            "type": {
+              "kind": "ENUM",
+              "name": "order_by"
+            }
+          },
+          {
+            "name": "rpc_type",
+            "type": {
+              "kind": "ENUM",
+              "name": "order_by"
+            }
+          },
+          {
+            "name": "testnet",
+            "type": {
+              "kind": "ENUM",
+              "name": "order_by"
+            }
+          },
+          {
+            "name": "universal_chain_id",
+            "type": {
+              "kind": "ENUM",
+              "name": "order_by"
+            }
+          }
+        ],
+        "isOneOf": false
+      },
+      {
+        "kind": "OBJECT",
+        "name": "v2_channel_type",
+        "fields": [
+          {
+            "name": "destination_chain",
+            "type": {
+              "kind": "OBJECT",
+              "name": "v2_chains_view"
+            },
+            "args": [],
+            "isDeprecated": false
+          },
+          {
+            "name": "destination_channel_id",
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int"
+            },
+            "args": [],
+            "isDeprecated": false
+          },
+          {
+            "name": "destination_client_id",
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int"
+            },
+            "args": [],
+            "isDeprecated": false
+          },
+          {
+            "name": "destination_connection_id",
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int"
+            },
+            "args": [],
+            "isDeprecated": false
+          },
+          {
+            "name": "destination_port_id",
+            "type": {
+              "kind": "SCALAR",
+              "name": "String"
+            },
+            "args": [],
+            "isDeprecated": false
+          },
+          {
+            "name": "destination_universal_chain_id",
+            "type": {
+              "kind": "SCALAR",
+              "name": "String"
+            },
+            "args": [],
+            "isDeprecated": false
+          },
+          {
+            "name": "sla",
+            "type": {
+              "kind": "SCALAR",
+              "name": "String"
+            },
+            "args": [],
+            "isDeprecated": false
+          },
+          {
+            "name": "sort_order",
+            "type": {
+              "kind": "SCALAR",
+              "name": "String"
+            },
+            "args": [],
+            "isDeprecated": false
+          },
+          {
+            "name": "source_chain",
+            "type": {
+              "kind": "OBJECT",
+              "name": "v2_chains_view"
+            },
+            "args": [],
+            "isDeprecated": false
+          },
+          {
+            "name": "source_channel_id",
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int"
+            },
+            "args": [],
+            "isDeprecated": false
+          },
+          {
+            "name": "source_client_id",
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int"
+            },
+            "args": [],
+            "isDeprecated": false
+          },
+          {
+            "name": "source_connection_id",
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int"
+            },
+            "args": [],
+            "isDeprecated": false
+          },
+          {
+            "name": "source_port_id",
+            "type": {
+              "kind": "SCALAR",
+              "name": "String"
+            },
+            "args": [],
+            "isDeprecated": false
+          },
+          {
+            "name": "source_universal_chain_id",
+            "type": {
+              "kind": "SCALAR",
+              "name": "String"
+            },
+            "args": [],
+            "isDeprecated": false
+          },
+          {
+            "name": "tags",
+            "type": {
+              "kind": "LIST",
+              "ofType": {
+                "kind": "NON_NULL",
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String"
+                }
+              }
+            },
+            "args": [],
+            "isDeprecated": false
+          },
+          {
+            "name": "version",
+            "type": {
+              "kind": "SCALAR",
+              "name": "String"
+            },
+            "args": [],
+            "isDeprecated": false
+          }
+        ],
+        "interfaces": []
+      },
+      {
+        "kind": "INPUT_OBJECT",
+        "name": "v2_channel_type_bool_exp",
+        "inputFields": [
+          {
+            "name": "_and",
+            "type": {
+              "kind": "LIST",
+              "ofType": {
+                "kind": "NON_NULL",
+                "ofType": {
+                  "kind": "INPUT_OBJECT",
+                  "name": "v2_channel_type_bool_exp"
+                }
+              }
+            }
+          },
+          {
+            "name": "_not",
+            "type": {
+              "kind": "INPUT_OBJECT",
+              "name": "v2_channel_type_bool_exp"
+            }
+          },
+          {
+            "name": "_or",
+            "type": {
+              "kind": "LIST",
+              "ofType": {
+                "kind": "NON_NULL",
+                "ofType": {
+                  "kind": "INPUT_OBJECT",
+                  "name": "v2_channel_type_bool_exp"
+                }
+              }
+            }
+          },
+          {
+            "name": "destination_chain",
+            "type": {
+              "kind": "INPUT_OBJECT",
+              "name": "v2_chains_view_bool_exp"
+            }
+          },
+          {
+            "name": "destination_channel_id",
+            "type": {
+              "kind": "INPUT_OBJECT",
+              "name": "Int_comparison_exp"
+            }
+          },
+          {
+            "name": "destination_client_id",
+            "type": {
+              "kind": "INPUT_OBJECT",
+              "name": "Int_comparison_exp"
+            }
+          },
+          {
+            "name": "destination_connection_id",
+            "type": {
+              "kind": "INPUT_OBJECT",
+              "name": "Int_comparison_exp"
+            }
+          },
+          {
+            "name": "destination_port_id",
+            "type": {
+              "kind": "INPUT_OBJECT",
+              "name": "String_comparison_exp"
+            }
+          },
+          {
+            "name": "destination_universal_chain_id",
+            "type": {
+              "kind": "INPUT_OBJECT",
+              "name": "String_comparison_exp"
+            }
+          },
+          {
+            "name": "sla",
+            "type": {
+              "kind": "INPUT_OBJECT",
+              "name": "String_comparison_exp"
+            }
+          },
+          {
+            "name": "sort_order",
+            "type": {
+              "kind": "INPUT_OBJECT",
+              "name": "String_comparison_exp"
+            }
+          },
+          {
+            "name": "source_chain",
+            "type": {
+              "kind": "INPUT_OBJECT",
+              "name": "v2_chains_view_bool_exp"
+            }
+          },
+          {
+            "name": "source_channel_id",
+            "type": {
+              "kind": "INPUT_OBJECT",
+              "name": "Int_comparison_exp"
+            }
+          },
+          {
+            "name": "source_client_id",
+            "type": {
+              "kind": "INPUT_OBJECT",
+              "name": "Int_comparison_exp"
+            }
+          },
+          {
+            "name": "source_connection_id",
+            "type": {
+              "kind": "INPUT_OBJECT",
+              "name": "Int_comparison_exp"
+            }
+          },
+          {
+            "name": "source_port_id",
+            "type": {
+              "kind": "INPUT_OBJECT",
+              "name": "String_comparison_exp"
+            }
+          },
+          {
+            "name": "source_universal_chain_id",
+            "type": {
+              "kind": "INPUT_OBJECT",
+              "name": "String_comparison_exp"
+            }
+          },
+          {
+            "name": "tags",
+            "type": {
+              "kind": "INPUT_OBJECT",
+              "name": "String_array_comparison_exp"
+            }
+          },
+          {
+            "name": "version",
+            "type": {
+              "kind": "INPUT_OBJECT",
+              "name": "String_comparison_exp"
+            }
+          }
+        ],
+        "isOneOf": false
+      },
+      {
+        "kind": "INPUT_OBJECT",
+        "name": "v2_channel_type_order_by",
+        "inputFields": [
+          {
+            "name": "destination_chain",
+            "type": {
+              "kind": "INPUT_OBJECT",
+              "name": "v2_chains_view_order_by"
+            }
+          },
+          {
+            "name": "destination_channel_id",
+            "type": {
+              "kind": "ENUM",
+              "name": "order_by"
+            }
+          },
+          {
+            "name": "destination_client_id",
+            "type": {
+              "kind": "ENUM",
+              "name": "order_by"
+            }
+          },
+          {
+            "name": "destination_connection_id",
+            "type": {
+              "kind": "ENUM",
+              "name": "order_by"
+            }
+          },
+          {
+            "name": "destination_port_id",
+            "type": {
+              "kind": "ENUM",
+              "name": "order_by"
+            }
+          },
+          {
+            "name": "destination_universal_chain_id",
+            "type": {
+              "kind": "ENUM",
+              "name": "order_by"
+            }
+          },
+          {
+            "name": "sla",
+            "type": {
+              "kind": "ENUM",
+              "name": "order_by"
+            }
+          },
+          {
+            "name": "sort_order",
+            "type": {
+              "kind": "ENUM",
+              "name": "order_by"
+            }
+          },
+          {
+            "name": "source_chain",
+            "type": {
+              "kind": "INPUT_OBJECT",
+              "name": "v2_chains_view_order_by"
+            }
+          },
+          {
+            "name": "source_channel_id",
+            "type": {
+              "kind": "ENUM",
+              "name": "order_by"
+            }
+          },
+          {
+            "name": "source_client_id",
+            "type": {
+              "kind": "ENUM",
+              "name": "order_by"
+            }
+          },
+          {
+            "name": "source_connection_id",
+            "type": {
+              "kind": "ENUM",
+              "name": "order_by"
+            }
+          },
+          {
+            "name": "source_port_id",
+            "type": {
+              "kind": "ENUM",
+              "name": "order_by"
+            }
+          },
+          {
+            "name": "source_universal_chain_id",
+            "type": {
+              "kind": "ENUM",
+              "name": "order_by"
+            }
+          },
+          {
+            "name": "tags",
+            "type": {
+              "kind": "ENUM",
+              "name": "order_by"
+            }
+          },
+          {
+            "name": "version",
+            "type": {
+              "kind": "ENUM",
+              "name": "order_by"
+            }
+          }
+        ],
+        "isOneOf": false
+      },
+      {
+        "kind": "ENUM",
+        "name": "v2_channel_type_select_column",
+        "enumValues": [
+          {
+            "name": "destination_channel_id",
+            "isDeprecated": false
+          },
+          {
+            "name": "destination_client_id",
+            "isDeprecated": false
+          },
+          {
+            "name": "destination_connection_id",
+            "isDeprecated": false
+          },
+          {
+            "name": "destination_port_id",
+            "isDeprecated": false
+          },
+          {
+            "name": "destination_universal_chain_id",
+            "isDeprecated": false
+          },
+          {
+            "name": "sla",
+            "isDeprecated": false
+          },
+          {
+            "name": "sort_order",
+            "isDeprecated": false
+          },
+          {
+            "name": "source_channel_id",
+            "isDeprecated": false
+          },
+          {
+            "name": "source_client_id",
+            "isDeprecated": false
+          },
+          {
+            "name": "source_connection_id",
+            "isDeprecated": false
+          },
+          {
+            "name": "source_port_id",
+            "isDeprecated": false
+          },
+          {
+            "name": "source_universal_chain_id",
+            "isDeprecated": false
+          },
+          {
+            "name": "tags",
+            "isDeprecated": false
+          },
+          {
+            "name": "version",
+            "isDeprecated": false
+          }
+        ]
+      },
+      {
+        "kind": "INPUT_OBJECT",
+        "name": "v2_channels_args",
+        "inputFields": [
+          {
+            "name": "p_comparison",
+            "type": {
+              "kind": "SCALAR",
+              "name": "String"
+            }
+          },
+          {
+            "name": "p_destination_channel_id",
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int"
+            }
+          },
+          {
+            "name": "p_destination_client_id",
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int"
+            }
+          },
+          {
+            "name": "p_destination_connection_id",
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int"
+            }
+          },
+          {
+            "name": "p_destination_port_id",
+            "type": {
+              "kind": "SCALAR",
+              "name": "String"
+            }
+          },
+          {
+            "name": "p_destination_universal_chain_id",
+            "type": {
+              "kind": "SCALAR",
+              "name": "String"
+            }
+          },
+          {
+            "name": "p_limit",
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int"
+            }
+          },
+          {
+            "name": "p_recommended",
+            "type": {
+              "kind": "SCALAR",
+              "name": "Boolean"
+            }
+          },
+          {
+            "name": "p_sort_order",
+            "type": {
+              "kind": "SCALAR",
+              "name": "String"
+            }
+          },
+          {
+            "name": "p_source_channel_id",
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int"
+            }
+          },
+          {
+            "name": "p_source_client_id",
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int"
+            }
+          },
+          {
+            "name": "p_source_connection_id",
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int"
+            }
+          },
+          {
+            "name": "p_source_port_id",
+            "type": {
+              "kind": "SCALAR",
+              "name": "String"
+            }
+          },
+          {
+            "name": "p_source_universal_chain_id",
+            "type": {
+              "kind": "SCALAR",
+              "name": "String"
+            }
+          },
+          {
+            "name": "p_tags",
+            "type": {
+              "kind": "SCALAR",
+              "name": "jsonb"
+            }
+          },
+          {
+            "name": "p_version",
+            "type": {
+              "kind": "SCALAR",
+              "name": "String"
+            }
+          }
+        ],
+        "isOneOf": false
+      },
+      {
+        "kind": "OBJECT",
+        "name": "v2_client_type",
+        "fields": [
+          {
+            "name": "client_id",
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int"
+            },
+            "args": [],
+            "isDeprecated": false
+          },
+          {
+            "name": "counterparty_universal_chain_id",
+            "type": {
+              "kind": "SCALAR",
+              "name": "String"
+            },
+            "args": [],
+            "isDeprecated": false
+          },
+          {
+            "name": "sort_order",
+            "type": {
+              "kind": "SCALAR",
+              "name": "String"
+            },
+            "args": [],
+            "isDeprecated": false
+          },
+          {
+            "name": "universal_chain_id",
+            "type": {
+              "kind": "SCALAR",
+              "name": "String"
+            },
+            "args": [],
+            "isDeprecated": false
+          }
+        ],
+        "interfaces": []
+      },
+      {
+        "kind": "INPUT_OBJECT",
+        "name": "v2_client_type_bool_exp",
+        "inputFields": [
+          {
+            "name": "_and",
+            "type": {
+              "kind": "LIST",
+              "ofType": {
+                "kind": "NON_NULL",
+                "ofType": {
+                  "kind": "INPUT_OBJECT",
+                  "name": "v2_client_type_bool_exp"
+                }
+              }
+            }
+          },
+          {
+            "name": "_not",
+            "type": {
+              "kind": "INPUT_OBJECT",
+              "name": "v2_client_type_bool_exp"
+            }
+          },
+          {
+            "name": "_or",
+            "type": {
+              "kind": "LIST",
+              "ofType": {
+                "kind": "NON_NULL",
+                "ofType": {
+                  "kind": "INPUT_OBJECT",
+                  "name": "v2_client_type_bool_exp"
+                }
+              }
+            }
+          },
+          {
+            "name": "client_id",
+            "type": {
+              "kind": "INPUT_OBJECT",
+              "name": "Int_comparison_exp"
+            }
+          },
+          {
+            "name": "counterparty_universal_chain_id",
+            "type": {
+              "kind": "INPUT_OBJECT",
+              "name": "String_comparison_exp"
+            }
+          },
+          {
+            "name": "sort_order",
+            "type": {
+              "kind": "INPUT_OBJECT",
+              "name": "String_comparison_exp"
+            }
+          },
+          {
+            "name": "universal_chain_id",
+            "type": {
+              "kind": "INPUT_OBJECT",
+              "name": "String_comparison_exp"
+            }
+          }
+        ],
+        "isOneOf": false
+      },
+      {
+        "kind": "INPUT_OBJECT",
+        "name": "v2_client_type_order_by",
+        "inputFields": [
+          {
+            "name": "client_id",
+            "type": {
+              "kind": "ENUM",
+              "name": "order_by"
+            }
+          },
+          {
+            "name": "counterparty_universal_chain_id",
+            "type": {
+              "kind": "ENUM",
+              "name": "order_by"
+            }
+          },
+          {
+            "name": "sort_order",
+            "type": {
+              "kind": "ENUM",
+              "name": "order_by"
+            }
+          },
+          {
+            "name": "universal_chain_id",
+            "type": {
+              "kind": "ENUM",
+              "name": "order_by"
+            }
+          }
+        ],
+        "isOneOf": false
+      },
+      {
+        "kind": "ENUM",
+        "name": "v2_client_type_select_column",
+        "enumValues": [
+          {
+            "name": "client_id",
+            "isDeprecated": false
+          },
+          {
+            "name": "counterparty_universal_chain_id",
+            "isDeprecated": false
+          },
+          {
+            "name": "sort_order",
+            "isDeprecated": false
+          },
+          {
+            "name": "universal_chain_id",
+            "isDeprecated": false
+          }
+        ]
+      },
+      {
+        "kind": "INPUT_OBJECT",
+        "name": "v2_clients_args",
+        "inputFields": [
+          {
+            "name": "p_client_id",
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int"
+            }
+          },
+          {
+            "name": "p_comparison",
+            "type": {
+              "kind": "SCALAR",
+              "name": "String"
+            }
+          },
+          {
+            "name": "p_counterparty_universal_chain_id",
+            "type": {
+              "kind": "SCALAR",
+              "name": "String"
+            }
+          },
+          {
+            "name": "p_limit",
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int"
+            }
+          },
+          {
+            "name": "p_sort_order",
+            "type": {
+              "kind": "SCALAR",
+              "name": "String"
+            }
+          },
+          {
+            "name": "p_universal_chain_id",
+            "type": {
+              "kind": "SCALAR",
+              "name": "String"
+            }
+          }
+        ],
+        "isOneOf": false
+      },
+      {
+        "kind": "OBJECT",
+        "name": "v2_connection_type",
+        "fields": [
+          {
+            "name": "destination_chain",
+            "type": {
+              "kind": "OBJECT",
+              "name": "v2_chains_view"
+            },
+            "args": [],
+            "isDeprecated": false
+          },
+          {
+            "name": "destination_client_id",
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int"
+            },
+            "args": [],
+            "isDeprecated": false
+          },
+          {
+            "name": "destination_connection_id",
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int"
+            },
+            "args": [],
+            "isDeprecated": false
+          },
+          {
+            "name": "destination_universal_chain_id",
+            "type": {
+              "kind": "SCALAR",
+              "name": "String"
+            },
+            "args": [],
+            "isDeprecated": false
+          },
+          {
+            "name": "sort_order",
+            "type": {
+              "kind": "SCALAR",
+              "name": "String"
+            },
+            "args": [],
+            "isDeprecated": false
+          },
+          {
+            "name": "source_chain",
+            "type": {
+              "kind": "OBJECT",
+              "name": "v2_chains_view"
+            },
+            "args": [],
+            "isDeprecated": false
+          },
+          {
+            "name": "source_client_id",
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int"
+            },
+            "args": [],
+            "isDeprecated": false
+          },
+          {
+            "name": "source_connection_id",
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int"
+            },
+            "args": [],
+            "isDeprecated": false
+          },
+          {
+            "name": "source_universal_chain_id",
+            "type": {
+              "kind": "SCALAR",
+              "name": "String"
+            },
+            "args": [],
+            "isDeprecated": false
+          }
+        ],
+        "interfaces": []
+      },
+      {
+        "kind": "INPUT_OBJECT",
+        "name": "v2_connection_type_bool_exp",
+        "inputFields": [
+          {
+            "name": "_and",
+            "type": {
+              "kind": "LIST",
+              "ofType": {
+                "kind": "NON_NULL",
+                "ofType": {
+                  "kind": "INPUT_OBJECT",
+                  "name": "v2_connection_type_bool_exp"
+                }
+              }
+            }
+          },
+          {
+            "name": "_not",
+            "type": {
+              "kind": "INPUT_OBJECT",
+              "name": "v2_connection_type_bool_exp"
+            }
+          },
+          {
+            "name": "_or",
+            "type": {
+              "kind": "LIST",
+              "ofType": {
+                "kind": "NON_NULL",
+                "ofType": {
+                  "kind": "INPUT_OBJECT",
+                  "name": "v2_connection_type_bool_exp"
+                }
+              }
+            }
+          },
+          {
+            "name": "destination_chain",
+            "type": {
+              "kind": "INPUT_OBJECT",
+              "name": "v2_chains_view_bool_exp"
+            }
+          },
+          {
+            "name": "destination_client_id",
+            "type": {
+              "kind": "INPUT_OBJECT",
+              "name": "Int_comparison_exp"
+            }
+          },
+          {
+            "name": "destination_connection_id",
+            "type": {
+              "kind": "INPUT_OBJECT",
+              "name": "Int_comparison_exp"
+            }
+          },
+          {
+            "name": "destination_universal_chain_id",
+            "type": {
+              "kind": "INPUT_OBJECT",
+              "name": "String_comparison_exp"
+            }
+          },
+          {
+            "name": "sort_order",
+            "type": {
+              "kind": "INPUT_OBJECT",
+              "name": "String_comparison_exp"
+            }
+          },
+          {
+            "name": "source_chain",
+            "type": {
+              "kind": "INPUT_OBJECT",
+              "name": "v2_chains_view_bool_exp"
+            }
+          },
+          {
+            "name": "source_client_id",
+            "type": {
+              "kind": "INPUT_OBJECT",
+              "name": "Int_comparison_exp"
+            }
+          },
+          {
+            "name": "source_connection_id",
+            "type": {
+              "kind": "INPUT_OBJECT",
+              "name": "Int_comparison_exp"
+            }
+          },
+          {
+            "name": "source_universal_chain_id",
+            "type": {
+              "kind": "INPUT_OBJECT",
+              "name": "String_comparison_exp"
+            }
+          }
+        ],
+        "isOneOf": false
+      },
+      {
+        "kind": "INPUT_OBJECT",
+        "name": "v2_connection_type_order_by",
+        "inputFields": [
+          {
+            "name": "destination_chain",
+            "type": {
+              "kind": "INPUT_OBJECT",
+              "name": "v2_chains_view_order_by"
+            }
+          },
+          {
+            "name": "destination_client_id",
+            "type": {
+              "kind": "ENUM",
+              "name": "order_by"
+            }
+          },
+          {
+            "name": "destination_connection_id",
+            "type": {
+              "kind": "ENUM",
+              "name": "order_by"
+            }
+          },
+          {
+            "name": "destination_universal_chain_id",
+            "type": {
+              "kind": "ENUM",
+              "name": "order_by"
+            }
+          },
+          {
+            "name": "sort_order",
+            "type": {
+              "kind": "ENUM",
+              "name": "order_by"
+            }
+          },
+          {
+            "name": "source_chain",
+            "type": {
+              "kind": "INPUT_OBJECT",
+              "name": "v2_chains_view_order_by"
+            }
+          },
+          {
+            "name": "source_client_id",
+            "type": {
+              "kind": "ENUM",
+              "name": "order_by"
+            }
+          },
+          {
+            "name": "source_connection_id",
+            "type": {
+              "kind": "ENUM",
+              "name": "order_by"
+            }
+          },
+          {
+            "name": "source_universal_chain_id",
+            "type": {
+              "kind": "ENUM",
+              "name": "order_by"
+            }
+          }
+        ],
+        "isOneOf": false
+      },
+      {
+        "kind": "ENUM",
+        "name": "v2_connection_type_select_column",
+        "enumValues": [
+          {
+            "name": "destination_client_id",
+            "isDeprecated": false
+          },
+          {
+            "name": "destination_connection_id",
+            "isDeprecated": false
+          },
+          {
+            "name": "destination_universal_chain_id",
+            "isDeprecated": false
+          },
+          {
+            "name": "sort_order",
+            "isDeprecated": false
+          },
+          {
+            "name": "source_client_id",
+            "isDeprecated": false
+          },
+          {
+            "name": "source_connection_id",
+            "isDeprecated": false
+          },
+          {
+            "name": "source_universal_chain_id",
+            "isDeprecated": false
+          }
+        ]
+      },
+      {
+        "kind": "INPUT_OBJECT",
+        "name": "v2_connections_args",
+        "inputFields": [
+          {
+            "name": "p_comparison",
+            "type": {
+              "kind": "SCALAR",
+              "name": "String"
+            }
+          },
+          {
+            "name": "p_destination_client_id",
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int"
+            }
+          },
+          {
+            "name": "p_destination_connection_id",
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int"
+            }
+          },
+          {
+            "name": "p_destination_universal_chain_id",
+            "type": {
+              "kind": "SCALAR",
+              "name": "String"
+            }
+          },
+          {
+            "name": "p_limit",
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int"
+            }
+          },
+          {
+            "name": "p_sort_order",
+            "type": {
+              "kind": "SCALAR",
+              "name": "String"
+            }
+          },
+          {
+            "name": "p_source_client_id",
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int"
+            }
+          },
+          {
+            "name": "p_source_connection_id",
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int"
+            }
+          },
+          {
+            "name": "p_source_universal_chain_id",
+            "type": {
+              "kind": "SCALAR",
+              "name": "String"
+            }
+          }
+        ],
+        "isOneOf": false
+      },
+      {
+        "kind": "OBJECT",
+        "name": "v2_error_type",
+        "fields": [
+          {
+            "name": "detail",
+            "type": {
+              "kind": "SCALAR",
+              "name": "String"
+            },
+            "args": [],
+            "isDeprecated": false
+          },
+          {
+            "name": "hint",
+            "type": {
+              "kind": "SCALAR",
+              "name": "String"
+            },
+            "args": [],
+            "isDeprecated": false
+          },
+          {
+            "name": "message",
+            "type": {
+              "kind": "SCALAR",
+              "name": "String"
+            },
+            "args": [],
+            "isDeprecated": false
+          },
+          {
+            "name": "union_error_code",
+            "type": {
+              "kind": "SCALAR",
+              "name": "String"
+            },
+            "args": [],
+            "isDeprecated": false
+          }
+        ],
+        "interfaces": []
+      },
+      {
+        "kind": "INPUT_OBJECT",
+        "name": "v2_error_type_bool_exp",
+        "inputFields": [
+          {
+            "name": "_and",
+            "type": {
+              "kind": "LIST",
+              "ofType": {
+                "kind": "NON_NULL",
+                "ofType": {
+                  "kind": "INPUT_OBJECT",
+                  "name": "v2_error_type_bool_exp"
+                }
+              }
+            }
+          },
+          {
+            "name": "_not",
+            "type": {
+              "kind": "INPUT_OBJECT",
+              "name": "v2_error_type_bool_exp"
+            }
+          },
+          {
+            "name": "_or",
+            "type": {
+              "kind": "LIST",
+              "ofType": {
+                "kind": "NON_NULL",
+                "ofType": {
+                  "kind": "INPUT_OBJECT",
+                  "name": "v2_error_type_bool_exp"
+                }
+              }
+            }
+          },
+          {
+            "name": "detail",
+            "type": {
+              "kind": "INPUT_OBJECT",
+              "name": "String_comparison_exp"
+            }
+          },
+          {
+            "name": "hint",
+            "type": {
+              "kind": "INPUT_OBJECT",
+              "name": "String_comparison_exp"
+            }
+          },
+          {
+            "name": "message",
+            "type": {
+              "kind": "INPUT_OBJECT",
+              "name": "String_comparison_exp"
+            }
+          },
+          {
+            "name": "union_error_code",
+            "type": {
+              "kind": "INPUT_OBJECT",
+              "name": "String_comparison_exp"
+            }
+          }
+        ],
+        "isOneOf": false
+      },
+      {
+        "kind": "INPUT_OBJECT",
+        "name": "v2_error_type_order_by",
+        "inputFields": [
+          {
+            "name": "detail",
+            "type": {
+              "kind": "ENUM",
+              "name": "order_by"
+            }
+          },
+          {
+            "name": "hint",
+            "type": {
+              "kind": "ENUM",
+              "name": "order_by"
+            }
+          },
+          {
+            "name": "message",
+            "type": {
+              "kind": "ENUM",
+              "name": "order_by"
+            }
+          },
+          {
+            "name": "union_error_code",
+            "type": {
+              "kind": "ENUM",
+              "name": "order_by"
+            }
+          }
+        ],
+        "isOneOf": false
+      },
+      {
+        "kind": "ENUM",
+        "name": "v2_error_type_select_column",
+        "enumValues": [
+          {
+            "name": "detail",
+            "isDeprecated": false
+          },
+          {
+            "name": "hint",
+            "isDeprecated": false
+          },
+          {
+            "name": "message",
+            "isDeprecated": false
+          },
+          {
+            "name": "union_error_code",
+            "isDeprecated": false
+          }
+        ]
+      },
+      {
+        "kind": "INPUT_OBJECT",
+        "name": "v2_error_type_stream_cursor_input",
+        "inputFields": [
+          {
+            "name": "initial_value",
+            "type": {
+              "kind": "NON_NULL",
+              "ofType": {
+                "kind": "INPUT_OBJECT",
+                "name": "v2_error_type_stream_cursor_value_input"
+              }
+            }
+          },
+          {
+            "name": "ordering",
+            "type": {
+              "kind": "ENUM",
+              "name": "cursor_ordering"
+            }
+          }
+        ],
+        "isOneOf": false
+      },
+      {
+        "kind": "INPUT_OBJECT",
+        "name": "v2_error_type_stream_cursor_value_input",
+        "inputFields": [
+          {
+            "name": "detail",
+            "type": {
+              "kind": "SCALAR",
+              "name": "String"
+            }
+          },
+          {
+            "name": "hint",
+            "type": {
+              "kind": "SCALAR",
+              "name": "String"
+            }
+          },
+          {
+            "name": "message",
+            "type": {
+              "kind": "SCALAR",
+              "name": "String"
+            }
+          },
+          {
+            "name": "union_error_code",
+            "type": {
+              "kind": "SCALAR",
+              "name": "String"
+            }
+          }
+        ],
+        "isOneOf": false
+      },
+      {
+        "kind": "OBJECT",
+        "name": "v2_explorers",
+        "fields": [
+          {
+            "name": "address_url",
+            "type": {
+              "kind": "SCALAR",
+              "name": "String"
+            },
+            "args": [],
+            "isDeprecated": false
+          },
+          {
+            "name": "block_url",
+            "type": {
+              "kind": "SCALAR",
+              "name": "String"
+            },
+            "args": [],
+            "isDeprecated": false
+          },
+          {
+            "name": "description",
+            "type": {
+              "kind": "SCALAR",
+              "name": "String"
+            },
+            "args": [],
+            "isDeprecated": false
+          },
+          {
+            "name": "display_name",
+            "type": {
+              "kind": "SCALAR",
+              "name": "String"
+            },
+            "args": [],
+            "isDeprecated": false
+          },
+          {
+            "name": "home_url",
+            "type": {
+              "kind": "SCALAR",
+              "name": "String"
+            },
+            "args": [],
+            "isDeprecated": false
+          },
+          {
+            "name": "logo_uri",
+            "type": {
+              "kind": "SCALAR",
+              "name": "String"
+            },
+            "args": [],
+            "isDeprecated": false
+          },
+          {
+            "name": "name",
+            "type": {
+              "kind": "SCALAR",
+              "name": "String"
+            },
+            "args": [],
+            "isDeprecated": false
+          },
+          {
+            "name": "tx_url",
+            "type": {
+              "kind": "SCALAR",
+              "name": "String"
+            },
+            "args": [],
+            "isDeprecated": false
+          }
+        ],
+        "interfaces": []
+      },
+      {
+        "kind": "INPUT_OBJECT",
+        "name": "v2_explorers_aggregate_order_by",
+        "inputFields": [
+          {
+            "name": "count",
+            "type": {
+              "kind": "ENUM",
+              "name": "order_by"
+            }
+          },
+          {
+            "name": "max",
+            "type": {
+              "kind": "INPUT_OBJECT",
+              "name": "v2_explorers_max_order_by"
+            }
+          },
+          {
+            "name": "min",
+            "type": {
+              "kind": "INPUT_OBJECT",
+              "name": "v2_explorers_min_order_by"
+            }
+          }
+        ],
+        "isOneOf": false
+      },
+      {
+        "kind": "INPUT_OBJECT",
+        "name": "v2_explorers_bool_exp",
+        "inputFields": [
+          {
+            "name": "_and",
+            "type": {
+              "kind": "LIST",
+              "ofType": {
+                "kind": "NON_NULL",
+                "ofType": {
+                  "kind": "INPUT_OBJECT",
+                  "name": "v2_explorers_bool_exp"
+                }
+              }
+            }
+          },
+          {
+            "name": "_not",
+            "type": {
+              "kind": "INPUT_OBJECT",
+              "name": "v2_explorers_bool_exp"
+            }
+          },
+          {
+            "name": "_or",
+            "type": {
+              "kind": "LIST",
+              "ofType": {
+                "kind": "NON_NULL",
+                "ofType": {
+                  "kind": "INPUT_OBJECT",
+                  "name": "v2_explorers_bool_exp"
+                }
+              }
+            }
+          },
+          {
+            "name": "address_url",
+            "type": {
+              "kind": "INPUT_OBJECT",
+              "name": "String_comparison_exp"
+            }
+          },
+          {
+            "name": "block_url",
+            "type": {
+              "kind": "INPUT_OBJECT",
+              "name": "String_comparison_exp"
+            }
+          },
+          {
+            "name": "description",
+            "type": {
+              "kind": "INPUT_OBJECT",
+              "name": "String_comparison_exp"
+            }
+          },
+          {
+            "name": "display_name",
+            "type": {
+              "kind": "INPUT_OBJECT",
+              "name": "String_comparison_exp"
+            }
+          },
+          {
+            "name": "home_url",
+            "type": {
+              "kind": "INPUT_OBJECT",
+              "name": "String_comparison_exp"
+            }
+          },
+          {
+            "name": "logo_uri",
+            "type": {
+              "kind": "INPUT_OBJECT",
+              "name": "String_comparison_exp"
+            }
+          },
+          {
+            "name": "name",
+            "type": {
+              "kind": "INPUT_OBJECT",
+              "name": "String_comparison_exp"
+            }
+          },
+          {
+            "name": "tx_url",
+            "type": {
+              "kind": "INPUT_OBJECT",
+              "name": "String_comparison_exp"
+            }
+          }
+        ],
+        "isOneOf": false
+      },
+      {
+        "kind": "INPUT_OBJECT",
+        "name": "v2_explorers_max_order_by",
+        "inputFields": [
+          {
+            "name": "address_url",
+            "type": {
+              "kind": "ENUM",
+              "name": "order_by"
+            }
+          },
+          {
+            "name": "block_url",
+            "type": {
+              "kind": "ENUM",
+              "name": "order_by"
+            }
+          },
+          {
+            "name": "description",
+            "type": {
+              "kind": "ENUM",
+              "name": "order_by"
+            }
+          },
+          {
+            "name": "display_name",
+            "type": {
+              "kind": "ENUM",
+              "name": "order_by"
+            }
+          },
+          {
+            "name": "home_url",
+            "type": {
+              "kind": "ENUM",
+              "name": "order_by"
+            }
+          },
+          {
+            "name": "logo_uri",
+            "type": {
+              "kind": "ENUM",
+              "name": "order_by"
+            }
+          },
+          {
+            "name": "name",
+            "type": {
+              "kind": "ENUM",
+              "name": "order_by"
+            }
+          },
+          {
+            "name": "tx_url",
+            "type": {
+              "kind": "ENUM",
+              "name": "order_by"
+            }
+          }
+        ],
+        "isOneOf": false
+      },
+      {
+        "kind": "INPUT_OBJECT",
+        "name": "v2_explorers_min_order_by",
+        "inputFields": [
+          {
+            "name": "address_url",
+            "type": {
+              "kind": "ENUM",
+              "name": "order_by"
+            }
+          },
+          {
+            "name": "block_url",
+            "type": {
+              "kind": "ENUM",
+              "name": "order_by"
+            }
+          },
+          {
+            "name": "description",
+            "type": {
+              "kind": "ENUM",
+              "name": "order_by"
+            }
+          },
+          {
+            "name": "display_name",
+            "type": {
+              "kind": "ENUM",
+              "name": "order_by"
+            }
+          },
+          {
+            "name": "home_url",
+            "type": {
+              "kind": "ENUM",
+              "name": "order_by"
+            }
+          },
+          {
+            "name": "logo_uri",
+            "type": {
+              "kind": "ENUM",
+              "name": "order_by"
+            }
+          },
+          {
+            "name": "name",
+            "type": {
+              "kind": "ENUM",
+              "name": "order_by"
+            }
+          },
+          {
+            "name": "tx_url",
+            "type": {
+              "kind": "ENUM",
+              "name": "order_by"
+            }
+          }
+        ],
+        "isOneOf": false
+      },
+      {
+        "kind": "INPUT_OBJECT",
+        "name": "v2_explorers_order_by",
+        "inputFields": [
+          {
+            "name": "address_url",
+            "type": {
+              "kind": "ENUM",
+              "name": "order_by"
+            }
+          },
+          {
+            "name": "block_url",
+            "type": {
+              "kind": "ENUM",
+              "name": "order_by"
+            }
+          },
+          {
+            "name": "description",
+            "type": {
+              "kind": "ENUM",
+              "name": "order_by"
+            }
+          },
+          {
+            "name": "display_name",
+            "type": {
+              "kind": "ENUM",
+              "name": "order_by"
+            }
+          },
+          {
+            "name": "home_url",
+            "type": {
+              "kind": "ENUM",
+              "name": "order_by"
+            }
+          },
+          {
+            "name": "logo_uri",
+            "type": {
+              "kind": "ENUM",
+              "name": "order_by"
+            }
+          },
+          {
+            "name": "name",
+            "type": {
+              "kind": "ENUM",
+              "name": "order_by"
+            }
+          },
+          {
+            "name": "tx_url",
+            "type": {
+              "kind": "ENUM",
+              "name": "order_by"
+            }
+          }
+        ],
+        "isOneOf": false
+      },
+      {
+        "kind": "ENUM",
+        "name": "v2_explorers_select_column",
+        "enumValues": [
+          {
+            "name": "address_url",
+            "isDeprecated": false
+          },
+          {
+            "name": "block_url",
+            "isDeprecated": false
+          },
+          {
+            "name": "description",
+            "isDeprecated": false
+          },
+          {
+            "name": "display_name",
+            "isDeprecated": false
+          },
+          {
+            "name": "home_url",
+            "isDeprecated": false
+          },
+          {
+            "name": "logo_uri",
+            "isDeprecated": false
+          },
+          {
+            "name": "name",
+            "isDeprecated": false
+          },
+          {
+            "name": "tx_url",
+            "isDeprecated": false
+          }
+        ]
+      },
+      {
+        "kind": "OBJECT",
+        "name": "v2_health_check_type",
+        "fields": [
+          {
+            "name": "environment",
+            "type": {
+              "kind": "SCALAR",
+              "name": "String"
+            },
+            "args": [],
+            "isDeprecated": false
+          },
+          {
+            "name": "last_update",
+            "type": {
+              "kind": "SCALAR",
+              "name": "timestamptz"
+            },
+            "args": [],
+            "isDeprecated": false
+          },
+          {
+            "name": "status",
+            "type": {
+              "kind": "SCALAR",
+              "name": "String"
+            },
+            "args": [],
+            "isDeprecated": false
+          }
+        ],
+        "interfaces": []
+      },
+      {
+        "kind": "INPUT_OBJECT",
+        "name": "v2_health_check_type_bool_exp",
+        "inputFields": [
+          {
+            "name": "_and",
+            "type": {
+              "kind": "LIST",
+              "ofType": {
+                "kind": "NON_NULL",
+                "ofType": {
+                  "kind": "INPUT_OBJECT",
+                  "name": "v2_health_check_type_bool_exp"
+                }
+              }
+            }
+          },
+          {
+            "name": "_not",
+            "type": {
+              "kind": "INPUT_OBJECT",
+              "name": "v2_health_check_type_bool_exp"
+            }
+          },
+          {
+            "name": "_or",
+            "type": {
+              "kind": "LIST",
+              "ofType": {
+                "kind": "NON_NULL",
+                "ofType": {
+                  "kind": "INPUT_OBJECT",
+                  "name": "v2_health_check_type_bool_exp"
+                }
+              }
+            }
+          },
+          {
+            "name": "environment",
+            "type": {
+              "kind": "INPUT_OBJECT",
+              "name": "String_comparison_exp"
+            }
+          },
+          {
+            "name": "last_update",
+            "type": {
+              "kind": "INPUT_OBJECT",
+              "name": "timestamptz_comparison_exp"
+            }
+          },
+          {
+            "name": "status",
+            "type": {
+              "kind": "INPUT_OBJECT",
+              "name": "String_comparison_exp"
+            }
+          }
+        ],
+        "isOneOf": false
+      },
+      {
+        "kind": "INPUT_OBJECT",
+        "name": "v2_health_check_type_order_by",
+        "inputFields": [
+          {
+            "name": "environment",
+            "type": {
+              "kind": "ENUM",
+              "name": "order_by"
+            }
+          },
+          {
+            "name": "last_update",
+            "type": {
+              "kind": "ENUM",
+              "name": "order_by"
+            }
+          },
+          {
+            "name": "status",
+            "type": {
+              "kind": "ENUM",
+              "name": "order_by"
+            }
+          }
+        ],
+        "isOneOf": false
+      },
+      {
+        "kind": "ENUM",
+        "name": "v2_health_check_type_select_column",
+        "enumValues": [
+          {
+            "name": "environment",
+            "isDeprecated": false
+          },
+          {
+            "name": "last_update",
+            "isDeprecated": false
+          },
+          {
+            "name": "status",
+            "isDeprecated": false
+          }
+        ]
+      },
+      {
+        "kind": "OBJECT",
+        "name": "v2_instruction_type",
+        "fields": [
+          {
+            "name": "acknowledgement",
+            "type": {
+              "kind": "SCALAR",
+              "name": "String"
+            },
+            "args": [],
+            "isDeprecated": false
+          },
+          {
+            "name": "channel_version",
+            "type": {
+              "kind": "SCALAR",
+              "name": "String"
+            },
+            "args": [],
+            "isDeprecated": false
+          },
+          {
+            "name": "data",
+            "type": {
+              "kind": "SCALAR",
+              "name": "String"
+            },
+            "args": [],
+            "isDeprecated": false
+          },
+          {
+            "name": "decoded",
+            "type": {
+              "kind": "SCALAR",
+              "name": "jsonb"
+            },
+            "args": [
+              {
+                "name": "path",
+                "type": {
+                  "kind": "SCALAR",
+                  "name": "String"
+                }
+              }
+            ],
+            "isDeprecated": false
+          },
+          {
+            "name": "decoded_flattened",
+            "type": {
+              "kind": "SCALAR",
+              "name": "jsonb"
+            },
+            "args": [
+              {
+                "name": "path",
+                "type": {
+                  "kind": "SCALAR",
+                  "name": "String"
+                }
+              }
+            ],
+            "isDeprecated": false
+          },
+          {
+            "name": "destination_chain",
+            "type": {
+              "kind": "OBJECT",
+              "name": "v2_chains_view"
+            },
+            "args": [],
+            "isDeprecated": false
+          },
+          {
+            "name": "destination_chain_id",
+            "type": {
+              "kind": "SCALAR",
+              "name": "String"
+            },
+            "args": [],
+            "isDeprecated": false
+          },
+          {
+            "name": "destination_channel_id",
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int"
+            },
+            "args": [],
+            "isDeprecated": false
+          },
+          {
+            "name": "destination_client_id",
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int"
+            },
+            "args": [],
+            "isDeprecated": false
+          },
+          {
+            "name": "destination_connection_id",
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int"
+            },
+            "args": [],
+            "isDeprecated": false
+          },
+          {
+            "name": "destination_port_id",
+            "type": {
+              "kind": "SCALAR",
+              "name": "String"
+            },
+            "args": [],
+            "isDeprecated": false
+          },
+          {
+            "name": "destination_universal_chain_id",
+            "type": {
+              "kind": "SCALAR",
+              "name": "String"
+            },
+            "args": [],
+            "isDeprecated": false
+          },
+          {
+            "name": "instruction",
+            "type": {
+              "kind": "SCALAR",
+              "name": "jsonb"
+            },
+            "args": [
+              {
+                "name": "path",
+                "type": {
+                  "kind": "SCALAR",
+                  "name": "String"
+                }
+              }
+            ],
+            "isDeprecated": false
+          },
+          {
+            "name": "instruction_hash",
+            "type": {
+              "kind": "SCALAR",
+              "name": "String"
+            },
+            "args": [],
+            "isDeprecated": false
+          },
+          {
+            "name": "instruction_index",
+            "type": {
+              "kind": "SCALAR",
+              "name": "String"
+            },
+            "args": [],
+            "isDeprecated": false
+          },
+          {
+            "name": "instruction_path",
+            "type": {
+              "kind": "SCALAR",
+              "name": "String"
+            },
+            "args": [],
+            "isDeprecated": false
+          },
+          {
+            "name": "instruction_type",
+            "type": {
+              "kind": "SCALAR",
+              "name": "String"
+            },
+            "args": [],
+            "isDeprecated": false
+          },
+          {
+            "name": "opcode",
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int"
+            },
+            "args": [],
+            "isDeprecated": false
+          },
+          {
+            "name": "operand",
+            "type": {
+              "kind": "SCALAR",
+              "name": "jsonb"
+            },
+            "args": [
+              {
+                "name": "path",
+                "type": {
+                  "kind": "SCALAR",
+                  "name": "String"
+                }
+              }
+            ],
+            "isDeprecated": false
+          },
+          {
+            "name": "packet_ack_block_hash",
+            "type": {
+              "kind": "SCALAR",
+              "name": "String"
+            },
+            "args": [],
+            "isDeprecated": false
+          },
+          {
+            "name": "packet_ack_height",
+            "type": {
+              "kind": "SCALAR",
+              "name": "String"
+            },
+            "args": [],
+            "isDeprecated": false
+          },
+          {
+            "name": "packet_ack_maker",
+            "type": {
+              "kind": "SCALAR",
+              "name": "String"
+            },
+            "args": [],
+            "isDeprecated": false
+          },
+          {
+            "name": "packet_ack_timestamp",
+            "type": {
+              "kind": "SCALAR",
+              "name": "timestamptz"
+            },
+            "args": [],
+            "isDeprecated": false
+          },
+          {
+            "name": "packet_ack_transaction_hash",
+            "type": {
+              "kind": "SCALAR",
+              "name": "String"
+            },
+            "args": [],
+            "isDeprecated": false
+          },
+          {
+            "name": "packet_hash",
+            "type": {
+              "kind": "SCALAR",
+              "name": "String"
+            },
+            "args": [],
+            "isDeprecated": false
+          },
+          {
+            "name": "packet_recv_block_hash",
+            "type": {
+              "kind": "SCALAR",
+              "name": "String"
+            },
+            "args": [],
+            "isDeprecated": false
+          },
+          {
+            "name": "packet_recv_height",
+            "type": {
+              "kind": "SCALAR",
+              "name": "String"
+            },
+            "args": [],
+            "isDeprecated": false
+          },
+          {
+            "name": "packet_recv_maker",
+            "type": {
+              "kind": "SCALAR",
+              "name": "String"
+            },
+            "args": [],
+            "isDeprecated": false
+          },
+          {
+            "name": "packet_recv_maker_msg",
+            "type": {
+              "kind": "SCALAR",
+              "name": "String"
+            },
+            "args": [],
+            "isDeprecated": false
+          },
+          {
+            "name": "packet_recv_timestamp",
+            "type": {
+              "kind": "SCALAR",
+              "name": "timestamptz"
+            },
+            "args": [],
+            "isDeprecated": false
+          },
+          {
+            "name": "packet_recv_transaction_hash",
+            "type": {
+              "kind": "SCALAR",
+              "name": "String"
+            },
+            "args": [],
+            "isDeprecated": false
+          },
+          {
+            "name": "packet_send_block_hash",
+            "type": {
+              "kind": "SCALAR",
+              "name": "String"
+            },
+            "args": [],
+            "isDeprecated": false
+          },
+          {
+            "name": "packet_send_height",
+            "type": {
+              "kind": "SCALAR",
+              "name": "String"
+            },
+            "args": [],
+            "isDeprecated": false
+          },
+          {
+            "name": "packet_send_timestamp",
+            "type": {
+              "kind": "SCALAR",
+              "name": "timestamptz"
+            },
+            "args": [],
+            "isDeprecated": false
+          },
+          {
+            "name": "packet_send_transaction_hash",
+            "type": {
+              "kind": "SCALAR",
+              "name": "String"
+            },
+            "args": [],
+            "isDeprecated": false
+          },
+          {
+            "name": "packet_timeout_block_hash",
+            "type": {
+              "kind": "SCALAR",
+              "name": "String"
+            },
+            "args": [],
+            "isDeprecated": false
+          },
+          {
+            "name": "packet_timeout_height",
+            "type": {
+              "kind": "SCALAR",
+              "name": "String"
+            },
+            "args": [],
+            "isDeprecated": false
+          },
+          {
+            "name": "packet_timeout_maker",
+            "type": {
+              "kind": "SCALAR",
+              "name": "String"
+            },
+            "args": [],
+            "isDeprecated": false
+          },
+          {
+            "name": "packet_timeout_timestamp",
+            "type": {
+              "kind": "SCALAR",
+              "name": "timestamptz"
+            },
+            "args": [],
+            "isDeprecated": false
+          },
+          {
+            "name": "packet_timeout_transaction_hash",
+            "type": {
+              "kind": "SCALAR",
+              "name": "String"
+            },
+            "args": [],
+            "isDeprecated": false
+          },
+          {
+            "name": "path",
+            "type": {
+              "kind": "SCALAR",
+              "name": "String"
+            },
+            "args": [],
+            "isDeprecated": false
+          },
+          {
+            "name": "salt",
+            "type": {
+              "kind": "SCALAR",
+              "name": "String"
+            },
+            "args": [],
+            "isDeprecated": false
+          },
+          {
+            "name": "sort_order",
+            "type": {
+              "kind": "SCALAR",
+              "name": "String"
+            },
+            "args": [],
+            "isDeprecated": false
+          },
+          {
+            "name": "source_chain",
+            "type": {
+              "kind": "OBJECT",
+              "name": "v2_chains_view"
+            },
+            "args": [],
+            "isDeprecated": false
+          },
+          {
+            "name": "source_channel_id",
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int"
+            },
+            "args": [],
+            "isDeprecated": false
+          },
+          {
+            "name": "source_client_id",
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int"
+            },
+            "args": [],
+            "isDeprecated": false
+          },
+          {
+            "name": "source_connection_id",
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int"
+            },
+            "args": [],
+            "isDeprecated": false
+          },
+          {
+            "name": "source_port_id",
+            "type": {
+              "kind": "SCALAR",
+              "name": "String"
+            },
+            "args": [],
+            "isDeprecated": false
+          },
+          {
+            "name": "source_universal_chain_id",
+            "type": {
+              "kind": "SCALAR",
+              "name": "String"
+            },
+            "args": [],
+            "isDeprecated": false
+          },
+          {
+            "name": "status",
+            "type": {
+              "kind": "SCALAR",
+              "name": "String"
+            },
+            "args": [],
+            "isDeprecated": false
+          },
+          {
+            "name": "success",
+            "type": {
+              "kind": "SCALAR",
+              "name": "Boolean"
+            },
+            "args": [],
+            "isDeprecated": false
+          },
+          {
+            "name": "timeout_height",
+            "type": {
+              "kind": "SCALAR",
+              "name": "String"
+            },
+            "args": [],
+            "isDeprecated": false
+          },
+          {
+            "name": "timeout_timestamp",
+            "type": {
+              "kind": "SCALAR",
+              "name": "String"
+            },
+            "args": [],
+            "isDeprecated": false
+          },
+          {
+            "name": "version",
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int"
+            },
+            "args": [],
+            "isDeprecated": false
+          },
+          {
+            "name": "write_ack_block_hash",
+            "type": {
+              "kind": "SCALAR",
+              "name": "String"
+            },
+            "args": [],
+            "isDeprecated": false
+          },
+          {
+            "name": "write_ack_height",
+            "type": {
+              "kind": "SCALAR",
+              "name": "String"
+            },
+            "args": [],
+            "isDeprecated": false
+          },
+          {
+            "name": "write_ack_timestamp",
+            "type": {
+              "kind": "SCALAR",
+              "name": "timestamptz"
+            },
+            "args": [],
+            "isDeprecated": false
+          },
+          {
+            "name": "write_ack_transaction_hash",
+            "type": {
+              "kind": "SCALAR",
+              "name": "String"
+            },
+            "args": [],
+            "isDeprecated": false
+          }
+        ],
+        "interfaces": []
+      },
+      {
+        "kind": "INPUT_OBJECT",
+        "name": "v2_instruction_type_bool_exp",
+        "inputFields": [
+          {
+            "name": "_and",
+            "type": {
+              "kind": "LIST",
+              "ofType": {
+                "kind": "NON_NULL",
+                "ofType": {
+                  "kind": "INPUT_OBJECT",
+                  "name": "v2_instruction_type_bool_exp"
+                }
+              }
+            }
+          },
+          {
+            "name": "_not",
+            "type": {
+              "kind": "INPUT_OBJECT",
+              "name": "v2_instruction_type_bool_exp"
+            }
+          },
+          {
+            "name": "_or",
+            "type": {
+              "kind": "LIST",
+              "ofType": {
+                "kind": "NON_NULL",
+                "ofType": {
+                  "kind": "INPUT_OBJECT",
+                  "name": "v2_instruction_type_bool_exp"
+                }
+              }
+            }
+          },
+          {
+            "name": "acknowledgement",
+            "type": {
+              "kind": "INPUT_OBJECT",
+              "name": "String_comparison_exp"
+            }
+          },
+          {
+            "name": "channel_version",
+            "type": {
+              "kind": "INPUT_OBJECT",
+              "name": "String_comparison_exp"
+            }
+          },
+          {
+            "name": "data",
+            "type": {
+              "kind": "INPUT_OBJECT",
+              "name": "String_comparison_exp"
+            }
+          },
+          {
+            "name": "decoded",
+            "type": {
+              "kind": "INPUT_OBJECT",
+              "name": "jsonb_comparison_exp"
+            }
+          },
+          {
+            "name": "decoded_flattened",
+            "type": {
+              "kind": "INPUT_OBJECT",
+              "name": "jsonb_comparison_exp"
+            }
+          },
+          {
+            "name": "destination_chain",
+            "type": {
+              "kind": "INPUT_OBJECT",
+              "name": "v2_chains_view_bool_exp"
+            }
+          },
+          {
+            "name": "destination_chain_id",
+            "type": {
+              "kind": "INPUT_OBJECT",
+              "name": "String_comparison_exp"
+            }
+          },
+          {
+            "name": "destination_channel_id",
+            "type": {
+              "kind": "INPUT_OBJECT",
+              "name": "Int_comparison_exp"
+            }
+          },
+          {
+            "name": "destination_client_id",
+            "type": {
+              "kind": "INPUT_OBJECT",
+              "name": "Int_comparison_exp"
+            }
+          },
+          {
+            "name": "destination_connection_id",
+            "type": {
+              "kind": "INPUT_OBJECT",
+              "name": "Int_comparison_exp"
+            }
+          },
+          {
+            "name": "destination_port_id",
+            "type": {
+              "kind": "INPUT_OBJECT",
+              "name": "String_comparison_exp"
+            }
+          },
+          {
+            "name": "destination_universal_chain_id",
+            "type": {
+              "kind": "INPUT_OBJECT",
+              "name": "String_comparison_exp"
+            }
+          },
+          {
+            "name": "instruction",
+            "type": {
+              "kind": "INPUT_OBJECT",
+              "name": "jsonb_comparison_exp"
+            }
+          },
+          {
+            "name": "instruction_hash",
+            "type": {
+              "kind": "INPUT_OBJECT",
+              "name": "String_comparison_exp"
+            }
+          },
+          {
+            "name": "instruction_index",
+            "type": {
+              "kind": "INPUT_OBJECT",
+              "name": "String_comparison_exp"
+            }
+          },
+          {
+            "name": "instruction_path",
+            "type": {
+              "kind": "INPUT_OBJECT",
+              "name": "String_comparison_exp"
+            }
+          },
+          {
+            "name": "instruction_type",
+            "type": {
+              "kind": "INPUT_OBJECT",
+              "name": "String_comparison_exp"
+            }
+          },
+          {
+            "name": "opcode",
+            "type": {
+              "kind": "INPUT_OBJECT",
+              "name": "Int_comparison_exp"
+            }
+          },
+          {
+            "name": "operand",
+            "type": {
+              "kind": "INPUT_OBJECT",
+              "name": "jsonb_comparison_exp"
+            }
+          },
+          {
+            "name": "packet_ack_block_hash",
+            "type": {
+              "kind": "INPUT_OBJECT",
+              "name": "String_comparison_exp"
+            }
+          },
+          {
+            "name": "packet_ack_height",
+            "type": {
+              "kind": "INPUT_OBJECT",
+              "name": "String_comparison_exp"
+            }
+          },
+          {
+            "name": "packet_ack_maker",
+            "type": {
+              "kind": "INPUT_OBJECT",
+              "name": "String_comparison_exp"
+            }
+          },
+          {
+            "name": "packet_ack_timestamp",
+            "type": {
+              "kind": "INPUT_OBJECT",
+              "name": "timestamptz_comparison_exp"
+            }
+          },
+          {
+            "name": "packet_ack_transaction_hash",
+            "type": {
+              "kind": "INPUT_OBJECT",
+              "name": "String_comparison_exp"
+            }
+          },
+          {
+            "name": "packet_hash",
+            "type": {
+              "kind": "INPUT_OBJECT",
+              "name": "String_comparison_exp"
+            }
+          },
+          {
+            "name": "packet_recv_block_hash",
+            "type": {
+              "kind": "INPUT_OBJECT",
+              "name": "String_comparison_exp"
+            }
+          },
+          {
+            "name": "packet_recv_height",
+            "type": {
+              "kind": "INPUT_OBJECT",
+              "name": "String_comparison_exp"
+            }
+          },
+          {
+            "name": "packet_recv_maker",
+            "type": {
+              "kind": "INPUT_OBJECT",
+              "name": "String_comparison_exp"
+            }
+          },
+          {
+            "name": "packet_recv_maker_msg",
+            "type": {
+              "kind": "INPUT_OBJECT",
+              "name": "String_comparison_exp"
+            }
+          },
+          {
+            "name": "packet_recv_timestamp",
+            "type": {
+              "kind": "INPUT_OBJECT",
+              "name": "timestamptz_comparison_exp"
+            }
+          },
+          {
+            "name": "packet_recv_transaction_hash",
+            "type": {
+              "kind": "INPUT_OBJECT",
+              "name": "String_comparison_exp"
+            }
+          },
+          {
+            "name": "packet_send_block_hash",
+            "type": {
+              "kind": "INPUT_OBJECT",
+              "name": "String_comparison_exp"
+            }
+          },
+          {
+            "name": "packet_send_height",
+            "type": {
+              "kind": "INPUT_OBJECT",
+              "name": "String_comparison_exp"
+            }
+          },
+          {
+            "name": "packet_send_timestamp",
+            "type": {
+              "kind": "INPUT_OBJECT",
+              "name": "timestamptz_comparison_exp"
+            }
+          },
+          {
+            "name": "packet_send_transaction_hash",
+            "type": {
+              "kind": "INPUT_OBJECT",
+              "name": "String_comparison_exp"
+            }
+          },
+          {
+            "name": "packet_timeout_block_hash",
+            "type": {
+              "kind": "INPUT_OBJECT",
+              "name": "String_comparison_exp"
+            }
+          },
+          {
+            "name": "packet_timeout_height",
+            "type": {
+              "kind": "INPUT_OBJECT",
+              "name": "String_comparison_exp"
+            }
+          },
+          {
+            "name": "packet_timeout_maker",
+            "type": {
+              "kind": "INPUT_OBJECT",
+              "name": "String_comparison_exp"
+            }
+          },
+          {
+            "name": "packet_timeout_timestamp",
+            "type": {
+              "kind": "INPUT_OBJECT",
+              "name": "timestamptz_comparison_exp"
+            }
+          },
+          {
+            "name": "packet_timeout_transaction_hash",
+            "type": {
+              "kind": "INPUT_OBJECT",
+              "name": "String_comparison_exp"
+            }
+          },
+          {
+            "name": "path",
+            "type": {
+              "kind": "INPUT_OBJECT",
+              "name": "String_comparison_exp"
+            }
+          },
+          {
+            "name": "salt",
+            "type": {
+              "kind": "INPUT_OBJECT",
+              "name": "String_comparison_exp"
+            }
+          },
+          {
+            "name": "sort_order",
+            "type": {
+              "kind": "INPUT_OBJECT",
+              "name": "String_comparison_exp"
+            }
+          },
+          {
+            "name": "source_chain",
+            "type": {
+              "kind": "INPUT_OBJECT",
+              "name": "v2_chains_view_bool_exp"
+            }
+          },
+          {
+            "name": "source_channel_id",
+            "type": {
+              "kind": "INPUT_OBJECT",
+              "name": "Int_comparison_exp"
+            }
+          },
+          {
+            "name": "source_client_id",
+            "type": {
+              "kind": "INPUT_OBJECT",
+              "name": "Int_comparison_exp"
+            }
+          },
+          {
+            "name": "source_connection_id",
+            "type": {
+              "kind": "INPUT_OBJECT",
+              "name": "Int_comparison_exp"
+            }
+          },
+          {
+            "name": "source_port_id",
+            "type": {
+              "kind": "INPUT_OBJECT",
+              "name": "String_comparison_exp"
+            }
+          },
+          {
+            "name": "source_universal_chain_id",
+            "type": {
+              "kind": "INPUT_OBJECT",
+              "name": "String_comparison_exp"
+            }
+          },
+          {
+            "name": "status",
+            "type": {
+              "kind": "INPUT_OBJECT",
+              "name": "String_comparison_exp"
+            }
+          },
+          {
+            "name": "success",
+            "type": {
+              "kind": "INPUT_OBJECT",
+              "name": "Boolean_comparison_exp"
+            }
+          },
+          {
+            "name": "timeout_height",
+            "type": {
+              "kind": "INPUT_OBJECT",
+              "name": "String_comparison_exp"
+            }
+          },
+          {
+            "name": "timeout_timestamp",
+            "type": {
+              "kind": "INPUT_OBJECT",
+              "name": "String_comparison_exp"
+            }
+          },
+          {
+            "name": "version",
+            "type": {
+              "kind": "INPUT_OBJECT",
+              "name": "Int_comparison_exp"
+            }
+          },
+          {
+            "name": "write_ack_block_hash",
+            "type": {
+              "kind": "INPUT_OBJECT",
+              "name": "String_comparison_exp"
+            }
+          },
+          {
+            "name": "write_ack_height",
+            "type": {
+              "kind": "INPUT_OBJECT",
+              "name": "String_comparison_exp"
+            }
+          },
+          {
+            "name": "write_ack_timestamp",
+            "type": {
+              "kind": "INPUT_OBJECT",
+              "name": "timestamptz_comparison_exp"
+            }
+          },
+          {
+            "name": "write_ack_transaction_hash",
+            "type": {
+              "kind": "INPUT_OBJECT",
+              "name": "String_comparison_exp"
+            }
+          }
+        ],
+        "isOneOf": false
+      },
+      {
+        "kind": "INPUT_OBJECT",
+        "name": "v2_instruction_type_order_by",
+        "inputFields": [
+          {
+            "name": "acknowledgement",
+            "type": {
+              "kind": "ENUM",
+              "name": "order_by"
+            }
+          },
+          {
+            "name": "channel_version",
+            "type": {
+              "kind": "ENUM",
+              "name": "order_by"
+            }
+          },
+          {
+            "name": "data",
+            "type": {
+              "kind": "ENUM",
+              "name": "order_by"
+            }
+          },
+          {
+            "name": "decoded",
+            "type": {
+              "kind": "ENUM",
+              "name": "order_by"
+            }
+          },
+          {
+            "name": "decoded_flattened",
+            "type": {
+              "kind": "ENUM",
+              "name": "order_by"
+            }
+          },
+          {
+            "name": "destination_chain",
+            "type": {
+              "kind": "INPUT_OBJECT",
+              "name": "v2_chains_view_order_by"
+            }
+          },
+          {
+            "name": "destination_chain_id",
+            "type": {
+              "kind": "ENUM",
+              "name": "order_by"
+            }
+          },
+          {
+            "name": "destination_channel_id",
+            "type": {
+              "kind": "ENUM",
+              "name": "order_by"
+            }
+          },
+          {
+            "name": "destination_client_id",
+            "type": {
+              "kind": "ENUM",
+              "name": "order_by"
+            }
+          },
+          {
+            "name": "destination_connection_id",
+            "type": {
+              "kind": "ENUM",
+              "name": "order_by"
+            }
+          },
+          {
+            "name": "destination_port_id",
+            "type": {
+              "kind": "ENUM",
+              "name": "order_by"
+            }
+          },
+          {
+            "name": "destination_universal_chain_id",
+            "type": {
+              "kind": "ENUM",
+              "name": "order_by"
+            }
+          },
+          {
+            "name": "instruction",
+            "type": {
+              "kind": "ENUM",
+              "name": "order_by"
+            }
+          },
+          {
+            "name": "instruction_hash",
+            "type": {
+              "kind": "ENUM",
+              "name": "order_by"
+            }
+          },
+          {
+            "name": "instruction_index",
+            "type": {
+              "kind": "ENUM",
+              "name": "order_by"
+            }
+          },
+          {
+            "name": "instruction_path",
+            "type": {
+              "kind": "ENUM",
+              "name": "order_by"
+            }
+          },
+          {
+            "name": "instruction_type",
+            "type": {
+              "kind": "ENUM",
+              "name": "order_by"
+            }
+          },
+          {
+            "name": "opcode",
+            "type": {
+              "kind": "ENUM",
+              "name": "order_by"
+            }
+          },
+          {
+            "name": "operand",
+            "type": {
+              "kind": "ENUM",
+              "name": "order_by"
+            }
+          },
+          {
+            "name": "packet_ack_block_hash",
+            "type": {
+              "kind": "ENUM",
+              "name": "order_by"
+            }
+          },
+          {
+            "name": "packet_ack_height",
+            "type": {
+              "kind": "ENUM",
+              "name": "order_by"
+            }
+          },
+          {
+            "name": "packet_ack_maker",
+            "type": {
+              "kind": "ENUM",
+              "name": "order_by"
+            }
+          },
+          {
+            "name": "packet_ack_timestamp",
+            "type": {
+              "kind": "ENUM",
+              "name": "order_by"
+            }
+          },
+          {
+            "name": "packet_ack_transaction_hash",
+            "type": {
+              "kind": "ENUM",
+              "name": "order_by"
+            }
+          },
+          {
+            "name": "packet_hash",
+            "type": {
+              "kind": "ENUM",
+              "name": "order_by"
+            }
+          },
+          {
+            "name": "packet_recv_block_hash",
+            "type": {
+              "kind": "ENUM",
+              "name": "order_by"
+            }
+          },
+          {
+            "name": "packet_recv_height",
+            "type": {
+              "kind": "ENUM",
+              "name": "order_by"
+            }
+          },
+          {
+            "name": "packet_recv_maker",
+            "type": {
+              "kind": "ENUM",
+              "name": "order_by"
+            }
+          },
+          {
+            "name": "packet_recv_maker_msg",
+            "type": {
+              "kind": "ENUM",
+              "name": "order_by"
+            }
+          },
+          {
+            "name": "packet_recv_timestamp",
+            "type": {
+              "kind": "ENUM",
+              "name": "order_by"
+            }
+          },
+          {
+            "name": "packet_recv_transaction_hash",
+            "type": {
+              "kind": "ENUM",
+              "name": "order_by"
+            }
+          },
+          {
+            "name": "packet_send_block_hash",
+            "type": {
+              "kind": "ENUM",
+              "name": "order_by"
+            }
+          },
+          {
+            "name": "packet_send_height",
+            "type": {
+              "kind": "ENUM",
+              "name": "order_by"
+            }
+          },
+          {
+            "name": "packet_send_timestamp",
+            "type": {
+              "kind": "ENUM",
+              "name": "order_by"
+            }
+          },
+          {
+            "name": "packet_send_transaction_hash",
+            "type": {
+              "kind": "ENUM",
+              "name": "order_by"
+            }
+          },
+          {
+            "name": "packet_timeout_block_hash",
+            "type": {
+              "kind": "ENUM",
+              "name": "order_by"
+            }
+          },
+          {
+            "name": "packet_timeout_height",
+            "type": {
+              "kind": "ENUM",
+              "name": "order_by"
+            }
+          },
+          {
+            "name": "packet_timeout_maker",
+            "type": {
+              "kind": "ENUM",
+              "name": "order_by"
+            }
+          },
+          {
+            "name": "packet_timeout_timestamp",
+            "type": {
+              "kind": "ENUM",
+              "name": "order_by"
+            }
+          },
+          {
+            "name": "packet_timeout_transaction_hash",
+            "type": {
+              "kind": "ENUM",
+              "name": "order_by"
+            }
+          },
+          {
+            "name": "path",
+            "type": {
+              "kind": "ENUM",
+              "name": "order_by"
+            }
+          },
+          {
+            "name": "salt",
+            "type": {
+              "kind": "ENUM",
+              "name": "order_by"
+            }
+          },
+          {
+            "name": "sort_order",
+            "type": {
+              "kind": "ENUM",
+              "name": "order_by"
+            }
+          },
+          {
+            "name": "source_chain",
+            "type": {
+              "kind": "INPUT_OBJECT",
+              "name": "v2_chains_view_order_by"
+            }
+          },
+          {
+            "name": "source_channel_id",
+            "type": {
+              "kind": "ENUM",
+              "name": "order_by"
+            }
+          },
+          {
+            "name": "source_client_id",
+            "type": {
+              "kind": "ENUM",
+              "name": "order_by"
+            }
+          },
+          {
+            "name": "source_connection_id",
+            "type": {
+              "kind": "ENUM",
+              "name": "order_by"
+            }
+          },
+          {
+            "name": "source_port_id",
+            "type": {
+              "kind": "ENUM",
+              "name": "order_by"
+            }
+          },
+          {
+            "name": "source_universal_chain_id",
+            "type": {
+              "kind": "ENUM",
+              "name": "order_by"
+            }
+          },
+          {
+            "name": "status",
+            "type": {
+              "kind": "ENUM",
+              "name": "order_by"
+            }
+          },
+          {
+            "name": "success",
+            "type": {
+              "kind": "ENUM",
+              "name": "order_by"
+            }
+          },
+          {
+            "name": "timeout_height",
+            "type": {
+              "kind": "ENUM",
+              "name": "order_by"
+            }
+          },
+          {
+            "name": "timeout_timestamp",
+            "type": {
+              "kind": "ENUM",
+              "name": "order_by"
+            }
+          },
+          {
+            "name": "version",
+            "type": {
+              "kind": "ENUM",
+              "name": "order_by"
+            }
+          },
+          {
+            "name": "write_ack_block_hash",
+            "type": {
+              "kind": "ENUM",
+              "name": "order_by"
+            }
+          },
+          {
+            "name": "write_ack_height",
+            "type": {
+              "kind": "ENUM",
+              "name": "order_by"
+            }
+          },
+          {
+            "name": "write_ack_timestamp",
+            "type": {
+              "kind": "ENUM",
+              "name": "order_by"
+            }
+          },
+          {
+            "name": "write_ack_transaction_hash",
+            "type": {
+              "kind": "ENUM",
+              "name": "order_by"
+            }
+          }
+        ],
+        "isOneOf": false
+      },
+      {
+        "kind": "ENUM",
+        "name": "v2_instruction_type_select_column",
+        "enumValues": [
+          {
+            "name": "acknowledgement",
+            "isDeprecated": false
+          },
+          {
+            "name": "channel_version",
+            "isDeprecated": false
+          },
+          {
+            "name": "data",
+            "isDeprecated": false
+          },
+          {
+            "name": "decoded",
+            "isDeprecated": false
+          },
+          {
+            "name": "decoded_flattened",
+            "isDeprecated": false
+          },
+          {
+            "name": "destination_chain_id",
+            "isDeprecated": false
+          },
+          {
+            "name": "destination_channel_id",
+            "isDeprecated": false
+          },
+          {
+            "name": "destination_client_id",
+            "isDeprecated": false
+          },
+          {
+            "name": "destination_connection_id",
+            "isDeprecated": false
+          },
+          {
+            "name": "destination_port_id",
+            "isDeprecated": false
+          },
+          {
+            "name": "destination_universal_chain_id",
+            "isDeprecated": false
+          },
+          {
+            "name": "instruction",
+            "isDeprecated": false
+          },
+          {
+            "name": "instruction_hash",
+            "isDeprecated": false
+          },
+          {
+            "name": "instruction_index",
+            "isDeprecated": false
+          },
+          {
+            "name": "instruction_path",
+            "isDeprecated": false
+          },
+          {
+            "name": "instruction_type",
+            "isDeprecated": false
+          },
+          {
+            "name": "opcode",
+            "isDeprecated": false
+          },
+          {
+            "name": "operand",
+            "isDeprecated": false
+          },
+          {
+            "name": "packet_ack_block_hash",
+            "isDeprecated": false
+          },
+          {
+            "name": "packet_ack_height",
+            "isDeprecated": false
+          },
+          {
+            "name": "packet_ack_maker",
+            "isDeprecated": false
+          },
+          {
+            "name": "packet_ack_timestamp",
+            "isDeprecated": false
+          },
+          {
+            "name": "packet_ack_transaction_hash",
+            "isDeprecated": false
+          },
+          {
+            "name": "packet_hash",
+            "isDeprecated": false
+          },
+          {
+            "name": "packet_recv_block_hash",
+            "isDeprecated": false
+          },
+          {
+            "name": "packet_recv_height",
+            "isDeprecated": false
+          },
+          {
+            "name": "packet_recv_maker",
+            "isDeprecated": false
+          },
+          {
+            "name": "packet_recv_maker_msg",
+            "isDeprecated": false
+          },
+          {
+            "name": "packet_recv_timestamp",
+            "isDeprecated": false
+          },
+          {
+            "name": "packet_recv_transaction_hash",
+            "isDeprecated": false
+          },
+          {
+            "name": "packet_send_block_hash",
+            "isDeprecated": false
+          },
+          {
+            "name": "packet_send_height",
+            "isDeprecated": false
+          },
+          {
+            "name": "packet_send_timestamp",
+            "isDeprecated": false
+          },
+          {
+            "name": "packet_send_transaction_hash",
+            "isDeprecated": false
+          },
+          {
+            "name": "packet_timeout_block_hash",
+            "isDeprecated": false
+          },
+          {
+            "name": "packet_timeout_height",
+            "isDeprecated": false
+          },
+          {
+            "name": "packet_timeout_maker",
+            "isDeprecated": false
+          },
+          {
+            "name": "packet_timeout_timestamp",
+            "isDeprecated": false
+          },
+          {
+            "name": "packet_timeout_transaction_hash",
+            "isDeprecated": false
+          },
+          {
+            "name": "path",
+            "isDeprecated": false
+          },
+          {
+            "name": "salt",
+            "isDeprecated": false
+          },
+          {
+            "name": "sort_order",
+            "isDeprecated": false
+          },
+          {
+            "name": "source_channel_id",
+            "isDeprecated": false
+          },
+          {
+            "name": "source_client_id",
+            "isDeprecated": false
+          },
+          {
+            "name": "source_connection_id",
+            "isDeprecated": false
+          },
+          {
+            "name": "source_port_id",
+            "isDeprecated": false
+          },
+          {
+            "name": "source_universal_chain_id",
+            "isDeprecated": false
+          },
+          {
+            "name": "status",
+            "isDeprecated": false
+          },
+          {
+            "name": "success",
+            "isDeprecated": false
+          },
+          {
+            "name": "timeout_height",
+            "isDeprecated": false
+          },
+          {
+            "name": "timeout_timestamp",
+            "isDeprecated": false
+          },
+          {
+            "name": "version",
+            "isDeprecated": false
+          },
+          {
+            "name": "write_ack_block_hash",
+            "isDeprecated": false
+          },
+          {
+            "name": "write_ack_height",
+            "isDeprecated": false
+          },
+          {
+            "name": "write_ack_timestamp",
+            "isDeprecated": false
+          },
+          {
+            "name": "write_ack_transaction_hash",
+            "isDeprecated": false
+          }
+        ]
+      },
+      {
+        "kind": "INPUT_OBJECT",
+        "name": "v2_instructions_args",
+        "inputFields": [
+          {
+            "name": "p_block_hash",
+            "type": {
+              "kind": "SCALAR",
+              "name": "String"
+            }
+          },
+          {
+            "name": "p_comparison",
+            "type": {
+              "kind": "SCALAR",
+              "name": "String"
+            }
+          },
+          {
+            "name": "p_limit",
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int"
+            }
+          },
+          {
+            "name": "p_multiplex_contract_address",
+            "type": {
+              "kind": "SCALAR",
+              "name": "String"
+            }
+          },
+          {
+            "name": "p_multiplex_sender",
+            "type": {
+              "kind": "SCALAR",
+              "name": "String"
+            }
+          },
+          {
+            "name": "p_network",
+            "type": {
+              "kind": "SCALAR",
+              "name": "String"
+            }
+          },
+          {
+            "name": "p_packet_hash",
+            "type": {
+              "kind": "SCALAR",
+              "name": "String"
+            }
+          },
+          {
+            "name": "p_sort_order",
+            "type": {
+              "kind": "SCALAR",
+              "name": "String"
+            }
+          },
+          {
+            "name": "p_transaction_hash",
+            "type": {
+              "kind": "SCALAR",
+              "name": "String"
+            }
+          }
+        ],
+        "isOneOf": false
+      },
+      {
+        "kind": "OBJECT",
+        "name": "v2_packet_type",
+        "fields": [
+          {
+            "name": "acknowledgement",
+            "type": {
+              "kind": "SCALAR",
+              "name": "String"
+            },
+            "args": [],
+            "isDeprecated": false
+          },
+          {
+            "name": "channel_version",
+            "type": {
+              "kind": "SCALAR",
+              "name": "String"
+            },
+            "args": [],
+            "isDeprecated": false
+          },
+          {
+            "name": "data",
+            "type": {
+              "kind": "SCALAR",
+              "name": "String"
+            },
+            "args": [],
+            "isDeprecated": false
+          },
+          {
+            "name": "decoded",
+            "type": {
+              "kind": "SCALAR",
+              "name": "jsonb"
+            },
+            "args": [
+              {
+                "name": "path",
+                "type": {
+                  "kind": "SCALAR",
+                  "name": "String"
+                }
+              }
+            ],
+            "isDeprecated": false
+          },
+          {
+            "name": "decoded_flattened",
+            "type": {
+              "kind": "SCALAR",
+              "name": "jsonb"
+            },
+            "args": [
+              {
+                "name": "path",
+                "type": {
+                  "kind": "SCALAR",
+                  "name": "String"
+                }
+              }
+            ],
+            "isDeprecated": false
+          },
+          {
+            "name": "destination_chain",
+            "type": {
+              "kind": "OBJECT",
+              "name": "v2_chains_view"
+            },
+            "args": [],
+            "isDeprecated": false
+          },
+          {
+            "name": "destination_chain_id",
+            "type": {
+              "kind": "SCALAR",
+              "name": "String"
+            },
+            "args": [],
+            "isDeprecated": false
+          },
+          {
+            "name": "destination_channel_id",
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int"
+            },
+            "args": [],
+            "isDeprecated": false
+          },
+          {
+            "name": "destination_client_id",
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int"
+            },
+            "args": [],
+            "isDeprecated": false
+          },
+          {
+            "name": "destination_connection_id",
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int"
+            },
+            "args": [],
+            "isDeprecated": false
+          },
+          {
+            "name": "destination_port_id",
+            "type": {
+              "kind": "SCALAR",
+              "name": "String"
+            },
+            "args": [],
+            "isDeprecated": false
+          },
+          {
+            "name": "destination_universal_chain_id",
+            "type": {
+              "kind": "SCALAR",
+              "name": "String"
+            },
+            "args": [],
+            "isDeprecated": false
+          },
+          {
+            "name": "packet_ack_block_hash",
+            "type": {
+              "kind": "SCALAR",
+              "name": "String"
+            },
+            "args": [],
+            "isDeprecated": false
+          },
+          {
+            "name": "packet_ack_height",
+            "type": {
+              "kind": "SCALAR",
+              "name": "String"
+            },
+            "args": [],
+            "isDeprecated": false
+          },
+          {
+            "name": "packet_ack_maker",
+            "type": {
+              "kind": "SCALAR",
+              "name": "String"
+            },
+            "args": [],
+            "isDeprecated": false
+          },
+          {
+            "name": "packet_ack_timestamp",
+            "type": {
+              "kind": "SCALAR",
+              "name": "timestamptz"
+            },
+            "args": [],
+            "isDeprecated": false
+          },
+          {
+            "name": "packet_ack_transaction_hash",
+            "type": {
+              "kind": "SCALAR",
+              "name": "String"
+            },
+            "args": [],
+            "isDeprecated": false
+          },
+          {
+            "name": "packet_hash",
+            "type": {
+              "kind": "SCALAR",
+              "name": "String"
+            },
+            "args": [],
+            "isDeprecated": false
+          },
+          {
+            "name": "packet_recv_block_hash",
+            "type": {
+              "kind": "SCALAR",
+              "name": "String"
+            },
+            "args": [],
+            "isDeprecated": false
+          },
+          {
+            "name": "packet_recv_height",
+            "type": {
+              "kind": "SCALAR",
+              "name": "String"
+            },
+            "args": [],
+            "isDeprecated": false
+          },
+          {
+            "name": "packet_recv_maker",
+            "type": {
+              "kind": "SCALAR",
+              "name": "String"
+            },
+            "args": [],
+            "isDeprecated": false
+          },
+          {
+            "name": "packet_recv_maker_msg",
+            "type": {
+              "kind": "SCALAR",
+              "name": "String"
+            },
+            "args": [],
+            "isDeprecated": false
+          },
+          {
+            "name": "packet_recv_timestamp",
+            "type": {
+              "kind": "SCALAR",
+              "name": "timestamptz"
+            },
+            "args": [],
+            "isDeprecated": false
+          },
+          {
+            "name": "packet_recv_transaction_hash",
+            "type": {
+              "kind": "SCALAR",
+              "name": "String"
+            },
+            "args": [],
+            "isDeprecated": false
+          },
+          {
+            "name": "packet_send_block_hash",
+            "type": {
+              "kind": "SCALAR",
+              "name": "String"
+            },
+            "args": [],
+            "isDeprecated": false
+          },
+          {
+            "name": "packet_send_height",
+            "type": {
+              "kind": "SCALAR",
+              "name": "String"
+            },
+            "args": [],
+            "isDeprecated": false
+          },
+          {
+            "name": "packet_send_timestamp",
+            "type": {
+              "kind": "SCALAR",
+              "name": "timestamptz"
+            },
+            "args": [],
+            "isDeprecated": false
+          },
+          {
+            "name": "packet_send_transaction_hash",
+            "type": {
+              "kind": "SCALAR",
+              "name": "String"
+            },
+            "args": [],
+            "isDeprecated": false
+          },
+          {
+            "name": "packet_timeout_block_hash",
+            "type": {
+              "kind": "SCALAR",
+              "name": "String"
+            },
+            "args": [],
+            "isDeprecated": false
+          },
+          {
+            "name": "packet_timeout_height",
+            "type": {
+              "kind": "SCALAR",
+              "name": "String"
+            },
+            "args": [],
+            "isDeprecated": false
+          },
+          {
+            "name": "packet_timeout_maker",
+            "type": {
+              "kind": "SCALAR",
+              "name": "String"
+            },
+            "args": [],
+            "isDeprecated": false
+          },
+          {
+            "name": "packet_timeout_timestamp",
+            "type": {
+              "kind": "SCALAR",
+              "name": "timestamptz"
+            },
+            "args": [],
+            "isDeprecated": false
+          },
+          {
+            "name": "packet_timeout_transaction_hash",
+            "type": {
+              "kind": "SCALAR",
+              "name": "String"
+            },
+            "args": [],
+            "isDeprecated": false
+          },
+          {
+            "name": "sort_order",
+            "type": {
+              "kind": "SCALAR",
+              "name": "String"
+            },
+            "args": [],
+            "isDeprecated": false
+          },
+          {
+            "name": "source_chain",
+            "type": {
+              "kind": "OBJECT",
+              "name": "v2_chains_view"
+            },
+            "args": [],
+            "isDeprecated": false
+          },
+          {
+            "name": "source_channel_id",
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int"
+            },
+            "args": [],
+            "isDeprecated": false
+          },
+          {
+            "name": "source_client_id",
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int"
+            },
+            "args": [],
+            "isDeprecated": false
+          },
+          {
+            "name": "source_connection_id",
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int"
+            },
+            "args": [],
+            "isDeprecated": false
+          },
+          {
+            "name": "source_port_id",
+            "type": {
+              "kind": "SCALAR",
+              "name": "String"
+            },
+            "args": [],
+            "isDeprecated": false
+          },
+          {
+            "name": "source_universal_chain_id",
+            "type": {
+              "kind": "SCALAR",
+              "name": "String"
+            },
+            "args": [],
+            "isDeprecated": false
+          },
+          {
+            "name": "status",
+            "type": {
+              "kind": "SCALAR",
+              "name": "String"
+            },
+            "args": [],
+            "isDeprecated": false
+          },
+          {
+            "name": "success",
+            "type": {
+              "kind": "SCALAR",
+              "name": "Boolean"
+            },
+            "args": [],
+            "isDeprecated": false
+          },
+          {
+            "name": "timeout_height",
+            "type": {
+              "kind": "SCALAR",
+              "name": "String"
+            },
+            "args": [],
+            "isDeprecated": false
+          },
+          {
+            "name": "timeout_timestamp",
+            "type": {
+              "kind": "SCALAR",
+              "name": "String"
+            },
+            "args": [],
+            "isDeprecated": false
+          },
+          {
+            "name": "traces",
+            "type": {
+              "kind": "LIST",
+              "ofType": {
+                "kind": "NON_NULL",
+                "ofType": {
+                  "kind": "OBJECT",
+                  "name": "v2_traces_type"
+                }
+              }
+            },
+            "args": [
+              {
+                "name": "distinct_on",
+                "type": {
+                  "kind": "LIST",
+                  "ofType": {
+                    "kind": "NON_NULL",
+                    "ofType": {
+                      "kind": "ENUM",
+                      "name": "v2_traces_type_select_column"
+                    }
+                  }
+                }
+              },
+              {
+                "name": "limit",
+                "type": {
+                  "kind": "SCALAR",
+                  "name": "Int"
+                }
+              },
+              {
+                "name": "offset",
+                "type": {
+                  "kind": "SCALAR",
+                  "name": "Int"
+                }
+              },
+              {
+                "name": "order_by",
+                "type": {
+                  "kind": "LIST",
+                  "ofType": {
+                    "kind": "NON_NULL",
+                    "ofType": {
+                      "kind": "INPUT_OBJECT",
+                      "name": "v2_traces_type_order_by"
+                    }
+                  }
+                }
+              },
+              {
+                "name": "where",
+                "type": {
+                  "kind": "INPUT_OBJECT",
+                  "name": "v2_traces_type_bool_exp"
+                }
+              }
+            ],
+            "isDeprecated": false
+          },
+          {
+            "name": "write_ack_block_hash",
+            "type": {
+              "kind": "SCALAR",
+              "name": "String"
+            },
+            "args": [],
+            "isDeprecated": false
+          },
+          {
+            "name": "write_ack_height",
+            "type": {
+              "kind": "SCALAR",
+              "name": "String"
+            },
+            "args": [],
+            "isDeprecated": false
+          },
+          {
+            "name": "write_ack_timestamp",
+            "type": {
+              "kind": "SCALAR",
+              "name": "timestamptz"
+            },
+            "args": [],
+            "isDeprecated": false
+          },
+          {
+            "name": "write_ack_transaction_hash",
+            "type": {
+              "kind": "SCALAR",
+              "name": "String"
+            },
+            "args": [],
+            "isDeprecated": false
+          }
+        ],
+        "interfaces": []
+      },
+      {
+        "kind": "INPUT_OBJECT",
+        "name": "v2_packet_type_bool_exp",
+        "inputFields": [
+          {
+            "name": "_and",
+            "type": {
+              "kind": "LIST",
+              "ofType": {
+                "kind": "NON_NULL",
+                "ofType": {
+                  "kind": "INPUT_OBJECT",
+                  "name": "v2_packet_type_bool_exp"
+                }
+              }
+            }
+          },
+          {
+            "name": "_not",
+            "type": {
+              "kind": "INPUT_OBJECT",
+              "name": "v2_packet_type_bool_exp"
+            }
+          },
+          {
+            "name": "_or",
+            "type": {
+              "kind": "LIST",
+              "ofType": {
+                "kind": "NON_NULL",
+                "ofType": {
+                  "kind": "INPUT_OBJECT",
+                  "name": "v2_packet_type_bool_exp"
+                }
+              }
+            }
+          },
+          {
+            "name": "acknowledgement",
+            "type": {
+              "kind": "INPUT_OBJECT",
+              "name": "String_comparison_exp"
+            }
+          },
+          {
+            "name": "channel_version",
+            "type": {
+              "kind": "INPUT_OBJECT",
+              "name": "String_comparison_exp"
+            }
+          },
+          {
+            "name": "data",
+            "type": {
+              "kind": "INPUT_OBJECT",
+              "name": "String_comparison_exp"
+            }
+          },
+          {
+            "name": "decoded",
+            "type": {
+              "kind": "INPUT_OBJECT",
+              "name": "jsonb_comparison_exp"
+            }
+          },
+          {
+            "name": "decoded_flattened",
+            "type": {
+              "kind": "INPUT_OBJECT",
+              "name": "jsonb_comparison_exp"
+            }
+          },
+          {
+            "name": "destination_chain",
+            "type": {
+              "kind": "INPUT_OBJECT",
+              "name": "v2_chains_view_bool_exp"
+            }
+          },
+          {
+            "name": "destination_chain_id",
+            "type": {
+              "kind": "INPUT_OBJECT",
+              "name": "String_comparison_exp"
+            }
+          },
+          {
+            "name": "destination_channel_id",
+            "type": {
+              "kind": "INPUT_OBJECT",
+              "name": "Int_comparison_exp"
+            }
+          },
+          {
+            "name": "destination_client_id",
+            "type": {
+              "kind": "INPUT_OBJECT",
+              "name": "Int_comparison_exp"
+            }
+          },
+          {
+            "name": "destination_connection_id",
+            "type": {
+              "kind": "INPUT_OBJECT",
+              "name": "Int_comparison_exp"
+            }
+          },
+          {
+            "name": "destination_port_id",
+            "type": {
+              "kind": "INPUT_OBJECT",
+              "name": "String_comparison_exp"
+            }
+          },
+          {
+            "name": "destination_universal_chain_id",
+            "type": {
+              "kind": "INPUT_OBJECT",
+              "name": "String_comparison_exp"
+            }
+          },
+          {
+            "name": "packet_ack_block_hash",
+            "type": {
+              "kind": "INPUT_OBJECT",
+              "name": "String_comparison_exp"
+            }
+          },
+          {
+            "name": "packet_ack_height",
+            "type": {
+              "kind": "INPUT_OBJECT",
+              "name": "String_comparison_exp"
+            }
+          },
+          {
+            "name": "packet_ack_maker",
+            "type": {
+              "kind": "INPUT_OBJECT",
+              "name": "String_comparison_exp"
+            }
+          },
+          {
+            "name": "packet_ack_timestamp",
+            "type": {
+              "kind": "INPUT_OBJECT",
+              "name": "timestamptz_comparison_exp"
+            }
+          },
+          {
+            "name": "packet_ack_transaction_hash",
+            "type": {
+              "kind": "INPUT_OBJECT",
+              "name": "String_comparison_exp"
+            }
+          },
+          {
+            "name": "packet_hash",
+            "type": {
+              "kind": "INPUT_OBJECT",
+              "name": "String_comparison_exp"
+            }
+          },
+          {
+            "name": "packet_recv_block_hash",
+            "type": {
+              "kind": "INPUT_OBJECT",
+              "name": "String_comparison_exp"
+            }
+          },
+          {
+            "name": "packet_recv_height",
+            "type": {
+              "kind": "INPUT_OBJECT",
+              "name": "String_comparison_exp"
+            }
+          },
+          {
+            "name": "packet_recv_maker",
+            "type": {
+              "kind": "INPUT_OBJECT",
+              "name": "String_comparison_exp"
+            }
+          },
+          {
+            "name": "packet_recv_maker_msg",
+            "type": {
+              "kind": "INPUT_OBJECT",
+              "name": "String_comparison_exp"
+            }
+          },
+          {
+            "name": "packet_recv_timestamp",
+            "type": {
+              "kind": "INPUT_OBJECT",
+              "name": "timestamptz_comparison_exp"
+            }
+          },
+          {
+            "name": "packet_recv_transaction_hash",
+            "type": {
+              "kind": "INPUT_OBJECT",
+              "name": "String_comparison_exp"
+            }
+          },
+          {
+            "name": "packet_send_block_hash",
+            "type": {
+              "kind": "INPUT_OBJECT",
+              "name": "String_comparison_exp"
+            }
+          },
+          {
+            "name": "packet_send_height",
+            "type": {
+              "kind": "INPUT_OBJECT",
+              "name": "String_comparison_exp"
+            }
+          },
+          {
+            "name": "packet_send_timestamp",
+            "type": {
+              "kind": "INPUT_OBJECT",
+              "name": "timestamptz_comparison_exp"
+            }
+          },
+          {
+            "name": "packet_send_transaction_hash",
+            "type": {
+              "kind": "INPUT_OBJECT",
+              "name": "String_comparison_exp"
+            }
+          },
+          {
+            "name": "packet_timeout_block_hash",
+            "type": {
+              "kind": "INPUT_OBJECT",
+              "name": "String_comparison_exp"
+            }
+          },
+          {
+            "name": "packet_timeout_height",
+            "type": {
+              "kind": "INPUT_OBJECT",
+              "name": "String_comparison_exp"
+            }
+          },
+          {
+            "name": "packet_timeout_maker",
+            "type": {
+              "kind": "INPUT_OBJECT",
+              "name": "String_comparison_exp"
+            }
+          },
+          {
+            "name": "packet_timeout_timestamp",
+            "type": {
+              "kind": "INPUT_OBJECT",
+              "name": "timestamptz_comparison_exp"
+            }
+          },
+          {
+            "name": "packet_timeout_transaction_hash",
+            "type": {
+              "kind": "INPUT_OBJECT",
+              "name": "String_comparison_exp"
+            }
+          },
+          {
+            "name": "sort_order",
+            "type": {
+              "kind": "INPUT_OBJECT",
+              "name": "String_comparison_exp"
+            }
+          },
+          {
+            "name": "source_chain",
+            "type": {
+              "kind": "INPUT_OBJECT",
+              "name": "v2_chains_view_bool_exp"
+            }
+          },
+          {
+            "name": "source_channel_id",
+            "type": {
+              "kind": "INPUT_OBJECT",
+              "name": "Int_comparison_exp"
+            }
+          },
+          {
+            "name": "source_client_id",
+            "type": {
+              "kind": "INPUT_OBJECT",
+              "name": "Int_comparison_exp"
+            }
+          },
+          {
+            "name": "source_connection_id",
+            "type": {
+              "kind": "INPUT_OBJECT",
+              "name": "Int_comparison_exp"
+            }
+          },
+          {
+            "name": "source_port_id",
+            "type": {
+              "kind": "INPUT_OBJECT",
+              "name": "String_comparison_exp"
+            }
+          },
+          {
+            "name": "source_universal_chain_id",
+            "type": {
+              "kind": "INPUT_OBJECT",
+              "name": "String_comparison_exp"
+            }
+          },
+          {
+            "name": "status",
+            "type": {
+              "kind": "INPUT_OBJECT",
+              "name": "String_comparison_exp"
+            }
+          },
+          {
+            "name": "success",
+            "type": {
+              "kind": "INPUT_OBJECT",
+              "name": "Boolean_comparison_exp"
+            }
+          },
+          {
+            "name": "timeout_height",
+            "type": {
+              "kind": "INPUT_OBJECT",
+              "name": "String_comparison_exp"
+            }
+          },
+          {
+            "name": "timeout_timestamp",
+            "type": {
+              "kind": "INPUT_OBJECT",
+              "name": "String_comparison_exp"
+            }
+          },
+          {
+            "name": "traces",
+            "type": {
+              "kind": "INPUT_OBJECT",
+              "name": "v2_traces_type_bool_exp"
+            }
+          },
+          {
+            "name": "write_ack_block_hash",
+            "type": {
+              "kind": "INPUT_OBJECT",
+              "name": "String_comparison_exp"
+            }
+          },
+          {
+            "name": "write_ack_height",
+            "type": {
+              "kind": "INPUT_OBJECT",
+              "name": "String_comparison_exp"
+            }
+          },
+          {
+            "name": "write_ack_timestamp",
+            "type": {
+              "kind": "INPUT_OBJECT",
+              "name": "timestamptz_comparison_exp"
+            }
+          },
+          {
+            "name": "write_ack_transaction_hash",
+            "type": {
+              "kind": "INPUT_OBJECT",
+              "name": "String_comparison_exp"
+            }
+          }
+        ],
+        "isOneOf": false
+      },
+      {
+        "kind": "INPUT_OBJECT",
+        "name": "v2_packet_type_order_by",
+        "inputFields": [
+          {
+            "name": "acknowledgement",
+            "type": {
+              "kind": "ENUM",
+              "name": "order_by"
+            }
+          },
+          {
+            "name": "channel_version",
+            "type": {
+              "kind": "ENUM",
+              "name": "order_by"
+            }
+          },
+          {
+            "name": "data",
+            "type": {
+              "kind": "ENUM",
+              "name": "order_by"
+            }
+          },
+          {
+            "name": "decoded",
+            "type": {
+              "kind": "ENUM",
+              "name": "order_by"
+            }
+          },
+          {
+            "name": "decoded_flattened",
+            "type": {
+              "kind": "ENUM",
+              "name": "order_by"
+            }
+          },
+          {
+            "name": "destination_chain",
+            "type": {
+              "kind": "INPUT_OBJECT",
+              "name": "v2_chains_view_order_by"
+            }
+          },
+          {
+            "name": "destination_chain_id",
+            "type": {
+              "kind": "ENUM",
+              "name": "order_by"
+            }
+          },
+          {
+            "name": "destination_channel_id",
+            "type": {
+              "kind": "ENUM",
+              "name": "order_by"
+            }
+          },
+          {
+            "name": "destination_client_id",
+            "type": {
+              "kind": "ENUM",
+              "name": "order_by"
+            }
+          },
+          {
+            "name": "destination_connection_id",
+            "type": {
+              "kind": "ENUM",
+              "name": "order_by"
+            }
+          },
+          {
+            "name": "destination_port_id",
+            "type": {
+              "kind": "ENUM",
+              "name": "order_by"
+            }
+          },
+          {
+            "name": "destination_universal_chain_id",
+            "type": {
+              "kind": "ENUM",
+              "name": "order_by"
+            }
+          },
+          {
+            "name": "packet_ack_block_hash",
+            "type": {
+              "kind": "ENUM",
+              "name": "order_by"
+            }
+          },
+          {
+            "name": "packet_ack_height",
+            "type": {
+              "kind": "ENUM",
+              "name": "order_by"
+            }
+          },
+          {
+            "name": "packet_ack_maker",
+            "type": {
+              "kind": "ENUM",
+              "name": "order_by"
+            }
+          },
+          {
+            "name": "packet_ack_timestamp",
+            "type": {
+              "kind": "ENUM",
+              "name": "order_by"
+            }
+          },
+          {
+            "name": "packet_ack_transaction_hash",
+            "type": {
+              "kind": "ENUM",
+              "name": "order_by"
+            }
+          },
+          {
+            "name": "packet_hash",
+            "type": {
+              "kind": "ENUM",
+              "name": "order_by"
+            }
+          },
+          {
+            "name": "packet_recv_block_hash",
+            "type": {
+              "kind": "ENUM",
+              "name": "order_by"
+            }
+          },
+          {
+            "name": "packet_recv_height",
+            "type": {
+              "kind": "ENUM",
+              "name": "order_by"
+            }
+          },
+          {
+            "name": "packet_recv_maker",
+            "type": {
+              "kind": "ENUM",
+              "name": "order_by"
+            }
+          },
+          {
+            "name": "packet_recv_maker_msg",
+            "type": {
+              "kind": "ENUM",
+              "name": "order_by"
+            }
+          },
+          {
+            "name": "packet_recv_timestamp",
+            "type": {
+              "kind": "ENUM",
+              "name": "order_by"
+            }
+          },
+          {
+            "name": "packet_recv_transaction_hash",
+            "type": {
+              "kind": "ENUM",
+              "name": "order_by"
+            }
+          },
+          {
+            "name": "packet_send_block_hash",
+            "type": {
+              "kind": "ENUM",
+              "name": "order_by"
+            }
+          },
+          {
+            "name": "packet_send_height",
+            "type": {
+              "kind": "ENUM",
+              "name": "order_by"
+            }
+          },
+          {
+            "name": "packet_send_timestamp",
+            "type": {
+              "kind": "ENUM",
+              "name": "order_by"
+            }
+          },
+          {
+            "name": "packet_send_transaction_hash",
+            "type": {
+              "kind": "ENUM",
+              "name": "order_by"
+            }
+          },
+          {
+            "name": "packet_timeout_block_hash",
+            "type": {
+              "kind": "ENUM",
+              "name": "order_by"
+            }
+          },
+          {
+            "name": "packet_timeout_height",
+            "type": {
+              "kind": "ENUM",
+              "name": "order_by"
+            }
+          },
+          {
+            "name": "packet_timeout_maker",
+            "type": {
+              "kind": "ENUM",
+              "name": "order_by"
+            }
+          },
+          {
+            "name": "packet_timeout_timestamp",
+            "type": {
+              "kind": "ENUM",
+              "name": "order_by"
+            }
+          },
+          {
+            "name": "packet_timeout_transaction_hash",
+            "type": {
+              "kind": "ENUM",
+              "name": "order_by"
+            }
+          },
+          {
+            "name": "sort_order",
+            "type": {
+              "kind": "ENUM",
+              "name": "order_by"
+            }
+          },
+          {
+            "name": "source_chain",
+            "type": {
+              "kind": "INPUT_OBJECT",
+              "name": "v2_chains_view_order_by"
+            }
+          },
+          {
+            "name": "source_channel_id",
+            "type": {
+              "kind": "ENUM",
+              "name": "order_by"
+            }
+          },
+          {
+            "name": "source_client_id",
+            "type": {
+              "kind": "ENUM",
+              "name": "order_by"
+            }
+          },
+          {
+            "name": "source_connection_id",
+            "type": {
+              "kind": "ENUM",
+              "name": "order_by"
+            }
+          },
+          {
+            "name": "source_port_id",
+            "type": {
+              "kind": "ENUM",
+              "name": "order_by"
+            }
+          },
+          {
+            "name": "source_universal_chain_id",
+            "type": {
+              "kind": "ENUM",
+              "name": "order_by"
+            }
+          },
+          {
+            "name": "status",
+            "type": {
+              "kind": "ENUM",
+              "name": "order_by"
+            }
+          },
+          {
+            "name": "success",
+            "type": {
+              "kind": "ENUM",
+              "name": "order_by"
+            }
+          },
+          {
+            "name": "timeout_height",
+            "type": {
+              "kind": "ENUM",
+              "name": "order_by"
+            }
+          },
+          {
+            "name": "timeout_timestamp",
+            "type": {
+              "kind": "ENUM",
+              "name": "order_by"
+            }
+          },
+          {
+            "name": "traces_aggregate",
+            "type": {
+              "kind": "INPUT_OBJECT",
+              "name": "v2_traces_type_aggregate_order_by"
+            }
+          },
+          {
+            "name": "write_ack_block_hash",
+            "type": {
+              "kind": "ENUM",
+              "name": "order_by"
+            }
+          },
+          {
+            "name": "write_ack_height",
+            "type": {
+              "kind": "ENUM",
+              "name": "order_by"
+            }
+          },
+          {
+            "name": "write_ack_timestamp",
+            "type": {
+              "kind": "ENUM",
+              "name": "order_by"
+            }
+          },
+          {
+            "name": "write_ack_transaction_hash",
+            "type": {
+              "kind": "ENUM",
+              "name": "order_by"
+            }
+          }
+        ],
+        "isOneOf": false
+      },
+      {
+        "kind": "ENUM",
+        "name": "v2_packet_type_select_column",
+        "enumValues": [
+          {
+            "name": "acknowledgement",
+            "isDeprecated": false
+          },
+          {
+            "name": "channel_version",
+            "isDeprecated": false
+          },
+          {
+            "name": "data",
+            "isDeprecated": false
+          },
+          {
+            "name": "decoded",
+            "isDeprecated": false
+          },
+          {
+            "name": "decoded_flattened",
+            "isDeprecated": false
+          },
+          {
+            "name": "destination_chain_id",
+            "isDeprecated": false
+          },
+          {
+            "name": "destination_channel_id",
+            "isDeprecated": false
+          },
+          {
+            "name": "destination_client_id",
+            "isDeprecated": false
+          },
+          {
+            "name": "destination_connection_id",
+            "isDeprecated": false
+          },
+          {
+            "name": "destination_port_id",
+            "isDeprecated": false
+          },
+          {
+            "name": "destination_universal_chain_id",
+            "isDeprecated": false
+          },
+          {
+            "name": "packet_ack_block_hash",
+            "isDeprecated": false
+          },
+          {
+            "name": "packet_ack_height",
+            "isDeprecated": false
+          },
+          {
+            "name": "packet_ack_maker",
+            "isDeprecated": false
+          },
+          {
+            "name": "packet_ack_timestamp",
+            "isDeprecated": false
+          },
+          {
+            "name": "packet_ack_transaction_hash",
+            "isDeprecated": false
+          },
+          {
+            "name": "packet_hash",
+            "isDeprecated": false
+          },
+          {
+            "name": "packet_recv_block_hash",
+            "isDeprecated": false
+          },
+          {
+            "name": "packet_recv_height",
+            "isDeprecated": false
+          },
+          {
+            "name": "packet_recv_maker",
+            "isDeprecated": false
+          },
+          {
+            "name": "packet_recv_maker_msg",
+            "isDeprecated": false
+          },
+          {
+            "name": "packet_recv_timestamp",
+            "isDeprecated": false
+          },
+          {
+            "name": "packet_recv_transaction_hash",
+            "isDeprecated": false
+          },
+          {
+            "name": "packet_send_block_hash",
+            "isDeprecated": false
+          },
+          {
+            "name": "packet_send_height",
+            "isDeprecated": false
+          },
+          {
+            "name": "packet_send_timestamp",
+            "isDeprecated": false
+          },
+          {
+            "name": "packet_send_transaction_hash",
+            "isDeprecated": false
+          },
+          {
+            "name": "packet_timeout_block_hash",
+            "isDeprecated": false
+          },
+          {
+            "name": "packet_timeout_height",
+            "isDeprecated": false
+          },
+          {
+            "name": "packet_timeout_maker",
+            "isDeprecated": false
+          },
+          {
+            "name": "packet_timeout_timestamp",
+            "isDeprecated": false
+          },
+          {
+            "name": "packet_timeout_transaction_hash",
+            "isDeprecated": false
+          },
+          {
+            "name": "sort_order",
+            "isDeprecated": false
+          },
+          {
+            "name": "source_channel_id",
+            "isDeprecated": false
+          },
+          {
+            "name": "source_client_id",
+            "isDeprecated": false
+          },
+          {
+            "name": "source_connection_id",
+            "isDeprecated": false
+          },
+          {
+            "name": "source_port_id",
+            "isDeprecated": false
+          },
+          {
+            "name": "source_universal_chain_id",
+            "isDeprecated": false
+          },
+          {
+            "name": "status",
+            "isDeprecated": false
+          },
+          {
+            "name": "success",
+            "isDeprecated": false
+          },
+          {
+            "name": "timeout_height",
+            "isDeprecated": false
+          },
+          {
+            "name": "timeout_timestamp",
+            "isDeprecated": false
+          },
+          {
+            "name": "write_ack_block_hash",
+            "isDeprecated": false
+          },
+          {
+            "name": "write_ack_height",
+            "isDeprecated": false
+          },
+          {
+            "name": "write_ack_timestamp",
+            "isDeprecated": false
+          },
+          {
+            "name": "write_ack_transaction_hash",
+            "isDeprecated": false
+          }
+        ]
+      },
+      {
+        "kind": "INPUT_OBJECT",
+        "name": "v2_packets_args",
+        "inputFields": [
+          {
+            "name": "p_block_hash",
+            "type": {
+              "kind": "SCALAR",
+              "name": "String"
+            }
+          },
+          {
+            "name": "p_comparison",
+            "type": {
+              "kind": "SCALAR",
+              "name": "String"
+            }
+          },
+          {
+            "name": "p_destination_universal_chain_id",
+            "type": {
+              "kind": "SCALAR",
+              "name": "String"
+            }
+          },
+          {
+            "name": "p_exceeding_sla",
+            "type": {
+              "kind": "SCALAR",
+              "name": "String"
+            }
+          },
+          {
+            "name": "p_limit",
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int"
+            }
+          },
+          {
+            "name": "p_network",
+            "type": {
+              "kind": "SCALAR",
+              "name": "String"
+            }
+          },
+          {
+            "name": "p_packet_hash",
+            "type": {
+              "kind": "SCALAR",
+              "name": "String"
+            }
+          },
+          {
+            "name": "p_packet_send_timestamp",
+            "type": {
+              "kind": "SCALAR",
+              "name": "timestamptz"
+            }
+          },
+          {
+            "name": "p_sort_order",
+            "type": {
+              "kind": "SCALAR",
+              "name": "String"
+            }
+          },
+          {
+            "name": "p_source_universal_chain_id",
+            "type": {
+              "kind": "SCALAR",
+              "name": "String"
+            }
+          },
+          {
+            "name": "p_transaction_hash",
+            "type": {
+              "kind": "SCALAR",
+              "name": "String"
+            }
+          }
+        ],
+        "isOneOf": false
+      },
+      {
+        "kind": "OBJECT",
+        "name": "v2_rpcs",
+        "fields": [
+          {
+            "name": "type",
+            "type": {
+              "kind": "SCALAR",
+              "name": "String"
+            },
+            "args": [],
+            "isDeprecated": false
+          },
+          {
+            "name": "url",
+            "type": {
+              "kind": "SCALAR",
+              "name": "String"
+            },
+            "args": [],
+            "isDeprecated": false
+          }
+        ],
+        "interfaces": []
+      },
+      {
+        "kind": "INPUT_OBJECT",
+        "name": "v2_rpcs_aggregate_order_by",
+        "inputFields": [
+          {
+            "name": "count",
+            "type": {
+              "kind": "ENUM",
+              "name": "order_by"
+            }
+          },
+          {
+            "name": "max",
+            "type": {
+              "kind": "INPUT_OBJECT",
+              "name": "v2_rpcs_max_order_by"
+            }
+          },
+          {
+            "name": "min",
+            "type": {
+              "kind": "INPUT_OBJECT",
+              "name": "v2_rpcs_min_order_by"
+            }
+          }
+        ],
+        "isOneOf": false
+      },
+      {
+        "kind": "INPUT_OBJECT",
+        "name": "v2_rpcs_bool_exp",
+        "inputFields": [
+          {
+            "name": "_and",
+            "type": {
+              "kind": "LIST",
+              "ofType": {
+                "kind": "NON_NULL",
+                "ofType": {
+                  "kind": "INPUT_OBJECT",
+                  "name": "v2_rpcs_bool_exp"
+                }
+              }
+            }
+          },
+          {
+            "name": "_not",
+            "type": {
+              "kind": "INPUT_OBJECT",
+              "name": "v2_rpcs_bool_exp"
+            }
+          },
+          {
+            "name": "_or",
+            "type": {
+              "kind": "LIST",
+              "ofType": {
+                "kind": "NON_NULL",
+                "ofType": {
+                  "kind": "INPUT_OBJECT",
+                  "name": "v2_rpcs_bool_exp"
+                }
+              }
+            }
+          },
+          {
+            "name": "type",
+            "type": {
+              "kind": "INPUT_OBJECT",
+              "name": "String_comparison_exp"
+            }
+          },
+          {
+            "name": "url",
+            "type": {
+              "kind": "INPUT_OBJECT",
+              "name": "String_comparison_exp"
+            }
+          }
+        ],
+        "isOneOf": false
+      },
+      {
+        "kind": "INPUT_OBJECT",
+        "name": "v2_rpcs_max_order_by",
+        "inputFields": [
+          {
+            "name": "type",
+            "type": {
+              "kind": "ENUM",
+              "name": "order_by"
+            }
+          },
+          {
+            "name": "url",
+            "type": {
+              "kind": "ENUM",
+              "name": "order_by"
+            }
+          }
+        ],
+        "isOneOf": false
+      },
+      {
+        "kind": "INPUT_OBJECT",
+        "name": "v2_rpcs_min_order_by",
+        "inputFields": [
+          {
+            "name": "type",
+            "type": {
+              "kind": "ENUM",
+              "name": "order_by"
+            }
+          },
+          {
+            "name": "url",
+            "type": {
+              "kind": "ENUM",
+              "name": "order_by"
+            }
+          }
+        ],
+        "isOneOf": false
+      },
+      {
+        "kind": "INPUT_OBJECT",
+        "name": "v2_rpcs_order_by",
+        "inputFields": [
+          {
+            "name": "type",
+            "type": {
+              "kind": "ENUM",
+              "name": "order_by"
+            }
+          },
+          {
+            "name": "url",
+            "type": {
+              "kind": "ENUM",
+              "name": "order_by"
+            }
+          }
+        ],
+        "isOneOf": false
+      },
+      {
+        "kind": "ENUM",
+        "name": "v2_rpcs_select_column",
+        "enumValues": [
+          {
+            "name": "type",
+            "isDeprecated": false
+          },
+          {
+            "name": "url",
+            "isDeprecated": false
+          }
+        ]
+      },
+      {
+        "kind": "OBJECT",
+        "name": "v2_stats_daily_count_type",
+        "fields": [
+          {
+            "name": "count",
+            "type": {
+              "kind": "SCALAR",
+              "name": "String"
+            },
+            "args": [],
+            "isDeprecated": false
+          },
+          {
+            "name": "day_date",
+            "type": {
+              "kind": "SCALAR",
+              "name": "date"
+            },
+            "args": [],
+            "isDeprecated": false
+          }
+        ],
+        "interfaces": []
+      },
+      {
+        "kind": "INPUT_OBJECT",
+        "name": "v2_stats_daily_count_type_bool_exp",
+        "inputFields": [
+          {
+            "name": "_and",
+            "type": {
+              "kind": "LIST",
+              "ofType": {
+                "kind": "NON_NULL",
+                "ofType": {
+                  "kind": "INPUT_OBJECT",
+                  "name": "v2_stats_daily_count_type_bool_exp"
+                }
+              }
+            }
+          },
+          {
+            "name": "_not",
+            "type": {
+              "kind": "INPUT_OBJECT",
+              "name": "v2_stats_daily_count_type_bool_exp"
+            }
+          },
+          {
+            "name": "_or",
+            "type": {
+              "kind": "LIST",
+              "ofType": {
+                "kind": "NON_NULL",
+                "ofType": {
+                  "kind": "INPUT_OBJECT",
+                  "name": "v2_stats_daily_count_type_bool_exp"
+                }
+              }
+            }
+          },
+          {
+            "name": "count",
+            "type": {
+              "kind": "INPUT_OBJECT",
+              "name": "String_comparison_exp"
+            }
+          },
+          {
+            "name": "day_date",
+            "type": {
+              "kind": "INPUT_OBJECT",
+              "name": "date_comparison_exp"
+            }
+          }
+        ],
+        "isOneOf": false
+      },
+      {
+        "kind": "INPUT_OBJECT",
+        "name": "v2_stats_daily_count_type_order_by",
+        "inputFields": [
+          {
+            "name": "count",
+            "type": {
+              "kind": "ENUM",
+              "name": "order_by"
+            }
+          },
+          {
+            "name": "day_date",
+            "type": {
+              "kind": "ENUM",
+              "name": "order_by"
+            }
+          }
+        ],
+        "isOneOf": false
+      },
+      {
+        "kind": "ENUM",
+        "name": "v2_stats_daily_count_type_select_column",
+        "enumValues": [
+          {
+            "name": "count",
+            "isDeprecated": false
+          },
+          {
+            "name": "day_date",
+            "isDeprecated": false
+          }
+        ]
+      },
+      {
+        "kind": "INPUT_OBJECT",
+        "name": "v2_stats_latency_args",
+        "inputFields": [
+          {
+            "name": "p_destination_universal_chain_id",
+            "type": {
+              "kind": "SCALAR",
+              "name": "String"
+            }
+          },
+          {
+            "name": "p_phase",
+            "type": {
+              "kind": "SCALAR",
+              "name": "String"
+            }
+          },
+          {
+            "name": "p_source_universal_chain_id",
+            "type": {
+              "kind": "SCALAR",
+              "name": "String"
+            }
+          }
+        ],
+        "isOneOf": false
+      },
+      {
+        "kind": "OBJECT",
+        "name": "v2_stats_latency_type",
+        "fields": [
+          {
+            "name": "secs_until_packet_ack",
+            "type": {
+              "kind": "SCALAR",
+              "name": "latency_percentiles_scalar"
+            },
+            "args": [],
+            "isDeprecated": false
+          },
+          {
+            "name": "secs_until_packet_recv",
+            "type": {
+              "kind": "SCALAR",
+              "name": "latency_percentiles_scalar"
+            },
+            "args": [],
+            "isDeprecated": false
+          },
+          {
+            "name": "secs_until_write_ack",
+            "type": {
+              "kind": "SCALAR",
+              "name": "latency_percentiles_scalar"
+            },
+            "args": [],
+            "isDeprecated": false
+          }
+        ],
+        "interfaces": []
+      },
+      {
+        "kind": "INPUT_OBJECT",
+        "name": "v2_stats_latency_type_bool_exp",
+        "inputFields": [
+          {
+            "name": "_and",
+            "type": {
+              "kind": "LIST",
+              "ofType": {
+                "kind": "NON_NULL",
+                "ofType": {
+                  "kind": "INPUT_OBJECT",
+                  "name": "v2_stats_latency_type_bool_exp"
+                }
+              }
+            }
+          },
+          {
+            "name": "_not",
+            "type": {
+              "kind": "INPUT_OBJECT",
+              "name": "v2_stats_latency_type_bool_exp"
+            }
+          },
+          {
+            "name": "_or",
+            "type": {
+              "kind": "LIST",
+              "ofType": {
+                "kind": "NON_NULL",
+                "ofType": {
+                  "kind": "INPUT_OBJECT",
+                  "name": "v2_stats_latency_type_bool_exp"
+                }
+              }
+            }
+          },
+          {
+            "name": "secs_until_packet_ack",
+            "type": {
+              "kind": "INPUT_OBJECT",
+              "name": "latency_percentiles_scalar_comparison_exp"
+            }
+          },
+          {
+            "name": "secs_until_packet_recv",
+            "type": {
+              "kind": "INPUT_OBJECT",
+              "name": "latency_percentiles_scalar_comparison_exp"
+            }
+          },
+          {
+            "name": "secs_until_write_ack",
+            "type": {
+              "kind": "INPUT_OBJECT",
+              "name": "latency_percentiles_scalar_comparison_exp"
+            }
+          }
+        ],
+        "isOneOf": false
+      },
+      {
+        "kind": "INPUT_OBJECT",
+        "name": "v2_stats_latency_type_order_by",
+        "inputFields": [
+          {
+            "name": "secs_until_packet_ack",
+            "type": {
+              "kind": "ENUM",
+              "name": "order_by"
+            }
+          },
+          {
+            "name": "secs_until_packet_recv",
+            "type": {
+              "kind": "ENUM",
+              "name": "order_by"
+            }
+          },
+          {
+            "name": "secs_until_write_ack",
+            "type": {
+              "kind": "ENUM",
+              "name": "order_by"
+            }
+          }
+        ],
+        "isOneOf": false
+      },
+      {
+        "kind": "ENUM",
+        "name": "v2_stats_latency_type_select_column",
+        "enumValues": [
+          {
+            "name": "secs_until_packet_ack",
+            "isDeprecated": false
+          },
+          {
+            "name": "secs_until_packet_recv",
+            "isDeprecated": false
+          },
+          {
+            "name": "secs_until_write_ack",
+            "isDeprecated": false
+          }
+        ]
+      },
+      {
+        "kind": "INPUT_OBJECT",
+        "name": "v2_stats_packets_chain_args",
+        "inputFields": [
+          {
+            "name": "p_days_back",
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int"
+            }
+          },
+          {
+            "name": "p_destination_universal_chain_id",
+            "type": {
+              "kind": "SCALAR",
+              "name": "String"
+            }
+          },
+          {
+            "name": "p_source_universal_chain_id",
+            "type": {
+              "kind": "SCALAR",
+              "name": "String"
+            }
+          }
+        ],
+        "isOneOf": false
+      },
+      {
+        "kind": "OBJECT",
+        "name": "v2_stats_packets_chain_type",
+        "fields": [
+          {
+            "name": "day_date",
+            "type": {
+              "kind": "SCALAR",
+              "name": "date"
+            },
+            "args": [],
+            "isDeprecated": false
+          },
+          {
+            "name": "destination_universal_chain_id",
+            "type": {
+              "kind": "SCALAR",
+              "name": "String"
+            },
+            "args": [],
+            "isDeprecated": false
+          },
+          {
+            "name": "source_universal_chain_id",
+            "type": {
+              "kind": "SCALAR",
+              "name": "String"
+            },
+            "args": [],
+            "isDeprecated": false
+          },
+          {
+            "name": "total_packets",
+            "type": {
+              "kind": "SCALAR",
+              "name": "String"
+            },
+            "args": [],
+            "isDeprecated": false
+          }
+        ],
+        "interfaces": []
+      },
+      {
+        "kind": "INPUT_OBJECT",
+        "name": "v2_stats_packets_chain_type_bool_exp",
+        "inputFields": [
+          {
+            "name": "_and",
+            "type": {
+              "kind": "LIST",
+              "ofType": {
+                "kind": "NON_NULL",
+                "ofType": {
+                  "kind": "INPUT_OBJECT",
+                  "name": "v2_stats_packets_chain_type_bool_exp"
+                }
+              }
+            }
+          },
+          {
+            "name": "_not",
+            "type": {
+              "kind": "INPUT_OBJECT",
+              "name": "v2_stats_packets_chain_type_bool_exp"
+            }
+          },
+          {
+            "name": "_or",
+            "type": {
+              "kind": "LIST",
+              "ofType": {
+                "kind": "NON_NULL",
+                "ofType": {
+                  "kind": "INPUT_OBJECT",
+                  "name": "v2_stats_packets_chain_type_bool_exp"
+                }
+              }
+            }
+          },
+          {
+            "name": "day_date",
+            "type": {
+              "kind": "INPUT_OBJECT",
+              "name": "date_comparison_exp"
+            }
+          },
+          {
+            "name": "destination_universal_chain_id",
+            "type": {
+              "kind": "INPUT_OBJECT",
+              "name": "String_comparison_exp"
+            }
+          },
+          {
+            "name": "source_universal_chain_id",
+            "type": {
+              "kind": "INPUT_OBJECT",
+              "name": "String_comparison_exp"
+            }
+          },
+          {
+            "name": "total_packets",
+            "type": {
+              "kind": "INPUT_OBJECT",
+              "name": "String_comparison_exp"
+            }
+          }
+        ],
+        "isOneOf": false
+      },
+      {
+        "kind": "INPUT_OBJECT",
+        "name": "v2_stats_packets_chain_type_order_by",
+        "inputFields": [
+          {
+            "name": "day_date",
+            "type": {
+              "kind": "ENUM",
+              "name": "order_by"
+            }
+          },
+          {
+            "name": "destination_universal_chain_id",
+            "type": {
+              "kind": "ENUM",
+              "name": "order_by"
+            }
+          },
+          {
+            "name": "source_universal_chain_id",
+            "type": {
+              "kind": "ENUM",
+              "name": "order_by"
+            }
+          },
+          {
+            "name": "total_packets",
+            "type": {
+              "kind": "ENUM",
+              "name": "order_by"
+            }
+          }
+        ],
+        "isOneOf": false
+      },
+      {
+        "kind": "ENUM",
+        "name": "v2_stats_packets_chain_type_select_column",
+        "enumValues": [
+          {
+            "name": "day_date",
+            "isDeprecated": false
+          },
+          {
+            "name": "destination_universal_chain_id",
+            "isDeprecated": false
+          },
+          {
+            "name": "source_universal_chain_id",
+            "isDeprecated": false
+          },
+          {
+            "name": "total_packets",
+            "isDeprecated": false
+          }
+        ]
+      },
+      {
+        "kind": "INPUT_OBJECT",
+        "name": "v2_stats_packets_daily_count_args",
+        "inputFields": [
+          {
+            "name": "p_days_back",
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int"
+            }
+          }
+        ],
+        "isOneOf": false
+      },
+      {
+        "kind": "INPUT_OBJECT",
+        "name": "v2_stats_transfers_address_args",
+        "inputFields": [
+          {
+            "name": "p_addresses_canonical",
+            "type": {
+              "kind": "SCALAR",
+              "name": "jsonb"
+            }
+          },
+          {
+            "name": "p_days_back",
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int"
+            }
+          },
+          {
+            "name": "p_destination_universal_chain_id",
+            "type": {
+              "kind": "SCALAR",
+              "name": "String"
+            }
+          },
+          {
+            "name": "p_source_universal_chain_id",
+            "type": {
+              "kind": "SCALAR",
+              "name": "String"
+            }
+          }
+        ],
+        "isOneOf": false
+      },
+      {
+        "kind": "OBJECT",
+        "name": "v2_stats_transfers_address_type",
+        "fields": [
+          {
+            "name": "canonical_address",
+            "type": {
+              "kind": "SCALAR",
+              "name": "String"
+            },
+            "args": [],
+            "isDeprecated": false
+          },
+          {
+            "name": "day_date",
+            "type": {
+              "kind": "SCALAR",
+              "name": "date"
+            },
+            "args": [],
+            "isDeprecated": false
+          },
+          {
+            "name": "destination_universal_chain_id",
+            "type": {
+              "kind": "SCALAR",
+              "name": "String"
+            },
+            "args": [],
+            "isDeprecated": false
+          },
+          {
+            "name": "source_universal_chain_id",
+            "type": {
+              "kind": "SCALAR",
+              "name": "String"
+            },
+            "args": [],
+            "isDeprecated": false
+          },
+          {
+            "name": "transfer_count",
+            "type": {
+              "kind": "SCALAR",
+              "name": "String"
+            },
+            "args": [],
+            "isDeprecated": false
+          }
+        ],
+        "interfaces": []
+      },
+      {
+        "kind": "INPUT_OBJECT",
+        "name": "v2_stats_transfers_address_type_bool_exp",
+        "inputFields": [
+          {
+            "name": "_and",
+            "type": {
+              "kind": "LIST",
+              "ofType": {
+                "kind": "NON_NULL",
+                "ofType": {
+                  "kind": "INPUT_OBJECT",
+                  "name": "v2_stats_transfers_address_type_bool_exp"
+                }
+              }
+            }
+          },
+          {
+            "name": "_not",
+            "type": {
+              "kind": "INPUT_OBJECT",
+              "name": "v2_stats_transfers_address_type_bool_exp"
+            }
+          },
+          {
+            "name": "_or",
+            "type": {
+              "kind": "LIST",
+              "ofType": {
+                "kind": "NON_NULL",
+                "ofType": {
+                  "kind": "INPUT_OBJECT",
+                  "name": "v2_stats_transfers_address_type_bool_exp"
+                }
+              }
+            }
+          },
+          {
+            "name": "canonical_address",
+            "type": {
+              "kind": "INPUT_OBJECT",
+              "name": "String_comparison_exp"
+            }
+          },
+          {
+            "name": "day_date",
+            "type": {
+              "kind": "INPUT_OBJECT",
+              "name": "date_comparison_exp"
+            }
+          },
+          {
+            "name": "destination_universal_chain_id",
+            "type": {
+              "kind": "INPUT_OBJECT",
+              "name": "String_comparison_exp"
+            }
+          },
+          {
+            "name": "source_universal_chain_id",
+            "type": {
+              "kind": "INPUT_OBJECT",
+              "name": "String_comparison_exp"
+            }
+          },
+          {
+            "name": "transfer_count",
+            "type": {
+              "kind": "INPUT_OBJECT",
+              "name": "String_comparison_exp"
+            }
+          }
+        ],
+        "isOneOf": false
+      },
+      {
+        "kind": "INPUT_OBJECT",
+        "name": "v2_stats_transfers_address_type_order_by",
+        "inputFields": [
+          {
+            "name": "canonical_address",
+            "type": {
+              "kind": "ENUM",
+              "name": "order_by"
+            }
+          },
+          {
+            "name": "day_date",
+            "type": {
+              "kind": "ENUM",
+              "name": "order_by"
+            }
+          },
+          {
+            "name": "destination_universal_chain_id",
+            "type": {
+              "kind": "ENUM",
+              "name": "order_by"
+            }
+          },
+          {
+            "name": "source_universal_chain_id",
+            "type": {
+              "kind": "ENUM",
+              "name": "order_by"
+            }
+          },
+          {
+            "name": "transfer_count",
+            "type": {
+              "kind": "ENUM",
+              "name": "order_by"
+            }
+          }
+        ],
+        "isOneOf": false
+      },
+      {
+        "kind": "ENUM",
+        "name": "v2_stats_transfers_address_type_select_column",
+        "enumValues": [
+          {
+            "name": "canonical_address",
+            "isDeprecated": false
+          },
+          {
+            "name": "day_date",
+            "isDeprecated": false
+          },
+          {
+            "name": "destination_universal_chain_id",
+            "isDeprecated": false
+          },
+          {
+            "name": "source_universal_chain_id",
+            "isDeprecated": false
+          },
+          {
+            "name": "transfer_count",
+            "isDeprecated": false
+          }
+        ]
+      },
+      {
+        "kind": "INPUT_OBJECT",
+        "name": "v2_stats_transfers_chain_args",
+        "inputFields": [
+          {
+            "name": "p_days_back",
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int"
+            }
+          },
+          {
+            "name": "p_destination_universal_chain_id",
+            "type": {
+              "kind": "SCALAR",
+              "name": "String"
+            }
+          },
+          {
+            "name": "p_source_universal_chain_id",
+            "type": {
+              "kind": "SCALAR",
+              "name": "String"
+            }
+          }
+        ],
+        "isOneOf": false
+      },
+      {
+        "kind": "OBJECT",
+        "name": "v2_stats_transfers_chain_type",
+        "fields": [
+          {
+            "name": "day_date",
+            "type": {
+              "kind": "SCALAR",
+              "name": "date"
+            },
+            "args": [],
+            "isDeprecated": false
+          },
+          {
+            "name": "destination_universal_chain_id",
+            "type": {
+              "kind": "SCALAR",
+              "name": "String"
+            },
+            "args": [],
+            "isDeprecated": false
+          },
+          {
+            "name": "source_universal_chain_id",
+            "type": {
+              "kind": "SCALAR",
+              "name": "String"
+            },
+            "args": [],
+            "isDeprecated": false
+          },
+          {
+            "name": "total_transfers",
+            "type": {
+              "kind": "SCALAR",
+              "name": "String"
+            },
+            "args": [],
+            "isDeprecated": false
+          }
+        ],
+        "interfaces": []
+      },
+      {
+        "kind": "INPUT_OBJECT",
+        "name": "v2_stats_transfers_chain_type_bool_exp",
+        "inputFields": [
+          {
+            "name": "_and",
+            "type": {
+              "kind": "LIST",
+              "ofType": {
+                "kind": "NON_NULL",
+                "ofType": {
+                  "kind": "INPUT_OBJECT",
+                  "name": "v2_stats_transfers_chain_type_bool_exp"
+                }
+              }
+            }
+          },
+          {
+            "name": "_not",
+            "type": {
+              "kind": "INPUT_OBJECT",
+              "name": "v2_stats_transfers_chain_type_bool_exp"
+            }
+          },
+          {
+            "name": "_or",
+            "type": {
+              "kind": "LIST",
+              "ofType": {
+                "kind": "NON_NULL",
+                "ofType": {
+                  "kind": "INPUT_OBJECT",
+                  "name": "v2_stats_transfers_chain_type_bool_exp"
+                }
+              }
+            }
+          },
+          {
+            "name": "day_date",
+            "type": {
+              "kind": "INPUT_OBJECT",
+              "name": "date_comparison_exp"
+            }
+          },
+          {
+            "name": "destination_universal_chain_id",
+            "type": {
+              "kind": "INPUT_OBJECT",
+              "name": "String_comparison_exp"
+            }
+          },
+          {
+            "name": "source_universal_chain_id",
+            "type": {
+              "kind": "INPUT_OBJECT",
+              "name": "String_comparison_exp"
+            }
+          },
+          {
+            "name": "total_transfers",
+            "type": {
+              "kind": "INPUT_OBJECT",
+              "name": "String_comparison_exp"
+            }
+          }
+        ],
+        "isOneOf": false
+      },
+      {
+        "kind": "INPUT_OBJECT",
+        "name": "v2_stats_transfers_chain_type_order_by",
+        "inputFields": [
+          {
+            "name": "day_date",
+            "type": {
+              "kind": "ENUM",
+              "name": "order_by"
+            }
+          },
+          {
+            "name": "destination_universal_chain_id",
+            "type": {
+              "kind": "ENUM",
+              "name": "order_by"
+            }
+          },
+          {
+            "name": "source_universal_chain_id",
+            "type": {
+              "kind": "ENUM",
+              "name": "order_by"
+            }
+          },
+          {
+            "name": "total_transfers",
+            "type": {
+              "kind": "ENUM",
+              "name": "order_by"
+            }
+          }
+        ],
+        "isOneOf": false
+      },
+      {
+        "kind": "ENUM",
+        "name": "v2_stats_transfers_chain_type_select_column",
+        "enumValues": [
+          {
+            "name": "day_date",
+            "isDeprecated": false
+          },
+          {
+            "name": "destination_universal_chain_id",
+            "isDeprecated": false
+          },
+          {
+            "name": "source_universal_chain_id",
+            "isDeprecated": false
+          },
+          {
+            "name": "total_transfers",
+            "isDeprecated": false
+          }
+        ]
+      },
+      {
+        "kind": "INPUT_OBJECT",
+        "name": "v2_stats_transfers_daily_count_args",
+        "inputFields": [
+          {
+            "name": "p_days_back",
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int"
+            }
+          }
+        ],
+        "isOneOf": false
+      },
+      {
+        "kind": "OBJECT",
+        "name": "v2_stats_type",
+        "fields": [
+          {
+            "name": "name",
+            "type": {
+              "kind": "SCALAR",
+              "name": "String"
+            },
+            "args": [],
+            "isDeprecated": false
+          },
+          {
+            "name": "value",
+            "type": {
+              "kind": "SCALAR",
+              "name": "String"
+            },
+            "args": [],
+            "isDeprecated": false
+          }
+        ],
+        "interfaces": []
+      },
+      {
+        "kind": "INPUT_OBJECT",
+        "name": "v2_stats_type_bool_exp",
+        "inputFields": [
+          {
+            "name": "_and",
+            "type": {
+              "kind": "LIST",
+              "ofType": {
+                "kind": "NON_NULL",
+                "ofType": {
+                  "kind": "INPUT_OBJECT",
+                  "name": "v2_stats_type_bool_exp"
+                }
+              }
+            }
+          },
+          {
+            "name": "_not",
+            "type": {
+              "kind": "INPUT_OBJECT",
+              "name": "v2_stats_type_bool_exp"
+            }
+          },
+          {
+            "name": "_or",
+            "type": {
+              "kind": "LIST",
+              "ofType": {
+                "kind": "NON_NULL",
+                "ofType": {
+                  "kind": "INPUT_OBJECT",
+                  "name": "v2_stats_type_bool_exp"
+                }
+              }
+            }
+          },
+          {
+            "name": "name",
+            "type": {
+              "kind": "INPUT_OBJECT",
+              "name": "String_comparison_exp"
+            }
+          },
+          {
+            "name": "value",
+            "type": {
+              "kind": "INPUT_OBJECT",
+              "name": "String_comparison_exp"
+            }
+          }
+        ],
+        "isOneOf": false
+      },
+      {
+        "kind": "INPUT_OBJECT",
+        "name": "v2_stats_type_order_by",
+        "inputFields": [
+          {
+            "name": "name",
+            "type": {
+              "kind": "ENUM",
+              "name": "order_by"
+            }
+          },
+          {
+            "name": "value",
+            "type": {
+              "kind": "ENUM",
+              "name": "order_by"
+            }
+          }
+        ],
+        "isOneOf": false
+      },
+      {
+        "kind": "ENUM",
+        "name": "v2_stats_type_select_column",
+        "enumValues": [
+          {
+            "name": "name",
+            "isDeprecated": false
+          },
+          {
+            "name": "value",
+            "isDeprecated": false
+          }
+        ]
+      },
+      {
+        "kind": "OBJECT",
+        "name": "v2_token_meta",
+        "fields": [
+          {
+            "name": "bucket",
+            "type": {
+              "kind": "OBJECT",
+              "name": "v2_token_meta_bucket"
+            },
+            "args": [],
+            "isDeprecated": false
+          },
+          {
+            "name": "chain",
+            "type": {
+              "kind": "OBJECT",
+              "name": "v2_chains_view"
+            },
+            "args": [],
+            "isDeprecated": false
+          },
+          {
+            "name": "denom",
+            "type": {
+              "kind": "SCALAR",
+              "name": "String"
+            },
+            "args": [],
+            "isDeprecated": false
+          },
+          {
+            "name": "rank",
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int"
+            },
+            "args": [],
+            "isDeprecated": false
+          },
+          {
+            "name": "representations",
+            "type": {
+              "kind": "NON_NULL",
+              "ofType": {
+                "kind": "LIST",
+                "ofType": {
+                  "kind": "NON_NULL",
+                  "ofType": {
+                    "kind": "OBJECT",
+                    "name": "v2_token_meta_representations"
+                  }
+                }
+              }
+            },
+            "args": [
+              {
+                "name": "distinct_on",
+                "type": {
+                  "kind": "LIST",
+                  "ofType": {
+                    "kind": "NON_NULL",
+                    "ofType": {
+                      "kind": "ENUM",
+                      "name": "v2_token_meta_representations_select_column"
+                    }
+                  }
+                }
+              },
+              {
+                "name": "limit",
+                "type": {
+                  "kind": "SCALAR",
+                  "name": "Int"
+                }
+              },
+              {
+                "name": "offset",
+                "type": {
+                  "kind": "SCALAR",
+                  "name": "Int"
+                }
+              },
+              {
+                "name": "order_by",
+                "type": {
+                  "kind": "LIST",
+                  "ofType": {
+                    "kind": "NON_NULL",
+                    "ofType": {
+                      "kind": "INPUT_OBJECT",
+                      "name": "v2_token_meta_representations_order_by"
+                    }
+                  }
+                }
+              },
+              {
+                "name": "where",
+                "type": {
+                  "kind": "INPUT_OBJECT",
+                  "name": "v2_token_meta_representations_bool_exp"
+                }
+              }
+            ],
+            "isDeprecated": false
+          },
+          {
+            "name": "wrapping",
+            "type": {
+              "kind": "NON_NULL",
+              "ofType": {
+                "kind": "LIST",
+                "ofType": {
+                  "kind": "NON_NULL",
+                  "ofType": {
+                    "kind": "OBJECT",
+                    "name": "v2_token_meta_wrapping"
+                  }
+                }
+              }
+            },
+            "args": [
+              {
+                "name": "distinct_on",
+                "type": {
+                  "kind": "LIST",
+                  "ofType": {
+                    "kind": "NON_NULL",
+                    "ofType": {
+                      "kind": "ENUM",
+                      "name": "v2_token_meta_wrapping_select_column"
+                    }
+                  }
+                }
+              },
+              {
+                "name": "limit",
+                "type": {
+                  "kind": "SCALAR",
+                  "name": "Int"
+                }
+              },
+              {
+                "name": "offset",
+                "type": {
+                  "kind": "SCALAR",
+                  "name": "Int"
+                }
+              },
+              {
+                "name": "order_by",
+                "type": {
+                  "kind": "LIST",
+                  "ofType": {
+                    "kind": "NON_NULL",
+                    "ofType": {
+                      "kind": "INPUT_OBJECT",
+                      "name": "v2_token_meta_wrapping_order_by"
+                    }
+                  }
+                }
+              },
+              {
+                "name": "where",
+                "type": {
+                  "kind": "INPUT_OBJECT",
+                  "name": "v2_token_meta_wrapping_bool_exp"
+                }
+              }
+            ],
+            "isDeprecated": false
+          }
+        ],
+        "interfaces": []
+      },
+      {
+        "kind": "INPUT_OBJECT",
+        "name": "v2_token_meta_bool_exp",
+        "inputFields": [
+          {
+            "name": "_and",
+            "type": {
+              "kind": "LIST",
+              "ofType": {
+                "kind": "NON_NULL",
+                "ofType": {
+                  "kind": "INPUT_OBJECT",
+                  "name": "v2_token_meta_bool_exp"
+                }
+              }
+            }
+          },
+          {
+            "name": "_not",
+            "type": {
+              "kind": "INPUT_OBJECT",
+              "name": "v2_token_meta_bool_exp"
+            }
+          },
+          {
+            "name": "_or",
+            "type": {
+              "kind": "LIST",
+              "ofType": {
+                "kind": "NON_NULL",
+                "ofType": {
+                  "kind": "INPUT_OBJECT",
+                  "name": "v2_token_meta_bool_exp"
+                }
+              }
+            }
+          },
+          {
+            "name": "bucket",
+            "type": {
+              "kind": "INPUT_OBJECT",
+              "name": "v2_token_meta_bucket_bool_exp"
+            }
+          },
+          {
+            "name": "chain",
+            "type": {
+              "kind": "INPUT_OBJECT",
+              "name": "v2_chains_view_bool_exp"
+            }
+          },
+          {
+            "name": "denom",
+            "type": {
+              "kind": "INPUT_OBJECT",
+              "name": "String_comparison_exp"
+            }
+          },
+          {
+            "name": "rank",
+            "type": {
+              "kind": "INPUT_OBJECT",
+              "name": "Int_comparison_exp"
+            }
+          },
+          {
+            "name": "representations",
+            "type": {
+              "kind": "INPUT_OBJECT",
+              "name": "v2_token_meta_representations_bool_exp"
+            }
+          },
+          {
+            "name": "wrapping",
+            "type": {
+              "kind": "INPUT_OBJECT",
+              "name": "v2_token_meta_wrapping_bool_exp"
+            }
+          }
+        ],
+        "isOneOf": false
+      },
+      {
+        "kind": "OBJECT",
+        "name": "v2_token_meta_bucket",
+        "fields": [
+          {
+            "name": "capacity",
+            "type": {
+              "kind": "SCALAR",
+              "name": "String"
+            },
+            "args": [],
+            "isDeprecated": false
+          },
+          {
+            "name": "refill_rate",
+            "type": {
+              "kind": "SCALAR",
+              "name": "String"
+            },
+            "args": [],
+            "isDeprecated": false
+          }
+        ],
+        "interfaces": []
+      },
+      {
+        "kind": "INPUT_OBJECT",
+        "name": "v2_token_meta_bucket_bool_exp",
+        "inputFields": [
+          {
+            "name": "_and",
+            "type": {
+              "kind": "LIST",
+              "ofType": {
+                "kind": "NON_NULL",
+                "ofType": {
+                  "kind": "INPUT_OBJECT",
+                  "name": "v2_token_meta_bucket_bool_exp"
+                }
+              }
+            }
+          },
+          {
+            "name": "_not",
+            "type": {
+              "kind": "INPUT_OBJECT",
+              "name": "v2_token_meta_bucket_bool_exp"
+            }
+          },
+          {
+            "name": "_or",
+            "type": {
+              "kind": "LIST",
+              "ofType": {
+                "kind": "NON_NULL",
+                "ofType": {
+                  "kind": "INPUT_OBJECT",
+                  "name": "v2_token_meta_bucket_bool_exp"
+                }
+              }
+            }
+          },
+          {
+            "name": "capacity",
+            "type": {
+              "kind": "INPUT_OBJECT",
+              "name": "String_comparison_exp"
+            }
+          },
+          {
+            "name": "refill_rate",
+            "type": {
+              "kind": "INPUT_OBJECT",
+              "name": "String_comparison_exp"
+            }
+          }
+        ],
+        "isOneOf": false
+      },
+      {
+        "kind": "INPUT_OBJECT",
+        "name": "v2_token_meta_bucket_order_by",
+        "inputFields": [
+          {
+            "name": "capacity",
+            "type": {
+              "kind": "ENUM",
+              "name": "order_by"
+            }
+          },
+          {
+            "name": "refill_rate",
+            "type": {
+              "kind": "ENUM",
+              "name": "order_by"
+            }
+          }
+        ],
+        "isOneOf": false
+      },
+      {
+        "kind": "INPUT_OBJECT",
+        "name": "v2_token_meta_order_by",
+        "inputFields": [
+          {
+            "name": "bucket",
+            "type": {
+              "kind": "INPUT_OBJECT",
+              "name": "v2_token_meta_bucket_order_by"
+            }
+          },
+          {
+            "name": "chain",
+            "type": {
+              "kind": "INPUT_OBJECT",
+              "name": "v2_chains_view_order_by"
+            }
+          },
+          {
+            "name": "denom",
+            "type": {
+              "kind": "ENUM",
+              "name": "order_by"
+            }
+          },
+          {
+            "name": "rank",
+            "type": {
+              "kind": "ENUM",
+              "name": "order_by"
+            }
+          },
+          {
+            "name": "representations_aggregate",
+            "type": {
+              "kind": "INPUT_OBJECT",
+              "name": "v2_token_meta_representations_aggregate_order_by"
+            }
+          },
+          {
+            "name": "wrapping_aggregate",
+            "type": {
+              "kind": "INPUT_OBJECT",
+              "name": "v2_token_meta_wrapping_aggregate_order_by"
+            }
+          }
+        ],
+        "isOneOf": false
+      },
+      {
+        "kind": "OBJECT",
+        "name": "v2_token_meta_representation_sources",
+        "fields": [
+          {
+            "name": "chain",
+            "type": {
+              "kind": "OBJECT",
+              "name": "v2_chains_view"
+            },
+            "args": [],
+            "isDeprecated": false
+          },
+          {
+            "name": "decimals",
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int"
+            },
+            "args": [],
+            "isDeprecated": false
+          },
+          {
+            "name": "denom",
+            "type": {
+              "kind": "SCALAR",
+              "name": "String"
+            },
+            "args": [],
+            "isDeprecated": false
+          },
+          {
+            "name": "name",
+            "type": {
+              "kind": "SCALAR",
+              "name": "String"
+            },
+            "args": [],
+            "isDeprecated": false
+          },
+          {
+            "name": "source",
+            "type": {
+              "kind": "OBJECT",
+              "name": "v2_token_meta_sources"
+            },
+            "args": [],
+            "isDeprecated": false
+          },
+          {
+            "name": "symbol",
+            "type": {
+              "kind": "SCALAR",
+              "name": "String"
+            },
+            "args": [],
+            "isDeprecated": false
+          },
+          {
+            "name": "update_timestamp",
+            "type": {
+              "kind": "SCALAR",
+              "name": "timestamptz"
+            },
+            "args": [],
+            "isDeprecated": false
+          },
+          {
+            "name": "wrapping",
+            "type": {
+              "kind": "NON_NULL",
+              "ofType": {
+                "kind": "LIST",
+                "ofType": {
+                  "kind": "NON_NULL",
+                  "ofType": {
+                    "kind": "OBJECT",
+                    "name": "v2_token_meta_representation_sources"
+                  }
+                }
+              }
+            },
+            "args": [
+              {
+                "name": "distinct_on",
+                "type": {
+                  "kind": "LIST",
+                  "ofType": {
+                    "kind": "NON_NULL",
+                    "ofType": {
+                      "kind": "ENUM",
+                      "name": "v2_token_meta_representation_sources_select_column"
+                    }
+                  }
+                }
+              },
+              {
+                "name": "limit",
+                "type": {
+                  "kind": "SCALAR",
+                  "name": "Int"
+                }
+              },
+              {
+                "name": "offset",
+                "type": {
+                  "kind": "SCALAR",
+                  "name": "Int"
+                }
+              },
+              {
+                "name": "order_by",
+                "type": {
+                  "kind": "LIST",
+                  "ofType": {
+                    "kind": "NON_NULL",
+                    "ofType": {
+                      "kind": "INPUT_OBJECT",
+                      "name": "v2_token_meta_representation_sources_order_by"
+                    }
+                  }
+                }
+              },
+              {
+                "name": "where",
+                "type": {
+                  "kind": "INPUT_OBJECT",
+                  "name": "v2_token_meta_representation_sources_bool_exp"
+                }
+              }
+            ],
+            "isDeprecated": false
+          }
+        ],
+        "interfaces": []
+      },
+      {
+        "kind": "INPUT_OBJECT",
+        "name": "v2_token_meta_representation_sources_aggregate_order_by",
+        "inputFields": [
+          {
+            "name": "avg",
+            "type": {
+              "kind": "INPUT_OBJECT",
+              "name": "v2_token_meta_representation_sources_avg_order_by"
+            }
+          },
+          {
+            "name": "count",
+            "type": {
+              "kind": "ENUM",
+              "name": "order_by"
+            }
+          },
+          {
+            "name": "max",
+            "type": {
+              "kind": "INPUT_OBJECT",
+              "name": "v2_token_meta_representation_sources_max_order_by"
+            }
+          },
+          {
+            "name": "min",
+            "type": {
+              "kind": "INPUT_OBJECT",
+              "name": "v2_token_meta_representation_sources_min_order_by"
+            }
+          },
+          {
+            "name": "stddev",
+            "type": {
+              "kind": "INPUT_OBJECT",
+              "name": "v2_token_meta_representation_sources_stddev_order_by"
+            }
+          },
+          {
+            "name": "stddev_pop",
+            "type": {
+              "kind": "INPUT_OBJECT",
+              "name": "v2_token_meta_representation_sources_stddev_pop_order_by"
+            }
+          },
+          {
+            "name": "stddev_samp",
+            "type": {
+              "kind": "INPUT_OBJECT",
+              "name": "v2_token_meta_representation_sources_stddev_samp_order_by"
+            }
+          },
+          {
+            "name": "sum",
+            "type": {
+              "kind": "INPUT_OBJECT",
+              "name": "v2_token_meta_representation_sources_sum_order_by"
+            }
+          },
+          {
+            "name": "var_pop",
+            "type": {
+              "kind": "INPUT_OBJECT",
+              "name": "v2_token_meta_representation_sources_var_pop_order_by"
+            }
+          },
+          {
+            "name": "var_samp",
+            "type": {
+              "kind": "INPUT_OBJECT",
+              "name": "v2_token_meta_representation_sources_var_samp_order_by"
+            }
+          },
+          {
+            "name": "variance",
+            "type": {
+              "kind": "INPUT_OBJECT",
+              "name": "v2_token_meta_representation_sources_variance_order_by"
+            }
+          }
+        ],
+        "isOneOf": false
+      },
+      {
+        "kind": "INPUT_OBJECT",
+        "name": "v2_token_meta_representation_sources_avg_order_by",
+        "inputFields": [
+          {
+            "name": "decimals",
+            "type": {
+              "kind": "ENUM",
+              "name": "order_by"
+            }
+          }
+        ],
+        "isOneOf": false
+      },
+      {
+        "kind": "INPUT_OBJECT",
+        "name": "v2_token_meta_representation_sources_bool_exp",
+        "inputFields": [
+          {
+            "name": "_and",
+            "type": {
+              "kind": "LIST",
+              "ofType": {
+                "kind": "NON_NULL",
+                "ofType": {
+                  "kind": "INPUT_OBJECT",
+                  "name": "v2_token_meta_representation_sources_bool_exp"
+                }
+              }
+            }
+          },
+          {
+            "name": "_not",
+            "type": {
+              "kind": "INPUT_OBJECT",
+              "name": "v2_token_meta_representation_sources_bool_exp"
+            }
+          },
+          {
+            "name": "_or",
+            "type": {
+              "kind": "LIST",
+              "ofType": {
+                "kind": "NON_NULL",
+                "ofType": {
+                  "kind": "INPUT_OBJECT",
+                  "name": "v2_token_meta_representation_sources_bool_exp"
+                }
+              }
+            }
+          },
+          {
+            "name": "chain",
+            "type": {
+              "kind": "INPUT_OBJECT",
+              "name": "v2_chains_view_bool_exp"
+            }
+          },
+          {
+            "name": "decimals",
+            "type": {
+              "kind": "INPUT_OBJECT",
+              "name": "Int_comparison_exp"
+            }
+          },
+          {
+            "name": "denom",
+            "type": {
+              "kind": "INPUT_OBJECT",
+              "name": "String_comparison_exp"
+            }
+          },
+          {
+            "name": "name",
+            "type": {
+              "kind": "INPUT_OBJECT",
+              "name": "String_comparison_exp"
+            }
+          },
+          {
+            "name": "source",
+            "type": {
+              "kind": "INPUT_OBJECT",
+              "name": "v2_token_meta_sources_bool_exp"
+            }
+          },
+          {
+            "name": "symbol",
+            "type": {
+              "kind": "INPUT_OBJECT",
+              "name": "String_comparison_exp"
+            }
+          },
+          {
+            "name": "update_timestamp",
+            "type": {
+              "kind": "INPUT_OBJECT",
+              "name": "timestamptz_comparison_exp"
+            }
+          },
+          {
+            "name": "wrapping",
+            "type": {
+              "kind": "INPUT_OBJECT",
+              "name": "v2_token_meta_representation_sources_bool_exp"
+            }
+          }
+        ],
+        "isOneOf": false
+      },
+      {
+        "kind": "INPUT_OBJECT",
+        "name": "v2_token_meta_representation_sources_max_order_by",
+        "inputFields": [
+          {
+            "name": "decimals",
+            "type": {
+              "kind": "ENUM",
+              "name": "order_by"
+            }
+          },
+          {
+            "name": "denom",
+            "type": {
+              "kind": "ENUM",
+              "name": "order_by"
+            }
+          },
+          {
+            "name": "name",
+            "type": {
+              "kind": "ENUM",
+              "name": "order_by"
+            }
+          },
+          {
+            "name": "symbol",
+            "type": {
+              "kind": "ENUM",
+              "name": "order_by"
+            }
+          },
+          {
+            "name": "update_timestamp",
+            "type": {
+              "kind": "ENUM",
+              "name": "order_by"
+            }
+          }
+        ],
+        "isOneOf": false
+      },
+      {
+        "kind": "INPUT_OBJECT",
+        "name": "v2_token_meta_representation_sources_min_order_by",
+        "inputFields": [
+          {
+            "name": "decimals",
+            "type": {
+              "kind": "ENUM",
+              "name": "order_by"
+            }
+          },
+          {
+            "name": "denom",
+            "type": {
+              "kind": "ENUM",
+              "name": "order_by"
+            }
+          },
+          {
+            "name": "name",
+            "type": {
+              "kind": "ENUM",
+              "name": "order_by"
+            }
+          },
+          {
+            "name": "symbol",
+            "type": {
+              "kind": "ENUM",
+              "name": "order_by"
+            }
+          },
+          {
+            "name": "update_timestamp",
+            "type": {
+              "kind": "ENUM",
+              "name": "order_by"
+            }
+          }
+        ],
+        "isOneOf": false
+      },
+      {
+        "kind": "INPUT_OBJECT",
+        "name": "v2_token_meta_representation_sources_order_by",
+        "inputFields": [
+          {
+            "name": "chain",
+            "type": {
+              "kind": "INPUT_OBJECT",
+              "name": "v2_chains_view_order_by"
+            }
+          },
+          {
+            "name": "decimals",
+            "type": {
+              "kind": "ENUM",
+              "name": "order_by"
+            }
+          },
+          {
+            "name": "denom",
+            "type": {
+              "kind": "ENUM",
+              "name": "order_by"
+            }
+          },
+          {
+            "name": "name",
+            "type": {
+              "kind": "ENUM",
+              "name": "order_by"
+            }
+          },
+          {
+            "name": "source",
+            "type": {
+              "kind": "INPUT_OBJECT",
+              "name": "v2_token_meta_sources_order_by"
+            }
+          },
+          {
+            "name": "symbol",
+            "type": {
+              "kind": "ENUM",
+              "name": "order_by"
+            }
+          },
+          {
+            "name": "update_timestamp",
+            "type": {
+              "kind": "ENUM",
+              "name": "order_by"
+            }
+          },
+          {
+            "name": "wrapping_aggregate",
+            "type": {
+              "kind": "INPUT_OBJECT",
+              "name": "v2_token_meta_representation_sources_aggregate_order_by"
+            }
+          }
+        ],
+        "isOneOf": false
+      },
+      {
+        "kind": "ENUM",
+        "name": "v2_token_meta_representation_sources_select_column",
+        "enumValues": [
+          {
+            "name": "decimals",
+            "isDeprecated": false
+          },
+          {
+            "name": "denom",
+            "isDeprecated": false
+          },
+          {
+            "name": "name",
+            "isDeprecated": false
+          },
+          {
+            "name": "symbol",
+            "isDeprecated": false
+          },
+          {
+            "name": "update_timestamp",
+            "isDeprecated": false
+          }
+        ]
+      },
+      {
+        "kind": "INPUT_OBJECT",
+        "name": "v2_token_meta_representation_sources_stddev_order_by",
+        "inputFields": [
+          {
+            "name": "decimals",
+            "type": {
+              "kind": "ENUM",
+              "name": "order_by"
+            }
+          }
+        ],
+        "isOneOf": false
+      },
+      {
+        "kind": "INPUT_OBJECT",
+        "name": "v2_token_meta_representation_sources_stddev_pop_order_by",
+        "inputFields": [
+          {
+            "name": "decimals",
+            "type": {
+              "kind": "ENUM",
+              "name": "order_by"
+            }
+          }
+        ],
+        "isOneOf": false
+      },
+      {
+        "kind": "INPUT_OBJECT",
+        "name": "v2_token_meta_representation_sources_stddev_samp_order_by",
+        "inputFields": [
+          {
+            "name": "decimals",
+            "type": {
+              "kind": "ENUM",
+              "name": "order_by"
+            }
+          }
+        ],
+        "isOneOf": false
+      },
+      {
+        "kind": "INPUT_OBJECT",
+        "name": "v2_token_meta_representation_sources_sum_order_by",
+        "inputFields": [
+          {
+            "name": "decimals",
+            "type": {
+              "kind": "ENUM",
+              "name": "order_by"
+            }
+          }
+        ],
+        "isOneOf": false
+      },
+      {
+        "kind": "INPUT_OBJECT",
+        "name": "v2_token_meta_representation_sources_var_pop_order_by",
+        "inputFields": [
+          {
+            "name": "decimals",
+            "type": {
+              "kind": "ENUM",
+              "name": "order_by"
+            }
+          }
+        ],
+        "isOneOf": false
+      },
+      {
+        "kind": "INPUT_OBJECT",
+        "name": "v2_token_meta_representation_sources_var_samp_order_by",
+        "inputFields": [
+          {
+            "name": "decimals",
+            "type": {
+              "kind": "ENUM",
+              "name": "order_by"
+            }
+          }
+        ],
+        "isOneOf": false
+      },
+      {
+        "kind": "INPUT_OBJECT",
+        "name": "v2_token_meta_representation_sources_variance_order_by",
+        "inputFields": [
+          {
+            "name": "decimals",
+            "type": {
+              "kind": "ENUM",
+              "name": "order_by"
+            }
+          }
+        ],
+        "isOneOf": false
+      },
+      {
+        "kind": "OBJECT",
+        "name": "v2_token_meta_representations",
+        "fields": [
+          {
+            "name": "chain",
+            "type": {
+              "kind": "OBJECT",
+              "name": "v2_chains_view"
+            },
+            "args": [],
+            "isDeprecated": false
+          },
+          {
+            "name": "decimals",
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int"
+            },
+            "args": [],
+            "isDeprecated": false
+          },
+          {
+            "name": "logo_uri",
+            "type": {
+              "kind": "SCALAR",
+              "name": "String"
+            },
+            "args": [],
+            "isDeprecated": false
+          },
+          {
+            "name": "name",
+            "type": {
+              "kind": "SCALAR",
+              "name": "String"
+            },
+            "args": [],
+            "isDeprecated": false
+          },
+          {
+            "name": "sources",
+            "type": {
+              "kind": "NON_NULL",
+              "ofType": {
+                "kind": "LIST",
+                "ofType": {
+                  "kind": "NON_NULL",
+                  "ofType": {
+                    "kind": "OBJECT",
+                    "name": "v2_token_meta_representation_sources"
+                  }
+                }
+              }
+            },
+            "args": [
+              {
+                "name": "distinct_on",
+                "type": {
+                  "kind": "LIST",
+                  "ofType": {
+                    "kind": "NON_NULL",
+                    "ofType": {
+                      "kind": "ENUM",
+                      "name": "v2_token_meta_representation_sources_select_column"
+                    }
+                  }
+                }
+              },
+              {
+                "name": "limit",
+                "type": {
+                  "kind": "SCALAR",
+                  "name": "Int"
+                }
+              },
+              {
+                "name": "offset",
+                "type": {
+                  "kind": "SCALAR",
+                  "name": "Int"
+                }
+              },
+              {
+                "name": "order_by",
+                "type": {
+                  "kind": "LIST",
+                  "ofType": {
+                    "kind": "NON_NULL",
+                    "ofType": {
+                      "kind": "INPUT_OBJECT",
+                      "name": "v2_token_meta_representation_sources_order_by"
+                    }
+                  }
+                }
+              },
+              {
+                "name": "where",
+                "type": {
+                  "kind": "INPUT_OBJECT",
+                  "name": "v2_token_meta_representation_sources_bool_exp"
+                }
+              }
+            ],
+            "isDeprecated": false
+          },
+          {
+            "name": "symbol",
+            "type": {
+              "kind": "SCALAR",
+              "name": "String"
+            },
+            "args": [],
+            "isDeprecated": false
+          }
+        ],
+        "interfaces": []
+      },
+      {
+        "kind": "INPUT_OBJECT",
+        "name": "v2_token_meta_representations_aggregate_order_by",
+        "inputFields": [
+          {
+            "name": "avg",
+            "type": {
+              "kind": "INPUT_OBJECT",
+              "name": "v2_token_meta_representations_avg_order_by"
+            }
+          },
+          {
+            "name": "count",
+            "type": {
+              "kind": "ENUM",
+              "name": "order_by"
+            }
+          },
+          {
+            "name": "max",
+            "type": {
+              "kind": "INPUT_OBJECT",
+              "name": "v2_token_meta_representations_max_order_by"
+            }
+          },
+          {
+            "name": "min",
+            "type": {
+              "kind": "INPUT_OBJECT",
+              "name": "v2_token_meta_representations_min_order_by"
+            }
+          },
+          {
+            "name": "stddev",
+            "type": {
+              "kind": "INPUT_OBJECT",
+              "name": "v2_token_meta_representations_stddev_order_by"
+            }
+          },
+          {
+            "name": "stddev_pop",
+            "type": {
+              "kind": "INPUT_OBJECT",
+              "name": "v2_token_meta_representations_stddev_pop_order_by"
+            }
+          },
+          {
+            "name": "stddev_samp",
+            "type": {
+              "kind": "INPUT_OBJECT",
+              "name": "v2_token_meta_representations_stddev_samp_order_by"
+            }
+          },
+          {
+            "name": "sum",
+            "type": {
+              "kind": "INPUT_OBJECT",
+              "name": "v2_token_meta_representations_sum_order_by"
+            }
+          },
+          {
+            "name": "var_pop",
+            "type": {
+              "kind": "INPUT_OBJECT",
+              "name": "v2_token_meta_representations_var_pop_order_by"
+            }
+          },
+          {
+            "name": "var_samp",
+            "type": {
+              "kind": "INPUT_OBJECT",
+              "name": "v2_token_meta_representations_var_samp_order_by"
+            }
+          },
+          {
+            "name": "variance",
+            "type": {
+              "kind": "INPUT_OBJECT",
+              "name": "v2_token_meta_representations_variance_order_by"
+            }
+          }
+        ],
+        "isOneOf": false
+      },
+      {
+        "kind": "INPUT_OBJECT",
+        "name": "v2_token_meta_representations_avg_order_by",
+        "inputFields": [
+          {
+            "name": "decimals",
+            "type": {
+              "kind": "ENUM",
+              "name": "order_by"
+            }
+          }
+        ],
+        "isOneOf": false
+      },
+      {
+        "kind": "INPUT_OBJECT",
+        "name": "v2_token_meta_representations_bool_exp",
+        "inputFields": [
+          {
+            "name": "_and",
+            "type": {
+              "kind": "LIST",
+              "ofType": {
+                "kind": "NON_NULL",
+                "ofType": {
+                  "kind": "INPUT_OBJECT",
+                  "name": "v2_token_meta_representations_bool_exp"
+                }
+              }
+            }
+          },
+          {
+            "name": "_not",
+            "type": {
+              "kind": "INPUT_OBJECT",
+              "name": "v2_token_meta_representations_bool_exp"
+            }
+          },
+          {
+            "name": "_or",
+            "type": {
+              "kind": "LIST",
+              "ofType": {
+                "kind": "NON_NULL",
+                "ofType": {
+                  "kind": "INPUT_OBJECT",
+                  "name": "v2_token_meta_representations_bool_exp"
+                }
+              }
+            }
+          },
+          {
+            "name": "chain",
+            "type": {
+              "kind": "INPUT_OBJECT",
+              "name": "v2_chains_view_bool_exp"
+            }
+          },
+          {
+            "name": "decimals",
+            "type": {
+              "kind": "INPUT_OBJECT",
+              "name": "Int_comparison_exp"
+            }
+          },
+          {
+            "name": "logo_uri",
+            "type": {
+              "kind": "INPUT_OBJECT",
+              "name": "String_comparison_exp"
+            }
+          },
+          {
+            "name": "name",
+            "type": {
+              "kind": "INPUT_OBJECT",
+              "name": "String_comparison_exp"
+            }
+          },
+          {
+            "name": "sources",
+            "type": {
+              "kind": "INPUT_OBJECT",
+              "name": "v2_token_meta_representation_sources_bool_exp"
+            }
+          },
+          {
+            "name": "symbol",
+            "type": {
+              "kind": "INPUT_OBJECT",
+              "name": "String_comparison_exp"
+            }
+          }
+        ],
+        "isOneOf": false
+      },
+      {
+        "kind": "INPUT_OBJECT",
+        "name": "v2_token_meta_representations_max_order_by",
+        "inputFields": [
+          {
+            "name": "decimals",
+            "type": {
+              "kind": "ENUM",
+              "name": "order_by"
+            }
+          },
+          {
+            "name": "logo_uri",
+            "type": {
+              "kind": "ENUM",
+              "name": "order_by"
+            }
+          },
+          {
+            "name": "name",
+            "type": {
+              "kind": "ENUM",
+              "name": "order_by"
+            }
+          },
+          {
+            "name": "symbol",
+            "type": {
+              "kind": "ENUM",
+              "name": "order_by"
+            }
+          }
+        ],
+        "isOneOf": false
+      },
+      {
+        "kind": "INPUT_OBJECT",
+        "name": "v2_token_meta_representations_min_order_by",
+        "inputFields": [
+          {
+            "name": "decimals",
+            "type": {
+              "kind": "ENUM",
+              "name": "order_by"
+            }
+          },
+          {
+            "name": "logo_uri",
+            "type": {
+              "kind": "ENUM",
+              "name": "order_by"
+            }
+          },
+          {
+            "name": "name",
+            "type": {
+              "kind": "ENUM",
+              "name": "order_by"
+            }
+          },
+          {
+            "name": "symbol",
+            "type": {
+              "kind": "ENUM",
+              "name": "order_by"
+            }
+          }
+        ],
+        "isOneOf": false
+      },
+      {
+        "kind": "INPUT_OBJECT",
+        "name": "v2_token_meta_representations_order_by",
+        "inputFields": [
+          {
+            "name": "chain",
+            "type": {
+              "kind": "INPUT_OBJECT",
+              "name": "v2_chains_view_order_by"
+            }
+          },
+          {
+            "name": "decimals",
+            "type": {
+              "kind": "ENUM",
+              "name": "order_by"
+            }
+          },
+          {
+            "name": "logo_uri",
+            "type": {
+              "kind": "ENUM",
+              "name": "order_by"
+            }
+          },
+          {
+            "name": "name",
+            "type": {
+              "kind": "ENUM",
+              "name": "order_by"
+            }
+          },
+          {
+            "name": "sources_aggregate",
+            "type": {
+              "kind": "INPUT_OBJECT",
+              "name": "v2_token_meta_representation_sources_aggregate_order_by"
+            }
+          },
+          {
+            "name": "symbol",
+            "type": {
+              "kind": "ENUM",
+              "name": "order_by"
+            }
+          }
+        ],
+        "isOneOf": false
+      },
+      {
+        "kind": "ENUM",
+        "name": "v2_token_meta_representations_select_column",
+        "enumValues": [
+          {
+            "name": "decimals",
+            "isDeprecated": false
+          },
+          {
+            "name": "logo_uri",
+            "isDeprecated": false
+          },
+          {
+            "name": "name",
+            "isDeprecated": false
+          },
+          {
+            "name": "symbol",
+            "isDeprecated": false
+          }
+        ]
+      },
+      {
+        "kind": "INPUT_OBJECT",
+        "name": "v2_token_meta_representations_stddev_order_by",
+        "inputFields": [
+          {
+            "name": "decimals",
+            "type": {
+              "kind": "ENUM",
+              "name": "order_by"
+            }
+          }
+        ],
+        "isOneOf": false
+      },
+      {
+        "kind": "INPUT_OBJECT",
+        "name": "v2_token_meta_representations_stddev_pop_order_by",
+        "inputFields": [
+          {
+            "name": "decimals",
+            "type": {
+              "kind": "ENUM",
+              "name": "order_by"
+            }
+          }
+        ],
+        "isOneOf": false
+      },
+      {
+        "kind": "INPUT_OBJECT",
+        "name": "v2_token_meta_representations_stddev_samp_order_by",
+        "inputFields": [
+          {
+            "name": "decimals",
+            "type": {
+              "kind": "ENUM",
+              "name": "order_by"
+            }
+          }
+        ],
+        "isOneOf": false
+      },
+      {
+        "kind": "INPUT_OBJECT",
+        "name": "v2_token_meta_representations_sum_order_by",
+        "inputFields": [
+          {
+            "name": "decimals",
+            "type": {
+              "kind": "ENUM",
+              "name": "order_by"
+            }
+          }
+        ],
+        "isOneOf": false
+      },
+      {
+        "kind": "INPUT_OBJECT",
+        "name": "v2_token_meta_representations_var_pop_order_by",
+        "inputFields": [
+          {
+            "name": "decimals",
+            "type": {
+              "kind": "ENUM",
+              "name": "order_by"
+            }
+          }
+        ],
+        "isOneOf": false
+      },
+      {
+        "kind": "INPUT_OBJECT",
+        "name": "v2_token_meta_representations_var_samp_order_by",
+        "inputFields": [
+          {
+            "name": "decimals",
+            "type": {
+              "kind": "ENUM",
+              "name": "order_by"
+            }
+          }
+        ],
+        "isOneOf": false
+      },
+      {
+        "kind": "INPUT_OBJECT",
+        "name": "v2_token_meta_representations_variance_order_by",
+        "inputFields": [
+          {
+            "name": "decimals",
+            "type": {
+              "kind": "ENUM",
+              "name": "order_by"
+            }
+          }
+        ],
+        "isOneOf": false
+      },
+      {
+        "kind": "ENUM",
+        "name": "v2_token_meta_select_column",
+        "enumValues": [
+          {
+            "name": "denom",
+            "isDeprecated": false
+          },
+          {
+            "name": "rank",
+            "isDeprecated": false
+          }
+        ]
+      },
+      {
+        "kind": "OBJECT",
+        "name": "v2_token_meta_sources",
+        "fields": [
+          {
+            "name": "logo_uri",
+            "type": {
+              "kind": "SCALAR",
+              "name": "String"
+            },
+            "args": [],
+            "isDeprecated": false
+          },
+          {
+            "name": "name",
+            "type": {
+              "kind": "SCALAR",
+              "name": "String"
+            },
+            "args": [],
+            "isDeprecated": false
+          },
+          {
+            "name": "source_uri",
+            "type": {
+              "kind": "SCALAR",
+              "name": "String"
+            },
+            "args": [],
+            "isDeprecated": false
+          }
+        ],
+        "interfaces": []
+      },
+      {
+        "kind": "INPUT_OBJECT",
+        "name": "v2_token_meta_sources_bool_exp",
+        "inputFields": [
+          {
+            "name": "_and",
+            "type": {
+              "kind": "LIST",
+              "ofType": {
+                "kind": "NON_NULL",
+                "ofType": {
+                  "kind": "INPUT_OBJECT",
+                  "name": "v2_token_meta_sources_bool_exp"
+                }
+              }
+            }
+          },
+          {
+            "name": "_not",
+            "type": {
+              "kind": "INPUT_OBJECT",
+              "name": "v2_token_meta_sources_bool_exp"
+            }
+          },
+          {
+            "name": "_or",
+            "type": {
+              "kind": "LIST",
+              "ofType": {
+                "kind": "NON_NULL",
+                "ofType": {
+                  "kind": "INPUT_OBJECT",
+                  "name": "v2_token_meta_sources_bool_exp"
+                }
+              }
+            }
+          },
+          {
+            "name": "logo_uri",
+            "type": {
+              "kind": "INPUT_OBJECT",
+              "name": "String_comparison_exp"
+            }
+          },
+          {
+            "name": "name",
+            "type": {
+              "kind": "INPUT_OBJECT",
+              "name": "String_comparison_exp"
+            }
+          },
+          {
+            "name": "source_uri",
+            "type": {
+              "kind": "INPUT_OBJECT",
+              "name": "String_comparison_exp"
+            }
+          }
+        ],
+        "isOneOf": false
+      },
+      {
+        "kind": "INPUT_OBJECT",
+        "name": "v2_token_meta_sources_order_by",
+        "inputFields": [
+          {
+            "name": "logo_uri",
+            "type": {
+              "kind": "ENUM",
+              "name": "order_by"
+            }
+          },
+          {
+            "name": "name",
+            "type": {
+              "kind": "ENUM",
+              "name": "order_by"
+            }
+          },
+          {
+            "name": "source_uri",
+            "type": {
+              "kind": "ENUM",
+              "name": "order_by"
+            }
+          }
+        ],
+        "isOneOf": false
+      },
+      {
+        "kind": "OBJECT",
+        "name": "v2_token_meta_wrapping",
+        "fields": [
+          {
+            "name": "destination_channel_id",
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int"
+            },
+            "args": [],
+            "isDeprecated": false
+          },
+          {
+            "name": "unwrapped_chain",
+            "type": {
+              "kind": "OBJECT",
+              "name": "v2_chains_view"
+            },
+            "args": [],
+            "isDeprecated": false
+          },
+          {
+            "name": "unwrapped_denom",
+            "type": {
+              "kind": "SCALAR",
+              "name": "String"
+            },
+            "args": [],
+            "isDeprecated": false
+          },
+          {
+            "name": "wrapped_chain",
+            "type": {
+              "kind": "OBJECT",
+              "name": "v2_chains_view"
+            },
+            "args": [],
+            "isDeprecated": false
+          },
+          {
+            "name": "wrapper",
+            "type": {
+              "kind": "SCALAR",
+              "name": "String"
+            },
+            "args": [],
+            "isDeprecated": false
+          }
+        ],
+        "interfaces": []
+      },
+      {
+        "kind": "INPUT_OBJECT",
+        "name": "v2_token_meta_wrapping_aggregate_order_by",
+        "inputFields": [
+          {
+            "name": "avg",
+            "type": {
+              "kind": "INPUT_OBJECT",
+              "name": "v2_token_meta_wrapping_avg_order_by"
+            }
+          },
+          {
+            "name": "count",
+            "type": {
+              "kind": "ENUM",
+              "name": "order_by"
+            }
+          },
+          {
+            "name": "max",
+            "type": {
+              "kind": "INPUT_OBJECT",
+              "name": "v2_token_meta_wrapping_max_order_by"
+            }
+          },
+          {
+            "name": "min",
+            "type": {
+              "kind": "INPUT_OBJECT",
+              "name": "v2_token_meta_wrapping_min_order_by"
+            }
+          },
+          {
+            "name": "stddev",
+            "type": {
+              "kind": "INPUT_OBJECT",
+              "name": "v2_token_meta_wrapping_stddev_order_by"
+            }
+          },
+          {
+            "name": "stddev_pop",
+            "type": {
+              "kind": "INPUT_OBJECT",
+              "name": "v2_token_meta_wrapping_stddev_pop_order_by"
+            }
+          },
+          {
+            "name": "stddev_samp",
+            "type": {
+              "kind": "INPUT_OBJECT",
+              "name": "v2_token_meta_wrapping_stddev_samp_order_by"
+            }
+          },
+          {
+            "name": "sum",
+            "type": {
+              "kind": "INPUT_OBJECT",
+              "name": "v2_token_meta_wrapping_sum_order_by"
+            }
+          },
+          {
+            "name": "var_pop",
+            "type": {
+              "kind": "INPUT_OBJECT",
+              "name": "v2_token_meta_wrapping_var_pop_order_by"
+            }
+          },
+          {
+            "name": "var_samp",
+            "type": {
+              "kind": "INPUT_OBJECT",
+              "name": "v2_token_meta_wrapping_var_samp_order_by"
+            }
+          },
+          {
+            "name": "variance",
+            "type": {
+              "kind": "INPUT_OBJECT",
+              "name": "v2_token_meta_wrapping_variance_order_by"
+            }
+          }
+        ],
+        "isOneOf": false
+      },
+      {
+        "kind": "INPUT_OBJECT",
+        "name": "v2_token_meta_wrapping_avg_order_by",
+        "inputFields": [
+          {
+            "name": "destination_channel_id",
+            "type": {
+              "kind": "ENUM",
+              "name": "order_by"
+            }
+          }
+        ],
+        "isOneOf": false
+      },
+      {
+        "kind": "INPUT_OBJECT",
+        "name": "v2_token_meta_wrapping_bool_exp",
+        "inputFields": [
+          {
+            "name": "_and",
+            "type": {
+              "kind": "LIST",
+              "ofType": {
+                "kind": "NON_NULL",
+                "ofType": {
+                  "kind": "INPUT_OBJECT",
+                  "name": "v2_token_meta_wrapping_bool_exp"
+                }
+              }
+            }
+          },
+          {
+            "name": "_not",
+            "type": {
+              "kind": "INPUT_OBJECT",
+              "name": "v2_token_meta_wrapping_bool_exp"
+            }
+          },
+          {
+            "name": "_or",
+            "type": {
+              "kind": "LIST",
+              "ofType": {
+                "kind": "NON_NULL",
+                "ofType": {
+                  "kind": "INPUT_OBJECT",
+                  "name": "v2_token_meta_wrapping_bool_exp"
+                }
+              }
+            }
+          },
+          {
+            "name": "destination_channel_id",
+            "type": {
+              "kind": "INPUT_OBJECT",
+              "name": "Int_comparison_exp"
+            }
+          },
+          {
+            "name": "unwrapped_chain",
+            "type": {
+              "kind": "INPUT_OBJECT",
+              "name": "v2_chains_view_bool_exp"
+            }
+          },
+          {
+            "name": "unwrapped_denom",
+            "type": {
+              "kind": "INPUT_OBJECT",
+              "name": "String_comparison_exp"
+            }
+          },
+          {
+            "name": "wrapped_chain",
+            "type": {
+              "kind": "INPUT_OBJECT",
+              "name": "v2_chains_view_bool_exp"
+            }
+          },
+          {
+            "name": "wrapper",
+            "type": {
+              "kind": "INPUT_OBJECT",
+              "name": "String_comparison_exp"
+            }
+          }
+        ],
+        "isOneOf": false
+      },
+      {
+        "kind": "INPUT_OBJECT",
+        "name": "v2_token_meta_wrapping_max_order_by",
+        "inputFields": [
+          {
+            "name": "destination_channel_id",
+            "type": {
+              "kind": "ENUM",
+              "name": "order_by"
+            }
+          },
+          {
+            "name": "unwrapped_denom",
+            "type": {
+              "kind": "ENUM",
+              "name": "order_by"
+            }
+          },
+          {
+            "name": "wrapper",
+            "type": {
+              "kind": "ENUM",
+              "name": "order_by"
+            }
+          }
+        ],
+        "isOneOf": false
+      },
+      {
+        "kind": "INPUT_OBJECT",
+        "name": "v2_token_meta_wrapping_min_order_by",
+        "inputFields": [
+          {
+            "name": "destination_channel_id",
+            "type": {
+              "kind": "ENUM",
+              "name": "order_by"
+            }
+          },
+          {
+            "name": "unwrapped_denom",
+            "type": {
+              "kind": "ENUM",
+              "name": "order_by"
+            }
+          },
+          {
+            "name": "wrapper",
+            "type": {
+              "kind": "ENUM",
+              "name": "order_by"
+            }
+          }
+        ],
+        "isOneOf": false
+      },
+      {
+        "kind": "INPUT_OBJECT",
+        "name": "v2_token_meta_wrapping_order_by",
+        "inputFields": [
+          {
+            "name": "destination_channel_id",
+            "type": {
+              "kind": "ENUM",
+              "name": "order_by"
+            }
+          },
+          {
+            "name": "unwrapped_chain",
+            "type": {
+              "kind": "INPUT_OBJECT",
+              "name": "v2_chains_view_order_by"
+            }
+          },
+          {
+            "name": "unwrapped_denom",
+            "type": {
+              "kind": "ENUM",
+              "name": "order_by"
+            }
+          },
+          {
+            "name": "wrapped_chain",
+            "type": {
+              "kind": "INPUT_OBJECT",
+              "name": "v2_chains_view_order_by"
+            }
+          },
+          {
+            "name": "wrapper",
+            "type": {
+              "kind": "ENUM",
+              "name": "order_by"
+            }
+          }
+        ],
+        "isOneOf": false
+      },
+      {
+        "kind": "ENUM",
+        "name": "v2_token_meta_wrapping_select_column",
+        "enumValues": [
+          {
+            "name": "destination_channel_id",
+            "isDeprecated": false
+          },
+          {
+            "name": "unwrapped_denom",
+            "isDeprecated": false
+          },
+          {
+            "name": "wrapper",
+            "isDeprecated": false
+          }
+        ]
+      },
+      {
+        "kind": "INPUT_OBJECT",
+        "name": "v2_token_meta_wrapping_stddev_order_by",
+        "inputFields": [
+          {
+            "name": "destination_channel_id",
+            "type": {
+              "kind": "ENUM",
+              "name": "order_by"
+            }
+          }
+        ],
+        "isOneOf": false
+      },
+      {
+        "kind": "INPUT_OBJECT",
+        "name": "v2_token_meta_wrapping_stddev_pop_order_by",
+        "inputFields": [
+          {
+            "name": "destination_channel_id",
+            "type": {
+              "kind": "ENUM",
+              "name": "order_by"
+            }
+          }
+        ],
+        "isOneOf": false
+      },
+      {
+        "kind": "INPUT_OBJECT",
+        "name": "v2_token_meta_wrapping_stddev_samp_order_by",
+        "inputFields": [
+          {
+            "name": "destination_channel_id",
+            "type": {
+              "kind": "ENUM",
+              "name": "order_by"
+            }
+          }
+        ],
+        "isOneOf": false
+      },
+      {
+        "kind": "INPUT_OBJECT",
+        "name": "v2_token_meta_wrapping_sum_order_by",
+        "inputFields": [
+          {
+            "name": "destination_channel_id",
+            "type": {
+              "kind": "ENUM",
+              "name": "order_by"
+            }
+          }
+        ],
+        "isOneOf": false
+      },
+      {
+        "kind": "INPUT_OBJECT",
+        "name": "v2_token_meta_wrapping_var_pop_order_by",
+        "inputFields": [
+          {
+            "name": "destination_channel_id",
+            "type": {
+              "kind": "ENUM",
+              "name": "order_by"
+            }
+          }
+        ],
+        "isOneOf": false
+      },
+      {
+        "kind": "INPUT_OBJECT",
+        "name": "v2_token_meta_wrapping_var_samp_order_by",
+        "inputFields": [
+          {
+            "name": "destination_channel_id",
+            "type": {
+              "kind": "ENUM",
+              "name": "order_by"
+            }
+          }
+        ],
+        "isOneOf": false
+      },
+      {
+        "kind": "INPUT_OBJECT",
+        "name": "v2_token_meta_wrapping_variance_order_by",
+        "inputFields": [
+          {
+            "name": "destination_channel_id",
+            "type": {
+              "kind": "ENUM",
+              "name": "order_by"
+            }
+          }
+        ],
+        "isOneOf": false
+      },
+      {
+        "kind": "INPUT_OBJECT",
+        "name": "v2_tokens_args",
+        "inputFields": [
+          {
+            "name": "p_denom",
+            "type": {
+              "kind": "SCALAR",
+              "name": "String"
+            }
+          },
+          {
+            "name": "p_universal_chain_id",
+            "type": {
+              "kind": "SCALAR",
+              "name": "String"
+            }
+          },
+          {
+            "name": "p_whitelist",
+            "type": {
+              "kind": "SCALAR",
+              "name": "Boolean"
+            }
+          }
+        ],
+        "isOneOf": false
+      },
+      {
+        "kind": "OBJECT",
+        "name": "v2_traces_type",
+        "fields": [
+          {
+            "name": "block_hash",
+            "type": {
+              "kind": "SCALAR",
+              "name": "String"
+            },
+            "args": [],
+            "isDeprecated": false
+          },
+          {
+            "name": "chain",
+            "type": {
+              "kind": "OBJECT",
+              "name": "v2_chains_view"
+            },
+            "args": [],
+            "isDeprecated": false
+          },
+          {
+            "name": "event_index",
+            "type": {
+              "kind": "SCALAR",
+              "name": "String"
+            },
+            "args": [],
+            "isDeprecated": false
+          },
+          {
+            "name": "height",
+            "type": {
+              "kind": "SCALAR",
+              "name": "String"
+            },
+            "args": [],
+            "isDeprecated": false
+          },
+          {
+            "name": "timestamp",
+            "type": {
+              "kind": "SCALAR",
+              "name": "timestamptz"
+            },
+            "args": [],
+            "isDeprecated": false
+          },
+          {
+            "name": "transaction_hash",
+            "type": {
+              "kind": "SCALAR",
+              "name": "String"
+            },
+            "args": [],
+            "isDeprecated": false
+          },
+          {
+            "name": "type",
+            "type": {
+              "kind": "SCALAR",
+              "name": "String"
+            },
+            "args": [],
+            "isDeprecated": false
+          },
+          {
+            "name": "universal_chain_id",
+            "type": {
+              "kind": "SCALAR",
+              "name": "String"
+            },
+            "args": [],
+            "isDeprecated": false
+          }
+        ],
+        "interfaces": []
+      },
+      {
+        "kind": "INPUT_OBJECT",
+        "name": "v2_traces_type_aggregate_order_by",
+        "inputFields": [
+          {
+            "name": "count",
+            "type": {
+              "kind": "ENUM",
+              "name": "order_by"
+            }
+          },
+          {
+            "name": "max",
+            "type": {
+              "kind": "INPUT_OBJECT",
+              "name": "v2_traces_type_max_order_by"
+            }
+          },
+          {
+            "name": "min",
+            "type": {
+              "kind": "INPUT_OBJECT",
+              "name": "v2_traces_type_min_order_by"
+            }
+          }
+        ],
+        "isOneOf": false
+      },
+      {
+        "kind": "INPUT_OBJECT",
+        "name": "v2_traces_type_bool_exp",
+        "inputFields": [
+          {
+            "name": "_and",
+            "type": {
+              "kind": "LIST",
+              "ofType": {
+                "kind": "NON_NULL",
+                "ofType": {
+                  "kind": "INPUT_OBJECT",
+                  "name": "v2_traces_type_bool_exp"
+                }
+              }
+            }
+          },
+          {
+            "name": "_not",
+            "type": {
+              "kind": "INPUT_OBJECT",
+              "name": "v2_traces_type_bool_exp"
+            }
+          },
+          {
+            "name": "_or",
+            "type": {
+              "kind": "LIST",
+              "ofType": {
+                "kind": "NON_NULL",
+                "ofType": {
+                  "kind": "INPUT_OBJECT",
+                  "name": "v2_traces_type_bool_exp"
+                }
+              }
+            }
+          },
+          {
+            "name": "block_hash",
+            "type": {
+              "kind": "INPUT_OBJECT",
+              "name": "String_comparison_exp"
+            }
+          },
+          {
+            "name": "chain",
+            "type": {
+              "kind": "INPUT_OBJECT",
+              "name": "v2_chains_view_bool_exp"
+            }
+          },
+          {
+            "name": "event_index",
+            "type": {
+              "kind": "INPUT_OBJECT",
+              "name": "String_comparison_exp"
+            }
+          },
+          {
+            "name": "height",
+            "type": {
+              "kind": "INPUT_OBJECT",
+              "name": "String_comparison_exp"
+            }
+          },
+          {
+            "name": "timestamp",
+            "type": {
+              "kind": "INPUT_OBJECT",
+              "name": "timestamptz_comparison_exp"
+            }
+          },
+          {
+            "name": "transaction_hash",
+            "type": {
+              "kind": "INPUT_OBJECT",
+              "name": "String_comparison_exp"
+            }
+          },
+          {
+            "name": "type",
+            "type": {
+              "kind": "INPUT_OBJECT",
+              "name": "String_comparison_exp"
+            }
+          },
+          {
+            "name": "universal_chain_id",
+            "type": {
+              "kind": "INPUT_OBJECT",
+              "name": "String_comparison_exp"
+            }
+          }
+        ],
+        "isOneOf": false
+      },
+      {
+        "kind": "INPUT_OBJECT",
+        "name": "v2_traces_type_max_order_by",
+        "inputFields": [
+          {
+            "name": "block_hash",
+            "type": {
+              "kind": "ENUM",
+              "name": "order_by"
+            }
+          },
+          {
+            "name": "event_index",
+            "type": {
+              "kind": "ENUM",
+              "name": "order_by"
+            }
+          },
+          {
+            "name": "height",
+            "type": {
+              "kind": "ENUM",
+              "name": "order_by"
+            }
+          },
+          {
+            "name": "timestamp",
+            "type": {
+              "kind": "ENUM",
+              "name": "order_by"
+            }
+          },
+          {
+            "name": "transaction_hash",
+            "type": {
+              "kind": "ENUM",
+              "name": "order_by"
+            }
+          },
+          {
+            "name": "type",
+            "type": {
+              "kind": "ENUM",
+              "name": "order_by"
+            }
+          },
+          {
+            "name": "universal_chain_id",
+            "type": {
+              "kind": "ENUM",
+              "name": "order_by"
+            }
+          }
+        ],
+        "isOneOf": false
+      },
+      {
+        "kind": "INPUT_OBJECT",
+        "name": "v2_traces_type_min_order_by",
+        "inputFields": [
+          {
+            "name": "block_hash",
+            "type": {
+              "kind": "ENUM",
+              "name": "order_by"
+            }
+          },
+          {
+            "name": "event_index",
+            "type": {
+              "kind": "ENUM",
+              "name": "order_by"
+            }
+          },
+          {
+            "name": "height",
+            "type": {
+              "kind": "ENUM",
+              "name": "order_by"
+            }
+          },
+          {
+            "name": "timestamp",
+            "type": {
+              "kind": "ENUM",
+              "name": "order_by"
+            }
+          },
+          {
+            "name": "transaction_hash",
+            "type": {
+              "kind": "ENUM",
+              "name": "order_by"
+            }
+          },
+          {
+            "name": "type",
+            "type": {
+              "kind": "ENUM",
+              "name": "order_by"
+            }
+          },
+          {
+            "name": "universal_chain_id",
+            "type": {
+              "kind": "ENUM",
+              "name": "order_by"
+            }
+          }
+        ],
+        "isOneOf": false
+      },
+      {
+        "kind": "INPUT_OBJECT",
+        "name": "v2_traces_type_order_by",
+        "inputFields": [
+          {
+            "name": "block_hash",
+            "type": {
+              "kind": "ENUM",
+              "name": "order_by"
+            }
+          },
+          {
+            "name": "chain",
+            "type": {
+              "kind": "INPUT_OBJECT",
+              "name": "v2_chains_view_order_by"
+            }
+          },
+          {
+            "name": "event_index",
+            "type": {
+              "kind": "ENUM",
+              "name": "order_by"
+            }
+          },
+          {
+            "name": "height",
+            "type": {
+              "kind": "ENUM",
+              "name": "order_by"
+            }
+          },
+          {
+            "name": "timestamp",
+            "type": {
+              "kind": "ENUM",
+              "name": "order_by"
+            }
+          },
+          {
+            "name": "transaction_hash",
+            "type": {
+              "kind": "ENUM",
+              "name": "order_by"
+            }
+          },
+          {
+            "name": "type",
+            "type": {
+              "kind": "ENUM",
+              "name": "order_by"
+            }
+          },
+          {
+            "name": "universal_chain_id",
+            "type": {
+              "kind": "ENUM",
+              "name": "order_by"
+            }
+          }
+        ],
+        "isOneOf": false
+      },
+      {
+        "kind": "ENUM",
+        "name": "v2_traces_type_select_column",
+        "enumValues": [
+          {
+            "name": "block_hash",
+            "isDeprecated": false
+          },
+          {
+            "name": "event_index",
+            "isDeprecated": false
+          },
+          {
+            "name": "height",
+            "isDeprecated": false
+          },
+          {
+            "name": "timestamp",
+            "isDeprecated": false
+          },
+          {
+            "name": "transaction_hash",
+            "isDeprecated": false
+          },
+          {
+            "name": "type",
+            "isDeprecated": false
+          },
+          {
+            "name": "universal_chain_id",
+            "isDeprecated": false
+          }
+        ]
+      },
+      {
+        "kind": "OBJECT",
+        "name": "v2_transfer_type",
+        "fields": [
+          {
+            "name": "base_amount",
+            "type": {
+              "kind": "SCALAR",
+              "name": "String"
+            },
+            "args": [],
+            "isDeprecated": false
+          },
+          {
+            "name": "base_token",
+            "type": {
+              "kind": "SCALAR",
+              "name": "String"
+            },
+            "args": [],
+            "isDeprecated": false
+          },
+          {
+            "name": "base_token_decimals",
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int"
+            },
+            "args": [],
+            "isDeprecated": false
+          },
+          {
+            "name": "base_token_meta",
+            "type": {
+              "kind": "OBJECT",
+              "name": "v2_token_meta"
+            },
+            "args": [],
+            "isDeprecated": false
+          },
+          {
+            "name": "base_token_name",
+            "type": {
+              "kind": "SCALAR",
+              "name": "String"
+            },
+            "args": [],
+            "isDeprecated": false
+          },
+          {
+            "name": "base_token_path",
+            "type": {
+              "kind": "SCALAR",
+              "name": "String"
+            },
+            "args": [],
+            "isDeprecated": false
+          },
+          {
+            "name": "base_token_symbol",
+            "type": {
+              "kind": "SCALAR",
+              "name": "String"
+            },
+            "args": [],
+            "isDeprecated": false
+          },
+          {
+            "name": "destination_chain",
+            "type": {
+              "kind": "OBJECT",
+              "name": "v2_chains_view"
+            },
+            "args": [],
+            "isDeprecated": false
+          },
+          {
+            "name": "destination_universal_chain_id",
+            "type": {
+              "kind": "SCALAR",
+              "name": "String"
+            },
+            "args": [],
+            "isDeprecated": false
+          },
+          {
+            "name": "fee_amount",
+            "type": {
+              "kind": "SCALAR",
+              "name": "String"
+            },
+            "args": [],
+            "isDeprecated": false
+          },
+          {
+            "name": "fee_token",
+            "type": {
+              "kind": "SCALAR",
+              "name": "String"
+            },
+            "args": [],
+            "isDeprecated": false
+          },
+          {
+            "name": "fee_token_meta",
+            "type": {
+              "kind": "OBJECT",
+              "name": "v2_token_meta"
+            },
+            "args": [],
+            "isDeprecated": false
+          },
+          {
+            "name": "fee_type",
+            "type": {
+              "kind": "SCALAR",
+              "name": "String"
+            },
+            "args": [],
+            "isDeprecated": false
+          },
+          {
+            "name": "packet_hash",
+            "type": {
+              "kind": "SCALAR",
+              "name": "String"
+            },
+            "args": [],
+            "isDeprecated": false
+          },
+          {
+            "name": "packet_shape",
+            "type": {
+              "kind": "SCALAR",
+              "name": "String"
+            },
+            "args": [],
+            "isDeprecated": false
+          },
+          {
+            "name": "quote_amount",
+            "type": {
+              "kind": "SCALAR",
+              "name": "String"
+            },
+            "args": [],
+            "isDeprecated": false
+          },
+          {
+            "name": "quote_token",
+            "type": {
+              "kind": "SCALAR",
+              "name": "String"
+            },
+            "args": [],
+            "isDeprecated": false
+          },
+          {
+            "name": "quote_token_meta",
+            "type": {
+              "kind": "OBJECT",
+              "name": "v2_token_meta"
+            },
+            "args": [],
+            "isDeprecated": false
+          },
+          {
+            "name": "receiver_canonical",
+            "type": {
+              "kind": "SCALAR",
+              "name": "String"
+            },
+            "args": [],
+            "isDeprecated": false
+          },
+          {
+            "name": "receiver_display",
+            "type": {
+              "kind": "SCALAR",
+              "name": "String"
+            },
+            "args": [],
+            "isDeprecated": false
+          },
+          {
+            "name": "receiver_zkgm",
+            "type": {
+              "kind": "SCALAR",
+              "name": "String"
+            },
+            "args": [],
+            "isDeprecated": false
+          },
+          {
+            "name": "sender_canonical",
+            "type": {
+              "kind": "SCALAR",
+              "name": "String"
+            },
+            "args": [],
+            "isDeprecated": false
+          },
+          {
+            "name": "sender_display",
+            "type": {
+              "kind": "SCALAR",
+              "name": "String"
+            },
+            "args": [],
+            "isDeprecated": false
+          },
+          {
+            "name": "sender_zkgm",
+            "type": {
+              "kind": "SCALAR",
+              "name": "String"
+            },
+            "args": [],
+            "isDeprecated": false
+          },
+          {
+            "name": "sort_order",
+            "type": {
+              "kind": "SCALAR",
+              "name": "String"
+            },
+            "args": [],
+            "isDeprecated": false
+          },
+          {
+            "name": "source_chain",
+            "type": {
+              "kind": "OBJECT",
+              "name": "v2_chains_view"
+            },
+            "args": [],
+            "isDeprecated": false
+          },
+          {
+            "name": "source_universal_chain_id",
+            "type": {
+              "kind": "SCALAR",
+              "name": "String"
+            },
+            "args": [],
+            "isDeprecated": false
+          },
+          {
+            "name": "success",
+            "type": {
+              "kind": "SCALAR",
+              "name": "Boolean"
+            },
+            "args": [],
+            "isDeprecated": false
+          },
+          {
+            "name": "traces",
+            "type": {
+              "kind": "LIST",
+              "ofType": {
+                "kind": "NON_NULL",
+                "ofType": {
+                  "kind": "OBJECT",
+                  "name": "v2_traces_type"
+                }
+              }
+            },
+            "args": [
+              {
+                "name": "distinct_on",
+                "type": {
+                  "kind": "LIST",
+                  "ofType": {
+                    "kind": "NON_NULL",
+                    "ofType": {
+                      "kind": "ENUM",
+                      "name": "v2_traces_type_select_column"
+                    }
+                  }
+                }
+              },
+              {
+                "name": "limit",
+                "type": {
+                  "kind": "SCALAR",
+                  "name": "Int"
+                }
+              },
+              {
+                "name": "offset",
+                "type": {
+                  "kind": "SCALAR",
+                  "name": "Int"
+                }
+              },
+              {
+                "name": "order_by",
+                "type": {
+                  "kind": "LIST",
+                  "ofType": {
+                    "kind": "NON_NULL",
+                    "ofType": {
+                      "kind": "INPUT_OBJECT",
+                      "name": "v2_traces_type_order_by"
+                    }
+                  }
+                }
+              },
+              {
+                "name": "where",
+                "type": {
+                  "kind": "INPUT_OBJECT",
+                  "name": "v2_traces_type_bool_exp"
+                }
+              }
+            ],
+            "isDeprecated": false
+          },
+          {
+            "name": "transfer_index",
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int"
+            },
+            "args": [],
+            "isDeprecated": false
+          },
+          {
+            "name": "transfer_recv_timestamp",
+            "type": {
+              "kind": "SCALAR",
+              "name": "timestamptz"
+            },
+            "args": [],
+            "isDeprecated": false
+          },
+          {
+            "name": "transfer_recv_transaction_hash",
+            "type": {
+              "kind": "SCALAR",
+              "name": "String"
+            },
+            "args": [],
+            "isDeprecated": false
+          },
+          {
+            "name": "transfer_send_timestamp",
+            "type": {
+              "kind": "SCALAR",
+              "name": "timestamptz"
+            },
+            "args": [],
+            "isDeprecated": false
+          },
+          {
+            "name": "transfer_send_transaction_hash",
+            "type": {
+              "kind": "SCALAR",
+              "name": "String"
+            },
+            "args": [],
+            "isDeprecated": false
+          },
+          {
+            "name": "transfer_timeout_timestamp",
+            "type": {
+              "kind": "SCALAR",
+              "name": "timestamptz"
+            },
+            "args": [],
+            "isDeprecated": false
+          },
+          {
+            "name": "transfer_timeout_transaction_hash",
+            "type": {
+              "kind": "SCALAR",
+              "name": "String"
+            },
+            "args": [],
+            "isDeprecated": false
+          },
+          {
+            "name": "wrap_direction",
+            "type": {
+              "kind": "SCALAR",
+              "name": "String"
+            },
+            "args": [],
+            "isDeprecated": false
+          }
+        ],
+        "interfaces": []
+      },
+      {
+        "kind": "INPUT_OBJECT",
+        "name": "v2_transfer_type_bool_exp",
+        "inputFields": [
+          {
+            "name": "_and",
+            "type": {
+              "kind": "LIST",
+              "ofType": {
+                "kind": "NON_NULL",
+                "ofType": {
+                  "kind": "INPUT_OBJECT",
+                  "name": "v2_transfer_type_bool_exp"
+                }
+              }
+            }
+          },
+          {
+            "name": "_not",
+            "type": {
+              "kind": "INPUT_OBJECT",
+              "name": "v2_transfer_type_bool_exp"
+            }
+          },
+          {
+            "name": "_or",
+            "type": {
+              "kind": "LIST",
+              "ofType": {
+                "kind": "NON_NULL",
+                "ofType": {
+                  "kind": "INPUT_OBJECT",
+                  "name": "v2_transfer_type_bool_exp"
+                }
+              }
+            }
+          },
+          {
+            "name": "base_amount",
+            "type": {
+              "kind": "INPUT_OBJECT",
+              "name": "String_comparison_exp"
+            }
+          },
+          {
+            "name": "base_token",
+            "type": {
+              "kind": "INPUT_OBJECT",
+              "name": "String_comparison_exp"
+            }
+          },
+          {
+            "name": "base_token_decimals",
+            "type": {
+              "kind": "INPUT_OBJECT",
+              "name": "Int_comparison_exp"
+            }
+          },
+          {
+            "name": "base_token_meta",
+            "type": {
+              "kind": "INPUT_OBJECT",
+              "name": "v2_token_meta_bool_exp"
+            }
+          },
+          {
+            "name": "base_token_name",
+            "type": {
+              "kind": "INPUT_OBJECT",
+              "name": "String_comparison_exp"
+            }
+          },
+          {
+            "name": "base_token_path",
+            "type": {
+              "kind": "INPUT_OBJECT",
+              "name": "String_comparison_exp"
+            }
+          },
+          {
+            "name": "base_token_symbol",
+            "type": {
+              "kind": "INPUT_OBJECT",
+              "name": "String_comparison_exp"
+            }
+          },
+          {
+            "name": "destination_chain",
+            "type": {
+              "kind": "INPUT_OBJECT",
+              "name": "v2_chains_view_bool_exp"
+            }
+          },
+          {
+            "name": "destination_universal_chain_id",
+            "type": {
+              "kind": "INPUT_OBJECT",
+              "name": "String_comparison_exp"
+            }
+          },
+          {
+            "name": "fee_amount",
+            "type": {
+              "kind": "INPUT_OBJECT",
+              "name": "String_comparison_exp"
+            }
+          },
+          {
+            "name": "fee_token",
+            "type": {
+              "kind": "INPUT_OBJECT",
+              "name": "String_comparison_exp"
+            }
+          },
+          {
+            "name": "fee_token_meta",
+            "type": {
+              "kind": "INPUT_OBJECT",
+              "name": "v2_token_meta_bool_exp"
+            }
+          },
+          {
+            "name": "fee_type",
+            "type": {
+              "kind": "INPUT_OBJECT",
+              "name": "String_comparison_exp"
+            }
+          },
+          {
+            "name": "packet_hash",
+            "type": {
+              "kind": "INPUT_OBJECT",
+              "name": "String_comparison_exp"
+            }
+          },
+          {
+            "name": "packet_shape",
+            "type": {
+              "kind": "INPUT_OBJECT",
+              "name": "String_comparison_exp"
+            }
+          },
+          {
+            "name": "quote_amount",
+            "type": {
+              "kind": "INPUT_OBJECT",
+              "name": "String_comparison_exp"
+            }
+          },
+          {
+            "name": "quote_token",
+            "type": {
+              "kind": "INPUT_OBJECT",
+              "name": "String_comparison_exp"
+            }
+          },
+          {
+            "name": "quote_token_meta",
+            "type": {
+              "kind": "INPUT_OBJECT",
+              "name": "v2_token_meta_bool_exp"
+            }
+          },
+          {
+            "name": "receiver_canonical",
+            "type": {
+              "kind": "INPUT_OBJECT",
+              "name": "String_comparison_exp"
+            }
+          },
+          {
+            "name": "receiver_display",
+            "type": {
+              "kind": "INPUT_OBJECT",
+              "name": "String_comparison_exp"
+            }
+          },
+          {
+            "name": "receiver_zkgm",
+            "type": {
+              "kind": "INPUT_OBJECT",
+              "name": "String_comparison_exp"
+            }
+          },
+          {
+            "name": "sender_canonical",
+            "type": {
+              "kind": "INPUT_OBJECT",
+              "name": "String_comparison_exp"
+            }
+          },
+          {
+            "name": "sender_display",
+            "type": {
+              "kind": "INPUT_OBJECT",
+              "name": "String_comparison_exp"
+            }
+          },
+          {
+            "name": "sender_zkgm",
+            "type": {
+              "kind": "INPUT_OBJECT",
+              "name": "String_comparison_exp"
+            }
+          },
+          {
+            "name": "sort_order",
+            "type": {
+              "kind": "INPUT_OBJECT",
+              "name": "String_comparison_exp"
+            }
+          },
+          {
+            "name": "source_chain",
+            "type": {
+              "kind": "INPUT_OBJECT",
+              "name": "v2_chains_view_bool_exp"
+            }
+          },
+          {
+            "name": "source_universal_chain_id",
+            "type": {
+              "kind": "INPUT_OBJECT",
+              "name": "String_comparison_exp"
+            }
+          },
+          {
+            "name": "success",
+            "type": {
+              "kind": "INPUT_OBJECT",
+              "name": "Boolean_comparison_exp"
+            }
+          },
+          {
+            "name": "traces",
+            "type": {
+              "kind": "INPUT_OBJECT",
+              "name": "v2_traces_type_bool_exp"
+            }
+          },
+          {
+            "name": "transfer_index",
+            "type": {
+              "kind": "INPUT_OBJECT",
+              "name": "Int_comparison_exp"
+            }
+          },
+          {
+            "name": "transfer_recv_timestamp",
+            "type": {
+              "kind": "INPUT_OBJECT",
+              "name": "timestamptz_comparison_exp"
+            }
+          },
+          {
+            "name": "transfer_recv_transaction_hash",
+            "type": {
+              "kind": "INPUT_OBJECT",
+              "name": "String_comparison_exp"
+            }
+          },
+          {
+            "name": "transfer_send_timestamp",
+            "type": {
+              "kind": "INPUT_OBJECT",
+              "name": "timestamptz_comparison_exp"
+            }
+          },
+          {
+            "name": "transfer_send_transaction_hash",
+            "type": {
+              "kind": "INPUT_OBJECT",
+              "name": "String_comparison_exp"
+            }
+          },
+          {
+            "name": "transfer_timeout_timestamp",
+            "type": {
+              "kind": "INPUT_OBJECT",
+              "name": "timestamptz_comparison_exp"
+            }
+          },
+          {
+            "name": "transfer_timeout_transaction_hash",
+            "type": {
+              "kind": "INPUT_OBJECT",
+              "name": "String_comparison_exp"
+            }
+          },
+          {
+            "name": "wrap_direction",
+            "type": {
+              "kind": "INPUT_OBJECT",
+              "name": "String_comparison_exp"
+            }
+          }
+        ],
+        "isOneOf": false
+      },
+      {
+        "kind": "INPUT_OBJECT",
+        "name": "v2_transfer_type_order_by",
+        "inputFields": [
+          {
+            "name": "base_amount",
+            "type": {
+              "kind": "ENUM",
+              "name": "order_by"
+            }
+          },
+          {
+            "name": "base_token",
+            "type": {
+              "kind": "ENUM",
+              "name": "order_by"
+            }
+          },
+          {
+            "name": "base_token_decimals",
+            "type": {
+              "kind": "ENUM",
+              "name": "order_by"
+            }
+          },
+          {
+            "name": "base_token_meta",
+            "type": {
+              "kind": "INPUT_OBJECT",
+              "name": "v2_token_meta_order_by"
+            }
+          },
+          {
+            "name": "base_token_name",
+            "type": {
+              "kind": "ENUM",
+              "name": "order_by"
+            }
+          },
+          {
+            "name": "base_token_path",
+            "type": {
+              "kind": "ENUM",
+              "name": "order_by"
+            }
+          },
+          {
+            "name": "base_token_symbol",
+            "type": {
+              "kind": "ENUM",
+              "name": "order_by"
+            }
+          },
+          {
+            "name": "destination_chain",
+            "type": {
+              "kind": "INPUT_OBJECT",
+              "name": "v2_chains_view_order_by"
+            }
+          },
+          {
+            "name": "destination_universal_chain_id",
+            "type": {
+              "kind": "ENUM",
+              "name": "order_by"
+            }
+          },
+          {
+            "name": "fee_amount",
+            "type": {
+              "kind": "ENUM",
+              "name": "order_by"
+            }
+          },
+          {
+            "name": "fee_token",
+            "type": {
+              "kind": "ENUM",
+              "name": "order_by"
+            }
+          },
+          {
+            "name": "fee_token_meta",
+            "type": {
+              "kind": "INPUT_OBJECT",
+              "name": "v2_token_meta_order_by"
+            }
+          },
+          {
+            "name": "fee_type",
+            "type": {
+              "kind": "ENUM",
+              "name": "order_by"
+            }
+          },
+          {
+            "name": "packet_hash",
+            "type": {
+              "kind": "ENUM",
+              "name": "order_by"
+            }
+          },
+          {
+            "name": "packet_shape",
+            "type": {
+              "kind": "ENUM",
+              "name": "order_by"
+            }
+          },
+          {
+            "name": "quote_amount",
+            "type": {
+              "kind": "ENUM",
+              "name": "order_by"
+            }
+          },
+          {
+            "name": "quote_token",
+            "type": {
+              "kind": "ENUM",
+              "name": "order_by"
+            }
+          },
+          {
+            "name": "quote_token_meta",
+            "type": {
+              "kind": "INPUT_OBJECT",
+              "name": "v2_token_meta_order_by"
+            }
+          },
+          {
+            "name": "receiver_canonical",
+            "type": {
+              "kind": "ENUM",
+              "name": "order_by"
+            }
+          },
+          {
+            "name": "receiver_display",
+            "type": {
+              "kind": "ENUM",
+              "name": "order_by"
+            }
+          },
+          {
+            "name": "receiver_zkgm",
+            "type": {
+              "kind": "ENUM",
+              "name": "order_by"
+            }
+          },
+          {
+            "name": "sender_canonical",
+            "type": {
+              "kind": "ENUM",
+              "name": "order_by"
+            }
+          },
+          {
+            "name": "sender_display",
+            "type": {
+              "kind": "ENUM",
+              "name": "order_by"
+            }
+          },
+          {
+            "name": "sender_zkgm",
+            "type": {
+              "kind": "ENUM",
+              "name": "order_by"
+            }
+          },
+          {
+            "name": "sort_order",
+            "type": {
+              "kind": "ENUM",
+              "name": "order_by"
+            }
+          },
+          {
+            "name": "source_chain",
+            "type": {
+              "kind": "INPUT_OBJECT",
+              "name": "v2_chains_view_order_by"
+            }
+          },
+          {
+            "name": "source_universal_chain_id",
+            "type": {
+              "kind": "ENUM",
+              "name": "order_by"
+            }
+          },
+          {
+            "name": "success",
+            "type": {
+              "kind": "ENUM",
+              "name": "order_by"
+            }
+          },
+          {
+            "name": "traces_aggregate",
+            "type": {
+              "kind": "INPUT_OBJECT",
+              "name": "v2_traces_type_aggregate_order_by"
+            }
+          },
+          {
+            "name": "transfer_index",
+            "type": {
+              "kind": "ENUM",
+              "name": "order_by"
+            }
+          },
+          {
+            "name": "transfer_recv_timestamp",
+            "type": {
+              "kind": "ENUM",
+              "name": "order_by"
+            }
+          },
+          {
+            "name": "transfer_recv_transaction_hash",
+            "type": {
+              "kind": "ENUM",
+              "name": "order_by"
+            }
+          },
+          {
+            "name": "transfer_send_timestamp",
+            "type": {
+              "kind": "ENUM",
+              "name": "order_by"
+            }
+          },
+          {
+            "name": "transfer_send_transaction_hash",
+            "type": {
+              "kind": "ENUM",
+              "name": "order_by"
+            }
+          },
+          {
+            "name": "transfer_timeout_timestamp",
+            "type": {
+              "kind": "ENUM",
+              "name": "order_by"
+            }
+          },
+          {
+            "name": "transfer_timeout_transaction_hash",
+            "type": {
+              "kind": "ENUM",
+              "name": "order_by"
+            }
+          },
+          {
+            "name": "wrap_direction",
+            "type": {
+              "kind": "ENUM",
+              "name": "order_by"
+            }
+          }
+        ],
+        "isOneOf": false
+      },
+      {
+        "kind": "ENUM",
+        "name": "v2_transfer_type_select_column",
+        "enumValues": [
+          {
+            "name": "base_amount",
+            "isDeprecated": false
+          },
+          {
+            "name": "base_token",
+            "isDeprecated": false
+          },
+          {
+            "name": "base_token_decimals",
+            "isDeprecated": false
+          },
+          {
+            "name": "base_token_name",
+            "isDeprecated": false
+          },
+          {
+            "name": "base_token_path",
+            "isDeprecated": false
+          },
+          {
+            "name": "base_token_symbol",
+            "isDeprecated": false
+          },
+          {
+            "name": "destination_universal_chain_id",
+            "isDeprecated": false
+          },
+          {
+            "name": "fee_amount",
+            "isDeprecated": false
+          },
+          {
+            "name": "fee_token",
+            "isDeprecated": false
+          },
+          {
+            "name": "fee_type",
+            "isDeprecated": false
+          },
+          {
+            "name": "packet_hash",
+            "isDeprecated": false
+          },
+          {
+            "name": "packet_shape",
+            "isDeprecated": false
+          },
+          {
+            "name": "quote_amount",
+            "isDeprecated": false
+          },
+          {
+            "name": "quote_token",
+            "isDeprecated": false
+          },
+          {
+            "name": "receiver_canonical",
+            "isDeprecated": false
+          },
+          {
+            "name": "receiver_display",
+            "isDeprecated": false
+          },
+          {
+            "name": "receiver_zkgm",
+            "isDeprecated": false
+          },
+          {
+            "name": "sender_canonical",
+            "isDeprecated": false
+          },
+          {
+            "name": "sender_display",
+            "isDeprecated": false
+          },
+          {
+            "name": "sender_zkgm",
+            "isDeprecated": false
+          },
+          {
+            "name": "sort_order",
+            "isDeprecated": false
+          },
+          {
+            "name": "source_universal_chain_id",
+            "isDeprecated": false
+          },
+          {
+            "name": "success",
+            "isDeprecated": false
+          },
+          {
+            "name": "transfer_index",
+            "isDeprecated": false
+          },
+          {
+            "name": "transfer_recv_timestamp",
+            "isDeprecated": false
+          },
+          {
+            "name": "transfer_recv_transaction_hash",
+            "isDeprecated": false
+          },
+          {
+            "name": "transfer_send_timestamp",
+            "isDeprecated": false
+          },
+          {
+            "name": "transfer_send_transaction_hash",
+            "isDeprecated": false
+          },
+          {
+            "name": "transfer_timeout_timestamp",
+            "isDeprecated": false
+          },
+          {
+            "name": "transfer_timeout_transaction_hash",
+            "isDeprecated": false
+          },
+          {
+            "name": "wrap_direction",
+            "isDeprecated": false
+          }
+        ]
+      },
+      {
+        "kind": "INPUT_OBJECT",
+        "name": "v2_transfers_args",
+        "inputFields": [
+          {
+            "name": "p_addresses_canonical",
+            "type": {
+              "kind": "SCALAR",
+              "name": "jsonb"
+            }
+          },
+          {
+            "name": "p_block_hash",
+            "type": {
+              "kind": "SCALAR",
+              "name": "String"
+            }
+          },
+          {
+            "name": "p_comparison",
+            "type": {
+              "kind": "SCALAR",
+              "name": "String"
+            }
+          },
+          {
+            "name": "p_destination_universal_chain_id",
+            "type": {
+              "kind": "SCALAR",
+              "name": "String"
+            }
+          },
+          {
+            "name": "p_limit",
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int"
+            }
+          },
+          {
+            "name": "p_network",
+            "type": {
+              "kind": "SCALAR",
+              "name": "String"
+            }
+          },
+          {
+            "name": "p_packet_hash",
+            "type": {
+              "kind": "SCALAR",
+              "name": "String"
+            }
+          },
+          {
+            "name": "p_sort_order",
+            "type": {
+              "kind": "SCALAR",
+              "name": "String"
+            }
+          },
+          {
+            "name": "p_source_universal_chain_id",
+            "type": {
+              "kind": "SCALAR",
+              "name": "String"
+            }
+          },
+          {
+            "name": "p_transaction_hash",
+            "type": {
+              "kind": "SCALAR",
+              "name": "String"
+            }
+          },
+          {
+            "name": "p_transfer_index",
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int"
+            }
+          }
+        ],
+        "isOneOf": false
+      },
+      {
+        "kind": "INPUT_OBJECT",
+        "name": "v2_util_get_address_types_for_display_address_args",
+        "inputFields": [
+          {
+            "name": "p_chain_type",
+            "type": {
+              "kind": "SCALAR",
+              "name": "String"
+            }
+          },
+          {
+            "name": "p_display_address",
+            "type": {
+              "kind": "SCALAR",
+              "name": "String"
+            }
+          }
+        ],
+        "isOneOf": false
+      },
+      {
+        "kind": "OBJECT",
+        "name": "v2_util_get_address_types_for_display_address_type",
+        "fields": [
+          {
+            "name": "canonical",
+            "type": {
+              "kind": "SCALAR",
+              "name": "String"
+            },
+            "args": [],
+            "isDeprecated": false
+          },
+          {
+            "name": "display",
+            "type": {
+              "kind": "SCALAR",
+              "name": "String"
+            },
+            "args": [],
+            "isDeprecated": false
+          },
+          {
+            "name": "zkgm",
+            "type": {
+              "kind": "SCALAR",
+              "name": "String"
+            },
+            "args": [],
+            "isDeprecated": false
+          }
+        ],
+        "interfaces": []
+      },
+      {
+        "kind": "INPUT_OBJECT",
+        "name": "v2_util_get_address_types_for_display_address_type_bool_exp",
+        "inputFields": [
+          {
+            "name": "_and",
+            "type": {
+              "kind": "LIST",
+              "ofType": {
+                "kind": "NON_NULL",
+                "ofType": {
+                  "kind": "INPUT_OBJECT",
+                  "name": "v2_util_get_address_types_for_display_address_type_bool_exp"
+                }
+              }
+            }
+          },
+          {
+            "name": "_not",
+            "type": {
+              "kind": "INPUT_OBJECT",
+              "name": "v2_util_get_address_types_for_display_address_type_bool_exp"
+            }
+          },
+          {
+            "name": "_or",
+            "type": {
+              "kind": "LIST",
+              "ofType": {
+                "kind": "NON_NULL",
+                "ofType": {
+                  "kind": "INPUT_OBJECT",
+                  "name": "v2_util_get_address_types_for_display_address_type_bool_exp"
+                }
+              }
+            }
+          },
+          {
+            "name": "canonical",
+            "type": {
+              "kind": "INPUT_OBJECT",
+              "name": "String_comparison_exp"
+            }
+          },
+          {
+            "name": "display",
+            "type": {
+              "kind": "INPUT_OBJECT",
+              "name": "String_comparison_exp"
+            }
+          },
+          {
+            "name": "zkgm",
+            "type": {
+              "kind": "INPUT_OBJECT",
+              "name": "String_comparison_exp"
+            }
+          }
+        ],
+        "isOneOf": false
+      },
+      {
+        "kind": "INPUT_OBJECT",
+        "name": "v2_util_get_address_types_for_display_address_type_order_by",
+        "inputFields": [
+          {
+            "name": "canonical",
+            "type": {
+              "kind": "ENUM",
+              "name": "order_by"
+            }
+          },
+          {
+            "name": "display",
+            "type": {
+              "kind": "ENUM",
+              "name": "order_by"
+            }
+          },
+          {
+            "name": "zkgm",
+            "type": {
+              "kind": "ENUM",
+              "name": "order_by"
+            }
+          }
+        ],
+        "isOneOf": false
+      },
+      {
+        "kind": "ENUM",
+        "name": "v2_util_get_address_types_for_display_address_type_select_column",
+        "enumValues": [
+          {
+            "name": "canonical",
+            "isDeprecated": false
+          },
+          {
+            "name": "display",
+            "isDeprecated": false
+          },
+          {
+            "name": "zkgm",
+            "isDeprecated": false
+          }
+        ]
+      },
+      {
+        "kind": "INPUT_OBJECT",
+        "name": "v2_util_get_transfer_request_details_args",
+        "inputFields": [
+          {
+            "name": "p_base_token",
+            "type": {
+              "kind": "SCALAR",
+              "name": "String"
+            }
+          },
+          {
+            "name": "p_destination_universal_chain_id",
+            "type": {
+              "kind": "SCALAR",
+              "name": "String"
+            }
+          },
+          {
+            "name": "p_source_universal_chain_id",
+            "type": {
+              "kind": "SCALAR",
+              "name": "String"
+            }
+          }
+        ],
+        "isOneOf": false
+      },
+      {
+        "kind": "OBJECT",
+        "name": "v2_util_get_transfer_request_details_type",
+        "fields": [
+          {
+            "name": "already_exists",
+            "type": {
+              "kind": "SCALAR",
+              "name": "Boolean"
+            },
+            "args": [],
+            "isDeprecated": false
+          },
+          {
+            "name": "destination_channel_id",
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int"
+            },
+            "args": [],
+            "isDeprecated": false
+          },
+          {
+            "name": "quote_token",
+            "type": {
+              "kind": "SCALAR",
+              "name": "String"
+            },
+            "args": [],
+            "isDeprecated": false
+          },
+          {
+            "name": "source_channel_id",
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int"
+            },
+            "args": [],
+            "isDeprecated": false
+          },
+          {
+            "name": "wrap_direction",
+            "type": {
+              "kind": "SCALAR",
+              "name": "String"
+            },
+            "args": [],
+            "isDeprecated": false
+          }
+        ],
+        "interfaces": []
+      },
+      {
+        "kind": "INPUT_OBJECT",
+        "name": "v2_util_get_transfer_request_details_type_bool_exp",
+        "inputFields": [
+          {
+            "name": "_and",
+            "type": {
+              "kind": "LIST",
+              "ofType": {
+                "kind": "NON_NULL",
+                "ofType": {
+                  "kind": "INPUT_OBJECT",
+                  "name": "v2_util_get_transfer_request_details_type_bool_exp"
+                }
+              }
+            }
+          },
+          {
+            "name": "_not",
+            "type": {
+              "kind": "INPUT_OBJECT",
+              "name": "v2_util_get_transfer_request_details_type_bool_exp"
+            }
+          },
+          {
+            "name": "_or",
+            "type": {
+              "kind": "LIST",
+              "ofType": {
+                "kind": "NON_NULL",
+                "ofType": {
+                  "kind": "INPUT_OBJECT",
+                  "name": "v2_util_get_transfer_request_details_type_bool_exp"
+                }
+              }
+            }
+          },
+          {
+            "name": "already_exists",
+            "type": {
+              "kind": "INPUT_OBJECT",
+              "name": "Boolean_comparison_exp"
+            }
+          },
+          {
+            "name": "destination_channel_id",
+            "type": {
+              "kind": "INPUT_OBJECT",
+              "name": "Int_comparison_exp"
+            }
+          },
+          {
+            "name": "quote_token",
+            "type": {
+              "kind": "INPUT_OBJECT",
+              "name": "String_comparison_exp"
+            }
+          },
+          {
+            "name": "source_channel_id",
+            "type": {
+              "kind": "INPUT_OBJECT",
+              "name": "Int_comparison_exp"
+            }
+          },
+          {
+            "name": "wrap_direction",
+            "type": {
+              "kind": "INPUT_OBJECT",
+              "name": "String_comparison_exp"
+            }
+          }
+        ],
+        "isOneOf": false
+      },
+      {
+        "kind": "INPUT_OBJECT",
+        "name": "v2_util_get_transfer_request_details_type_order_by",
+        "inputFields": [
+          {
+            "name": "already_exists",
+            "type": {
+              "kind": "ENUM",
+              "name": "order_by"
+            }
+          },
+          {
+            "name": "destination_channel_id",
+            "type": {
+              "kind": "ENUM",
+              "name": "order_by"
+            }
+          },
+          {
+            "name": "quote_token",
+            "type": {
+              "kind": "ENUM",
+              "name": "order_by"
+            }
+          },
+          {
+            "name": "source_channel_id",
+            "type": {
+              "kind": "ENUM",
+              "name": "order_by"
+            }
+          },
+          {
+            "name": "wrap_direction",
+            "type": {
+              "kind": "ENUM",
+              "name": "order_by"
+            }
+          }
+        ],
+        "isOneOf": false
+      },
+      {
+        "kind": "ENUM",
+        "name": "v2_util_get_transfer_request_details_type_select_column",
+        "enumValues": [
+          {
+            "name": "already_exists",
+            "isDeprecated": false
+          },
+          {
+            "name": "destination_channel_id",
+            "isDeprecated": false
+          },
+          {
+            "name": "quote_token",
+            "isDeprecated": false
+          },
+          {
+            "name": "source_channel_id",
+            "isDeprecated": false
+          },
+          {
+            "name": "wrap_direction",
+            "isDeprecated": false
+          }
+        ]
+      }
+    ],
+    "directives": []
+  }
 };
 
 import * as gqlTada from 'gql.tada';

--- a/app2/src/generated/schema.graphql
+++ b/app2/src/generated/schema.graphql
@@ -132,6 +132,87 @@ enum cursor_ordering {
   DESC
 }
 
+input dashboard_balance_current_args {
+  p_contract_address_canonical: String
+  p_phase: String
+  p_universal_chain_id: String
+  p_wallet_addresses_canonical: jsonb
+}
+
+"""
+columns and relationships of "dashboard.balance_current_type"
+"""
+type dashboard_balance_current_type {
+  balance: String
+  balance_usd: String
+  contract_address_canonical: String
+  token: String
+  universal_chain_id: String
+  wallet_address_canonical: String
+  weighted_balance: String
+  weighted_balance_usd: String
+}
+
+"""
+Boolean expression to filter rows from the table "dashboard.balance_current_type". All fields are combined with a logical 'AND'.
+"""
+input dashboard_balance_current_type_bool_exp {
+  _and: [dashboard_balance_current_type_bool_exp!]
+  _not: dashboard_balance_current_type_bool_exp
+  _or: [dashboard_balance_current_type_bool_exp!]
+  balance: String_comparison_exp
+  balance_usd: String_comparison_exp
+  contract_address_canonical: String_comparison_exp
+  token: String_comparison_exp
+  universal_chain_id: String_comparison_exp
+  wallet_address_canonical: String_comparison_exp
+  weighted_balance: String_comparison_exp
+  weighted_balance_usd: String_comparison_exp
+}
+
+"""
+Ordering options when selecting data from "dashboard.balance_current_type".
+"""
+input dashboard_balance_current_type_order_by {
+  balance: order_by
+  balance_usd: order_by
+  contract_address_canonical: order_by
+  token: order_by
+  universal_chain_id: order_by
+  wallet_address_canonical: order_by
+  weighted_balance: order_by
+  weighted_balance_usd: order_by
+}
+
+"""
+select columns of table "dashboard.balance_current_type"
+"""
+enum dashboard_balance_current_type_select_column {
+  """column name"""
+  balance
+
+  """column name"""
+  balance_usd
+
+  """column name"""
+  contract_address_canonical
+
+  """column name"""
+  token
+
+  """column name"""
+  universal_chain_id
+
+  """column name"""
+  wallet_address_canonical
+
+  """column name"""
+  weighted_balance
+
+  """column name"""
+  weighted_balance_usd
+}
+
 """
 columns and relationships of "dashboard.count_by_chain_type"
 """
@@ -331,6 +412,31 @@ enum order_by {
 }
 
 type query_root {
+  """
+  execute function "dashboard.balance_current" which returns "dashboard.balance_current_type"
+  """
+  dashboard_balance_current(
+    """
+    input parameters for function "dashboard_balance_current"
+    """
+    args: dashboard_balance_current_args
+
+    """distinct select on columns"""
+    distinct_on: [dashboard_balance_current_type_select_column!]
+
+    """limit the number of rows returned"""
+    limit: Int
+
+    """skip the first n rows. Use only with order_by"""
+    offset: Int
+
+    """sort the rows by one or more columns"""
+    order_by: [dashboard_balance_current_type_order_by!]
+
+    """filter the rows returned"""
+    where: dashboard_balance_current_type_bool_exp
+  ): [dashboard_balance_current_type!]!
+
   """
   execute function "dashboard.transfer_count_by_chain" which returns "dashboard.count_by_chain_type"
   """
@@ -541,6 +647,31 @@ type query_root {
     """filter the rows returned"""
     where: v2_health_check_type_bool_exp
   ): [v2_health_check_type!]!
+
+  """
+  execute function "v2.instructions" which returns "v2.instruction_type"
+  """
+  v2_instructions(
+    """
+    input parameters for function "v2_instructions"
+    """
+    args: v2_instructions_args
+
+    """distinct select on columns"""
+    distinct_on: [v2_instruction_type_select_column!]
+
+    """limit the number of rows returned"""
+    limit: Int
+
+    """skip the first n rows. Use only with order_by"""
+    offset: Int
+
+    """sort the rows by one or more columns"""
+    order_by: [v2_instruction_type_order_by!]
+
+    """filter the rows returned"""
+    where: v2_instruction_type_bool_exp
+  ): [v2_instruction_type!]!
 
   """
   execute function "v2.packets" which returns "v2.packet_type"
@@ -840,6 +971,31 @@ type query_root {
 
 type subscription_root {
   """
+  execute function "dashboard.balance_current" which returns "dashboard.balance_current_type"
+  """
+  dashboard_balance_current(
+    """
+    input parameters for function "dashboard_balance_current"
+    """
+    args: dashboard_balance_current_args
+
+    """distinct select on columns"""
+    distinct_on: [dashboard_balance_current_type_select_column!]
+
+    """limit the number of rows returned"""
+    limit: Int
+
+    """skip the first n rows. Use only with order_by"""
+    offset: Int
+
+    """sort the rows by one or more columns"""
+    order_by: [dashboard_balance_current_type_order_by!]
+
+    """filter the rows returned"""
+    where: dashboard_balance_current_type_bool_exp
+  ): [dashboard_balance_current_type!]!
+
+  """
   execute function "dashboard.transfer_count_by_chain" which returns "dashboard.count_by_chain_type"
   """
   dashboard_transfer_count_by_chain(
@@ -1062,6 +1218,31 @@ type subscription_root {
     """filter the rows returned"""
     where: v2_health_check_type_bool_exp
   ): [v2_health_check_type!]!
+
+  """
+  execute function "v2.instructions" which returns "v2.instruction_type"
+  """
+  v2_instructions(
+    """
+    input parameters for function "v2_instructions"
+    """
+    args: v2_instructions_args
+
+    """distinct select on columns"""
+    distinct_on: [v2_instruction_type_select_column!]
+
+    """limit the number of rows returned"""
+    limit: Int
+
+    """skip the first n rows. Use only with order_by"""
+    offset: Int
+
+    """sort the rows by one or more columns"""
+    order_by: [v2_instruction_type_order_by!]
+
+    """filter the rows returned"""
+    where: v2_instruction_type_bool_exp
+  ): [v2_instruction_type!]!
 
   """
   execute function "v2.packets" which returns "v2.packet_type"
@@ -1729,6 +1910,7 @@ type v2_chain_type {
     where: v2_chain_features_bool_exp
   ): [v2_chain_features!]!
   logo_uri: String
+  minter_address_display: String
   rpc_type: String
 
   """An array relationship"""
@@ -1786,6 +1968,7 @@ input v2_chain_type_bool_exp {
   explorers: v2_explorers_bool_exp
   features: v2_chain_features_bool_exp
   logo_uri: String_comparison_exp
+  minter_address_display: String_comparison_exp
   rpc_type: String_comparison_exp
   rpcs: v2_rpcs_bool_exp
   status: v2_chain_status_type_bool_exp
@@ -1802,6 +1985,7 @@ input v2_chain_type_order_by {
   explorers_aggregate: v2_explorers_aggregate_order_by
   features_aggregate: v2_chain_features_aggregate_order_by
   logo_uri: order_by
+  minter_address_display: order_by
   rpc_type: order_by
   rpcs_aggregate: v2_rpcs_aggregate_order_by
   status_aggregate: v2_chain_status_type_aggregate_order_by
@@ -1824,6 +2008,9 @@ enum v2_chain_type_select_column {
 
   """column name"""
   logo_uri
+
+  """column name"""
+  minter_address_display
 
   """column name"""
   rpc_type
@@ -1893,6 +2080,7 @@ type v2_channel_type {
   destination_connection_id: Int
   destination_port_id: String
   destination_universal_chain_id: String
+  sla: String
   sort_order: String
 
   """An object relationship"""
@@ -1919,6 +2107,7 @@ input v2_channel_type_bool_exp {
   destination_connection_id: Int_comparison_exp
   destination_port_id: String_comparison_exp
   destination_universal_chain_id: String_comparison_exp
+  sla: String_comparison_exp
   sort_order: String_comparison_exp
   source_chain: v2_chains_view_bool_exp
   source_channel_id: Int_comparison_exp
@@ -1938,6 +2127,7 @@ input v2_channel_type_order_by {
   destination_connection_id: order_by
   destination_port_id: order_by
   destination_universal_chain_id: order_by
+  sla: order_by
   sort_order: order_by
   source_chain: v2_chains_view_order_by
   source_channel_id: order_by
@@ -1967,6 +2157,9 @@ enum v2_channel_type_select_column {
 
   """column name"""
   destination_universal_chain_id
+
+  """column name"""
+  sla
 
   """column name"""
   sort_order
@@ -2375,6 +2568,400 @@ enum v2_health_check_type_select_column {
 }
 
 """
+columns and relationships of "v2.instruction_type"
+"""
+type v2_instruction_type {
+  acknowledgement: String
+  channel_version: String
+  data: String
+  decoded(
+    """JSON select path"""
+    path: String
+  ): jsonb
+  decoded_flattened(
+    """JSON select path"""
+    path: String
+  ): jsonb
+
+  """An object relationship"""
+  destination_chain: v2_chains_view
+  destination_chain_id: String
+  destination_channel_id: Int
+  destination_client_id: Int
+  destination_connection_id: Int
+  destination_port_id: String
+  destination_universal_chain_id: String
+  instruction(
+    """JSON select path"""
+    path: String
+  ): jsonb
+  instruction_hash: String
+  instruction_index: String
+  instruction_path: String
+  instruction_type: String
+  opcode: Int
+  operand(
+    """JSON select path"""
+    path: String
+  ): jsonb
+  packet_ack_block_hash: String
+  packet_ack_height: String
+  packet_ack_maker: String
+  packet_ack_timestamp: timestamptz
+  packet_ack_transaction_hash: String
+  packet_hash: String
+  packet_recv_block_hash: String
+  packet_recv_height: String
+  packet_recv_maker: String
+  packet_recv_maker_msg: String
+  packet_recv_timestamp: timestamptz
+  packet_recv_transaction_hash: String
+  packet_send_block_hash: String
+  packet_send_height: String
+  packet_send_timestamp: timestamptz
+  packet_send_transaction_hash: String
+  packet_timeout_block_hash: String
+  packet_timeout_height: String
+  packet_timeout_maker: String
+  packet_timeout_timestamp: timestamptz
+  packet_timeout_transaction_hash: String
+  path: String
+  salt: String
+  sort_order: String
+
+  """An object relationship"""
+  source_chain: v2_chains_view
+  source_channel_id: Int
+  source_client_id: Int
+  source_connection_id: Int
+  source_port_id: String
+  source_universal_chain_id: String
+  status: String
+  success: Boolean
+  timeout_height: String
+  timeout_timestamp: String
+  version: Int
+  write_ack_block_hash: String
+  write_ack_height: String
+  write_ack_timestamp: timestamptz
+  write_ack_transaction_hash: String
+}
+
+"""
+Boolean expression to filter rows from the table "v2.instruction_type". All fields are combined with a logical 'AND'.
+"""
+input v2_instruction_type_bool_exp {
+  _and: [v2_instruction_type_bool_exp!]
+  _not: v2_instruction_type_bool_exp
+  _or: [v2_instruction_type_bool_exp!]
+  acknowledgement: String_comparison_exp
+  channel_version: String_comparison_exp
+  data: String_comparison_exp
+  decoded: jsonb_comparison_exp
+  decoded_flattened: jsonb_comparison_exp
+  destination_chain: v2_chains_view_bool_exp
+  destination_chain_id: String_comparison_exp
+  destination_channel_id: Int_comparison_exp
+  destination_client_id: Int_comparison_exp
+  destination_connection_id: Int_comparison_exp
+  destination_port_id: String_comparison_exp
+  destination_universal_chain_id: String_comparison_exp
+  instruction: jsonb_comparison_exp
+  instruction_hash: String_comparison_exp
+  instruction_index: String_comparison_exp
+  instruction_path: String_comparison_exp
+  instruction_type: String_comparison_exp
+  opcode: Int_comparison_exp
+  operand: jsonb_comparison_exp
+  packet_ack_block_hash: String_comparison_exp
+  packet_ack_height: String_comparison_exp
+  packet_ack_maker: String_comparison_exp
+  packet_ack_timestamp: timestamptz_comparison_exp
+  packet_ack_transaction_hash: String_comparison_exp
+  packet_hash: String_comparison_exp
+  packet_recv_block_hash: String_comparison_exp
+  packet_recv_height: String_comparison_exp
+  packet_recv_maker: String_comparison_exp
+  packet_recv_maker_msg: String_comparison_exp
+  packet_recv_timestamp: timestamptz_comparison_exp
+  packet_recv_transaction_hash: String_comparison_exp
+  packet_send_block_hash: String_comparison_exp
+  packet_send_height: String_comparison_exp
+  packet_send_timestamp: timestamptz_comparison_exp
+  packet_send_transaction_hash: String_comparison_exp
+  packet_timeout_block_hash: String_comparison_exp
+  packet_timeout_height: String_comparison_exp
+  packet_timeout_maker: String_comparison_exp
+  packet_timeout_timestamp: timestamptz_comparison_exp
+  packet_timeout_transaction_hash: String_comparison_exp
+  path: String_comparison_exp
+  salt: String_comparison_exp
+  sort_order: String_comparison_exp
+  source_chain: v2_chains_view_bool_exp
+  source_channel_id: Int_comparison_exp
+  source_client_id: Int_comparison_exp
+  source_connection_id: Int_comparison_exp
+  source_port_id: String_comparison_exp
+  source_universal_chain_id: String_comparison_exp
+  status: String_comparison_exp
+  success: Boolean_comparison_exp
+  timeout_height: String_comparison_exp
+  timeout_timestamp: String_comparison_exp
+  version: Int_comparison_exp
+  write_ack_block_hash: String_comparison_exp
+  write_ack_height: String_comparison_exp
+  write_ack_timestamp: timestamptz_comparison_exp
+  write_ack_transaction_hash: String_comparison_exp
+}
+
+"""Ordering options when selecting data from "v2.instruction_type"."""
+input v2_instruction_type_order_by {
+  acknowledgement: order_by
+  channel_version: order_by
+  data: order_by
+  decoded: order_by
+  decoded_flattened: order_by
+  destination_chain: v2_chains_view_order_by
+  destination_chain_id: order_by
+  destination_channel_id: order_by
+  destination_client_id: order_by
+  destination_connection_id: order_by
+  destination_port_id: order_by
+  destination_universal_chain_id: order_by
+  instruction: order_by
+  instruction_hash: order_by
+  instruction_index: order_by
+  instruction_path: order_by
+  instruction_type: order_by
+  opcode: order_by
+  operand: order_by
+  packet_ack_block_hash: order_by
+  packet_ack_height: order_by
+  packet_ack_maker: order_by
+  packet_ack_timestamp: order_by
+  packet_ack_transaction_hash: order_by
+  packet_hash: order_by
+  packet_recv_block_hash: order_by
+  packet_recv_height: order_by
+  packet_recv_maker: order_by
+  packet_recv_maker_msg: order_by
+  packet_recv_timestamp: order_by
+  packet_recv_transaction_hash: order_by
+  packet_send_block_hash: order_by
+  packet_send_height: order_by
+  packet_send_timestamp: order_by
+  packet_send_transaction_hash: order_by
+  packet_timeout_block_hash: order_by
+  packet_timeout_height: order_by
+  packet_timeout_maker: order_by
+  packet_timeout_timestamp: order_by
+  packet_timeout_transaction_hash: order_by
+  path: order_by
+  salt: order_by
+  sort_order: order_by
+  source_chain: v2_chains_view_order_by
+  source_channel_id: order_by
+  source_client_id: order_by
+  source_connection_id: order_by
+  source_port_id: order_by
+  source_universal_chain_id: order_by
+  status: order_by
+  success: order_by
+  timeout_height: order_by
+  timeout_timestamp: order_by
+  version: order_by
+  write_ack_block_hash: order_by
+  write_ack_height: order_by
+  write_ack_timestamp: order_by
+  write_ack_transaction_hash: order_by
+}
+
+"""
+select columns of table "v2.instruction_type"
+"""
+enum v2_instruction_type_select_column {
+  """column name"""
+  acknowledgement
+
+  """column name"""
+  channel_version
+
+  """column name"""
+  data
+
+  """column name"""
+  decoded
+
+  """column name"""
+  decoded_flattened
+
+  """column name"""
+  destination_chain_id
+
+  """column name"""
+  destination_channel_id
+
+  """column name"""
+  destination_client_id
+
+  """column name"""
+  destination_connection_id
+
+  """column name"""
+  destination_port_id
+
+  """column name"""
+  destination_universal_chain_id
+
+  """column name"""
+  instruction
+
+  """column name"""
+  instruction_hash
+
+  """column name"""
+  instruction_index
+
+  """column name"""
+  instruction_path
+
+  """column name"""
+  instruction_type
+
+  """column name"""
+  opcode
+
+  """column name"""
+  operand
+
+  """column name"""
+  packet_ack_block_hash
+
+  """column name"""
+  packet_ack_height
+
+  """column name"""
+  packet_ack_maker
+
+  """column name"""
+  packet_ack_timestamp
+
+  """column name"""
+  packet_ack_transaction_hash
+
+  """column name"""
+  packet_hash
+
+  """column name"""
+  packet_recv_block_hash
+
+  """column name"""
+  packet_recv_height
+
+  """column name"""
+  packet_recv_maker
+
+  """column name"""
+  packet_recv_maker_msg
+
+  """column name"""
+  packet_recv_timestamp
+
+  """column name"""
+  packet_recv_transaction_hash
+
+  """column name"""
+  packet_send_block_hash
+
+  """column name"""
+  packet_send_height
+
+  """column name"""
+  packet_send_timestamp
+
+  """column name"""
+  packet_send_transaction_hash
+
+  """column name"""
+  packet_timeout_block_hash
+
+  """column name"""
+  packet_timeout_height
+
+  """column name"""
+  packet_timeout_maker
+
+  """column name"""
+  packet_timeout_timestamp
+
+  """column name"""
+  packet_timeout_transaction_hash
+
+  """column name"""
+  path
+
+  """column name"""
+  salt
+
+  """column name"""
+  sort_order
+
+  """column name"""
+  source_channel_id
+
+  """column name"""
+  source_client_id
+
+  """column name"""
+  source_connection_id
+
+  """column name"""
+  source_port_id
+
+  """column name"""
+  source_universal_chain_id
+
+  """column name"""
+  status
+
+  """column name"""
+  success
+
+  """column name"""
+  timeout_height
+
+  """column name"""
+  timeout_timestamp
+
+  """column name"""
+  version
+
+  """column name"""
+  write_ack_block_hash
+
+  """column name"""
+  write_ack_height
+
+  """column name"""
+  write_ack_timestamp
+
+  """column name"""
+  write_ack_transaction_hash
+}
+
+input v2_instructions_args {
+  p_block_hash: String
+  p_comparison: String
+  p_limit: Int
+  p_multiplex_contract_address: String
+  p_multiplex_sender: String
+  p_network: String
+  p_packet_hash: String
+  p_sort_order: String
+  p_transaction_hash: String
+}
+
+"""
 columns and relationships of "v2.packet_type"
 """
 type v2_packet_type {
@@ -2716,7 +3303,9 @@ input v2_packets_args {
   p_block_hash: String
   p_comparison: String
   p_destination_universal_chain_id: String
+  p_exceeding_sla: String
   p_limit: Int
+  p_network: String
   p_packet_hash: String
   p_packet_send_timestamp: timestamptz
   p_sort_order: String
@@ -4091,6 +4680,7 @@ input v2_transfers_args {
   p_comparison: String
   p_destination_universal_chain_id: String
   p_limit: Int
+  p_network: String
   p_packet_hash: String
   p_sort_order: String
   p_source_universal_chain_id: String

--- a/app2/src/lib/components/SettingsModal.svelte
+++ b/app2/src/lib/components/SettingsModal.svelte
@@ -14,6 +14,7 @@ const { isOpen, onClose }: Props = $props()
 let tempPageLimit = $state(settingsStore.pageLimit)
 let tempShowQuoteTokens = $state(settingsStore.showQuoteTokens)
 let tempShowDeveloperChainDetails = $state(settingsStore.showDeveloperChainDetails)
+let tempMainnetOnly = $state(settingsStore.mainnetOnly)
 let tempShowZeroBalances = $state(uiStore.showZeroBalances)
 let tempShowDeveloperPages = $state(uiStore.showDeveloperPages)
 
@@ -21,6 +22,7 @@ function handleSave() {
   settingsStore.pageLimit = tempPageLimit
   settingsStore.showQuoteTokens = tempShowQuoteTokens
   settingsStore.showDeveloperChainDetails = tempShowDeveloperChainDetails
+  settingsStore.mainnetOnly = tempMainnetOnly
   uiStore.showZeroBalances = tempShowZeroBalances
   uiStore.showDeveloperPages = tempShowDeveloperPages
   onClose()
@@ -71,6 +73,17 @@ function handleSave() {
           class="form-checkbox"
         />
         <span class="text-sm font-medium">Show developer chain details</span>
+      </label>
+    </div>
+
+    <div class="space-y-2">
+      <label class="flex items-center space-x-2">
+        <input
+          type="checkbox"
+          bind:checked={tempMainnetOnly}
+          class="form-checkbox"
+        />
+        <span class="text-sm font-medium">Mainnet only (explorer)</span>
       </label>
     </div>
 

--- a/app2/src/lib/components/SettingsModal.svelte
+++ b/app2/src/lib/components/SettingsModal.svelte
@@ -3,6 +3,7 @@ import { settingsStore } from "$lib/stores/settings.svelte"
 import { uiStore } from "$lib/stores/ui.svelte"
 import Button from "./ui/Button.svelte"
 import Modal from "./ui/Modal.svelte"
+import Switch from "./ui/Switch.svelte"
 
 type Props = {
   isOpen: boolean
@@ -55,58 +56,43 @@ function handleSave() {
     </div>
 
     <div class="space-y-2">
-      <label class="flex items-center space-x-2">
-        <input
-          type="checkbox"
-          bind:checked={tempShowQuoteTokens}
-          class="form-checkbox"
-        />
-        <span class="text-sm font-medium">Show quote tokens</span>
-      </label>
+      <Switch 
+        checked={tempShowQuoteTokens}
+        label="Show quote tokens"
+        on:click={() => tempShowQuoteTokens = !tempShowQuoteTokens}
+      />
     </div>
 
     <div class="space-y-2">
-      <label class="flex items-center space-x-2">
-        <input
-          type="checkbox"
-          bind:checked={tempShowDeveloperChainDetails}
-          class="form-checkbox"
-        />
-        <span class="text-sm font-medium">Show developer chain details</span>
-      </label>
+      <Switch 
+        checked={tempShowDeveloperChainDetails}
+        label="Show developer chain details"
+        on:click={() => tempShowDeveloperChainDetails = !tempShowDeveloperChainDetails}
+      />
     </div>
 
     <div class="space-y-2">
-      <label class="flex items-center space-x-2">
-        <input
-          type="checkbox"
-          bind:checked={tempMainnetOnly}
-          class="form-checkbox"
-        />
-        <span class="text-sm font-medium">Mainnet only (explorer)</span>
-      </label>
+      <Switch 
+        checked={tempMainnetOnly}
+        label="Mainnet only (explorer)"
+        on:click={() => tempMainnetOnly = !tempMainnetOnly}
+      />
     </div>
 
     <div class="space-y-2">
-      <label class="flex items-center space-x-2">
-        <input
-          type="checkbox"
-          bind:checked={tempShowZeroBalances}
-          class="form-checkbox"
-        />
-        <span class="text-sm font-medium">Show zero balances</span>
-      </label>
+      <Switch 
+        checked={tempShowZeroBalances}
+        label="Show zero balances"
+        on:click={() => tempShowZeroBalances = !tempShowZeroBalances}
+      />
     </div>
 
     <div class="space-y-2">
-      <label class="flex items-center space-x-2">
-        <input
-          type="checkbox"
-          bind:checked={tempShowDeveloperPages}
-          class="form-checkbox"
-        />
-        <span class="text-sm font-medium">Show developer pages</span>
-      </label>
+      <Switch 
+        checked={tempShowDeveloperPages}
+        label="Show developer pages"
+        on:click={() => tempShowDeveloperPages = !tempShowDeveloperPages}
+      />
     </div>
 
     <div class="flex justify-start gap-2 pt-4">

--- a/app2/src/lib/components/SettingsModal.svelte
+++ b/app2/src/lib/components/SettingsModal.svelte
@@ -59,7 +59,7 @@ function handleSave() {
       <Switch 
         checked={tempShowQuoteTokens}
         label="Show quote tokens"
-        on:click={() => tempShowQuoteTokens = !tempShowQuoteTokens}
+        on:change={(e) => tempShowQuoteTokens = e.detail}
       />
     </div>
 
@@ -67,7 +67,7 @@ function handleSave() {
       <Switch 
         checked={tempShowDeveloperChainDetails}
         label="Show developer chain details"
-        on:click={() => tempShowDeveloperChainDetails = !tempShowDeveloperChainDetails}
+        on:change={(e) => tempShowDeveloperChainDetails = e.detail}
       />
     </div>
 
@@ -75,7 +75,7 @@ function handleSave() {
       <Switch 
         checked={tempMainnetOnly}
         label="Mainnet only (explorer)"
-        on:click={() => tempMainnetOnly = !tempMainnetOnly}
+        on:change={(e) => tempMainnetOnly = e.detail}
       />
     </div>
 
@@ -83,7 +83,7 @@ function handleSave() {
       <Switch 
         checked={tempShowZeroBalances}
         label="Show zero balances"
-        on:click={() => tempShowZeroBalances = !tempShowZeroBalances}
+        on:change={(e) => tempShowZeroBalances = e.detail}
       />
     </div>
 
@@ -91,7 +91,7 @@ function handleSave() {
       <Switch 
         checked={tempShowDeveloperPages}
         label="Show developer pages"
-        on:click={() => tempShowDeveloperPages = !tempShowDeveloperPages}
+        on:change={(e) => tempShowDeveloperPages = e.detail}
       />
     </div>
 

--- a/app2/src/lib/components/SettingsModal.svelte
+++ b/app2/src/lib/components/SettingsModal.svelte
@@ -56,42 +56,42 @@ function handleSave() {
     </div>
 
     <div class="space-y-2">
-      <Switch 
+      <Switch
         checked={tempShowQuoteTokens}
         label="Show quote tokens"
-        on:change={(e) => tempShowQuoteTokens = e.detail}
+        change={(value) => tempShowQuoteTokens = value}
       />
     </div>
 
     <div class="space-y-2">
-      <Switch 
+      <Switch
         checked={tempShowDeveloperChainDetails}
         label="Show developer chain details"
-        on:change={(e) => tempShowDeveloperChainDetails = e.detail}
+        change={(value) => tempShowDeveloperChainDetails = value}
       />
     </div>
 
     <div class="space-y-2">
-      <Switch 
+      <Switch
         checked={tempMainnetOnly}
         label="Mainnet only (explorer)"
-        on:change={(e) => tempMainnetOnly = e.detail}
+        change={(value) => tempMainnetOnly = value}
       />
     </div>
 
     <div class="space-y-2">
-      <Switch 
+      <Switch
         checked={tempShowZeroBalances}
         label="Show zero balances"
-        on:change={(e) => tempShowZeroBalances = e.detail}
+        change={(value) => tempShowZeroBalances = value}
       />
     </div>
 
     <div class="space-y-2">
-      <Switch 
+      <Switch
         checked={tempShowDeveloperPages}
         label="Show developer pages"
-        on:change={(e) => tempShowDeveloperPages = e.detail}
+        change={(value) => tempShowDeveloperPages = value}
       />
     </div>
 

--- a/app2/src/lib/components/ui/Switch.svelte
+++ b/app2/src/lib/components/ui/Switch.svelte
@@ -1,0 +1,75 @@
+<script lang="ts">
+import { createEventDispatcher } from 'svelte';
+
+/**
+ * A toggle switch component based on Bits UI design
+ */
+interface Props {
+  checked: boolean
+  disabled?: boolean
+  name?: string
+  required?: boolean
+  value?: string
+  label?: string
+  class?: string
+}
+
+const dispatch = createEventDispatcher<{
+  click: boolean;
+}>();
+
+const {
+  checked = false,
+  disabled = false,
+  name = undefined,
+  required = false,
+  value = undefined,
+  label = undefined,
+  class: className = "",
+} = $props<Props>();
+
+let inputElement: HTMLInputElement;
+
+// Create a reactive variable for the checked state
+let isChecked = $state(checked);
+
+// Update internal state when checked prop changes
+$effect(() => {
+  isChecked = checked;
+});
+
+function toggle() {
+  if (disabled) return;
+  
+  const newValue = !isChecked;
+  isChecked = newValue;
+  
+  // Dispatch the click event with the new value
+  dispatch('click', newValue);
+}
+
+// Allow for custom styling while providing defaults
+const switchClass = `relative inline-flex h-5 w-9 shrink-0 cursor-pointer items-center rounded-full border-2 border-transparent transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-zinc-400 focus-visible:ring-offset-2 focus-visible:ring-offset-zinc-950 disabled:cursor-not-allowed disabled:opacity-50 data-[state=checked]:bg-accent data-[state=unchecked]:bg-zinc-700 ${className}`;
+
+const thumbClass = "pointer-events-none block h-4 w-4 rounded-full bg-white shadow-lg ring-0 transition-transform data-[state=checked]:translate-x-4 data-[state=unchecked]:translate-x-0";
+</script>
+
+<label class="flex items-center space-x-2" class:opacity-60={disabled}>
+  <button
+    type="button"
+    role="switch"
+    aria-checked={isChecked}
+    data-state={isChecked ? "checked" : "unchecked"}
+    class={switchClass}
+    {disabled}
+    on:click|preventDefault={toggle}
+  >
+    <span
+      class={thumbClass}
+      data-state={isChecked ? "checked" : "unchecked"}
+    ></span>
+  </button>
+  {#if label}
+    <span class="text-sm cursor-pointer" on:click={toggle}>{label}</span>
+  {/if}
+</label>

--- a/app2/src/lib/components/ui/Switch.svelte
+++ b/app2/src/lib/components/ui/Switch.svelte
@@ -1,60 +1,68 @@
 <script lang="ts">
-import { createEventDispatcher } from 'svelte';
+import { createEventDispatcher } from "svelte"
+import type { HTMLButtonAttributes } from "svelte/elements"
 
 /**
  * A toggle switch component based on Bits UI design
  */
-interface Props {
+type Props = HTMLButtonAttributes & {
   checked: boolean
   disabled?: boolean
   name?: string
-  required?: boolean
   value?: string
   label?: string
   class?: string
 }
 
 const dispatch = createEventDispatcher<{
-  click: boolean;
-}>();
+  change: boolean
+}>()
 
 const {
   checked = false,
   disabled = false,
   name = undefined,
-  required = false,
   value = undefined,
   label = undefined,
   class: className = "",
-} = $props<Props>();
-
-let inputElement: HTMLInputElement;
+  ...rest
+}: Props = $props()
 
 // Create a reactive variable for the checked state
-let isChecked = $state(checked);
+let isChecked = $state(checked)
 
 // Update internal state when checked prop changes
 $effect(() => {
-  isChecked = checked;
-});
+  isChecked = checked
+})
 
-function toggle() {
-  if (disabled) return;
-  
-  const newValue = !isChecked;
-  isChecked = newValue;
-  
-  // Dispatch the click event with the new value
-  dispatch('click', newValue);
+function handleClick(event: Event) {
+  // Prevent default behavior
+  event.preventDefault()
+
+  if (disabled) {
+    return
+  }
+
+  const newValue = !isChecked
+  isChecked = newValue
+
+  // Dispatch the change event with the new value
+  dispatch("change", newValue)
 }
 
 // Allow for custom styling while providing defaults
-const switchClass = `relative inline-flex h-5 w-9 shrink-0 cursor-pointer items-center rounded-full border-2 border-transparent transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-zinc-400 focus-visible:ring-offset-2 focus-visible:ring-offset-zinc-950 disabled:cursor-not-allowed disabled:opacity-50 data-[state=checked]:bg-accent data-[state=unchecked]:bg-zinc-700 ${className}`;
+const switchClass =
+  `relative inline-flex h-5 w-9 shrink-0 cursor-pointer items-center rounded-full border-2 border-transparent transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-zinc-400 focus-visible:ring-offset-2 focus-visible:ring-offset-zinc-950 disabled:cursor-not-allowed disabled:opacity-50 data-[state=checked]:bg-accent data-[state=unchecked]:bg-zinc-700 ${className}`
 
-const thumbClass = "pointer-events-none block h-4 w-4 rounded-full bg-white shadow-lg ring-0 transition-transform data-[state=checked]:translate-x-4 data-[state=unchecked]:translate-x-0";
+const thumbClass =
+  "pointer-events-none block h-4 w-4 rounded-full bg-white shadow-lg ring-0 transition-transform data-[state=checked]:translate-x-4 data-[state=unchecked]:translate-x-0"
 </script>
 
-<label class="flex items-center space-x-2" class:opacity-60={disabled}>
+<label
+  class="flex items-center space-x-2"
+  class:opacity-60={disabled}
+>
   <button
     type="button"
     role="switch"
@@ -62,7 +70,8 @@ const thumbClass = "pointer-events-none block h-4 w-4 rounded-full bg-white shad
     data-state={isChecked ? "checked" : "unchecked"}
     class={switchClass}
     {disabled}
-    on:click|preventDefault={toggle}
+    onclick={handleClick}
+    {...rest}
   >
     <span
       class={thumbClass}
@@ -70,6 +79,11 @@ const thumbClass = "pointer-events-none block h-4 w-4 rounded-full bg-white shad
     ></span>
   </button>
   {#if label}
-    <span class="text-sm cursor-pointer" on:click={toggle}>{label}</span>
+    <!-- svelte-ignore a11y_click_events_have_key_events -->
+    <!-- svelte-ignore a11y_no_static_element_interactions -->
+    <span
+      class="text-sm cursor-pointer"
+      onclick={handleClick}
+    >{label}</span>
   {/if}
 </label>

--- a/app2/src/lib/components/ui/Switch.svelte
+++ b/app2/src/lib/components/ui/Switch.svelte
@@ -1,5 +1,4 @@
 <script lang="ts">
-import { createEventDispatcher } from "svelte"
 import type { HTMLButtonAttributes } from "svelte/elements"
 
 /**
@@ -12,11 +11,8 @@ type Props = HTMLButtonAttributes & {
   value?: string
   label?: string
   class?: string
+  change: (value: boolean) => void
 }
-
-const dispatch = createEventDispatcher<{
-  change: boolean
-}>()
 
 const {
   checked = false,
@@ -25,6 +21,7 @@ const {
   value = undefined,
   label = undefined,
   class: className = "",
+  change,
   ...rest
 }: Props = $props()
 
@@ -37,7 +34,6 @@ $effect(() => {
 })
 
 function handleClick(event: Event) {
-  // Prevent default behavior
   event.preventDefault()
 
   if (disabled) {
@@ -47,8 +43,7 @@ function handleClick(event: Event) {
   const newValue = !isChecked
   isChecked = newValue
 
-  // Dispatch the change event with the new value
-  dispatch("change", newValue)
+  change(newValue)
 }
 
 // Allow for custom styling while providing defaults

--- a/app2/src/lib/queries/packet-list.svelte.ts
+++ b/app2/src/lib/queries/packet-list.svelte.ts
@@ -8,14 +8,15 @@ import { graphql } from "gql.tada"
 
 export const LIMIT = 10
 
-export let packetListLatestQuery = (limit = LIMIT) =>
+export let packetListLatestQuery = (limit = LIMIT, mainnetOnly = false) =>
   createQueryGraphql({
     schema: Schema.Struct({ v2_packets: PacketList }),
     document: graphql(
       `
-    query PacketsLatest($limit: Int!) @cached(ttl: 1) {
+    query PacketsLatest($limit: Int!, $network: String) @cached(ttl: 1) {
       v2_packets(args: {
-        p_limit: $limit
+        p_limit: $limit,
+        p_network: $network
       }) {
       ...PacketListItem
       }
@@ -23,7 +24,10 @@ export let packetListLatestQuery = (limit = LIMIT) =>
   `,
       [packetListItemFragment],
     ),
-    variables: { limit },
+    variables: { 
+      limit,
+      network: mainnetOnly ? "mainnet" : null
+    },
     refetchInterval: "1 second",
     writeData: data => {
       packetList.data = data.pipe(Option.map(d => d.v2_packets))
@@ -33,17 +37,18 @@ export let packetListLatestQuery = (limit = LIMIT) =>
     },
   })
 
-export let packetListPageLtQuery = (page: typeof SortOrder.Type, limit = LIMIT) =>
+export let packetListPageLtQuery = (page: typeof SortOrder.Type, limit = LIMIT, mainnetOnly = false) =>
   createQueryGraphql({
     schema: Schema.Struct({ v2_packets: PacketList }),
     document: graphql(
       `
-    query PacketsPage($page: String!, $limit: Int!)
+    query PacketsPage($page: String!, $limit: Int!, $network: String)
     @cached(ttl: 30) {
       v2_packets(args: {
         p_limit: $limit,
-        p_sort_order: $page
-        p_comparison: "lt"
+        p_sort_order: $page,
+        p_comparison: "lt",
+        p_network: $network
       }) {
       ...PacketListItem
       }
@@ -51,7 +56,11 @@ export let packetListPageLtQuery = (page: typeof SortOrder.Type, limit = LIMIT) 
   `,
       [packetListItemFragment],
     ),
-    variables: { page, limit },
+    variables: { 
+      page, 
+      limit,
+      network: mainnetOnly ? "mainnet" : null
+    },
     refetchInterval: "30 seconds",
     writeData: data => {
       packetList.data = data.pipe(Option.map(d => d.v2_packets))
@@ -61,16 +70,17 @@ export let packetListPageLtQuery = (page: typeof SortOrder.Type, limit = LIMIT) 
     },
   })
 
-export let packetListPageGtQuery = (page: typeof SortOrder.Type, limit = LIMIT) =>
+export let packetListPageGtQuery = (page: typeof SortOrder.Type, limit = LIMIT, mainnetOnly = false) =>
   createQueryGraphql({
     schema: Schema.Struct({ v2_packets: PacketList }),
     document: graphql(
       `
-    query PacketsPage($page: String!, $limit: Int!) @cached(ttl: 30) {
+    query PacketsPage($page: String!, $limit: Int!, $network: String) @cached(ttl: 30) {
       v2_packets(args: {
         p_limit: $limit,
         p_sort_order: $page,
-        p_comparison: "gt"
+        p_comparison: "gt",
+        p_network: $network
       }) {
       ...PacketListItem
       }
@@ -78,7 +88,11 @@ export let packetListPageGtQuery = (page: typeof SortOrder.Type, limit = LIMIT) 
   `,
       [packetListItemFragment],
     ),
-    variables: { page, limit },
+    variables: { 
+      page, 
+      limit,
+      network: mainnetOnly ? "mainnet" : null
+    },
     refetchInterval: "30 seconds",
     writeData: data => {
       packetList.data = data.pipe(Option.map(d => d.v2_packets.toReversed()))

--- a/app2/src/lib/queries/transfer-list.svelte.ts
+++ b/app2/src/lib/queries/transfer-list.svelte.ts
@@ -8,14 +8,15 @@ import { graphql } from "gql.tada"
 
 export const LIMIT = 10
 
-export let transferListLatestQuery = (limit = LIMIT) =>
+export let transferListLatestQuery = (limit = LIMIT, mainnetOnly = false) =>
   createQueryGraphql({
     schema: Schema.Struct({ v2_transfers: TransferList }),
     document: graphql(
       `
-    query TransferListLatest($limit: Int!) @cached(ttl: 1) {
+    query TransferListLatest($limit: Int!, $network: String) @cached(ttl: 1) {
       v2_transfers(args: {
-        p_limit: $limit
+        p_limit: $limit,
+        p_network: $network
       }) {
       ...TransferListItem
       }
@@ -23,7 +24,10 @@ export let transferListLatestQuery = (limit = LIMIT) =>
   `,
       [transferListItemFragment],
     ),
-    variables: { limit },
+    variables: {
+      limit,
+      network: mainnetOnly ? "mainnet" : null,
+    },
     refetchInterval: "1 second",
     writeData: data => {
       transferList.data = data.pipe(Option.map(d => d.v2_transfers))
@@ -33,16 +37,21 @@ export let transferListLatestQuery = (limit = LIMIT) =>
     },
   })
 
-export let transferListPageLtQuery = (page: typeof SortOrder.Type, limit = LIMIT) =>
+export let transferListPageLtQuery = (
+  page: typeof SortOrder.Type,
+  limit = LIMIT,
+  mainnetOnly = false,
+) =>
   createQueryGraphql({
     schema: Schema.Struct({ v2_transfers: TransferList }),
     document: graphql(
       `
-    query TransferListPage($page: String!, $limit: Int!)
+    query TransferListPage($page: String!, $limit: Int!, $network: String)
     @cached(ttl: 30) {
       v2_transfers(args: {
         p_limit: $limit,
-        p_sort_order: $page
+        p_sort_order: $page,
+        p_network: $network
       }) {
       ...TransferListItem
       }
@@ -50,7 +59,11 @@ export let transferListPageLtQuery = (page: typeof SortOrder.Type, limit = LIMIT
   `,
       [transferListItemFragment],
     ),
-    variables: { page, limit },
+    variables: {
+      page,
+      limit,
+      network: mainnetOnly ? "mainnet" : null,
+    },
     refetchInterval: "30 seconds",
     writeData: data => {
       transferList.data = data.pipe(Option.map(d => d.v2_transfers))
@@ -60,16 +73,21 @@ export let transferListPageLtQuery = (page: typeof SortOrder.Type, limit = LIMIT
     },
   })
 
-export let transferListPageGtQuery = (page: typeof SortOrder.Type, limit = LIMIT) =>
+export let transferListPageGtQuery = (
+  page: typeof SortOrder.Type,
+  limit = LIMIT,
+  mainnetOnly = false,
+) =>
   createQueryGraphql({
     schema: Schema.Struct({ v2_transfers: TransferList }),
     document: graphql(
       `
-    query TransferListPage($page: String!, $limit: Int!) @cached(ttl: 30) {
+    query TransferListPage($page: String!, $limit: Int!, $network: String) @cached(ttl: 30) {
       v2_transfers(args: {
         p_limit: $limit,
         p_sort_order: $page,
-        p_comparison: "gt"
+        p_comparison: "gt",
+        p_network: $network
       }) {
       ...TransferListItem
       }
@@ -77,7 +95,11 @@ export let transferListPageGtQuery = (page: typeof SortOrder.Type, limit = LIMIT
   `,
       [transferListItemFragment],
     ),
-    variables: { page, limit },
+    variables: {
+      page,
+      limit,
+      network: mainnetOnly ? "mainnet" : null,
+    },
     refetchInterval: "30 seconds",
     writeData: data => {
       transferList.data = data.pipe(Option.map(d => d.v2_transfers.toReversed()))

--- a/app2/src/lib/stores/settings.svelte.ts
+++ b/app2/src/lib/stores/settings.svelte.ts
@@ -1,8 +1,30 @@
+// Careful, this is untyped. Ensure the overrides actually exist in SettingsStore
+const editionDefaults: Record<string, Record<string, any>> = {
+  btc: {
+    mainnetOnly: true,
+  },
+  app: {
+    mainnetOnly: false,
+  },
+}
+
 class SettingsStore {
   pageLimit: number = $state(12)
   showQuoteTokens: boolean = $state(false)
   showDeveloperChainDetails: boolean = $state(false)
   mainnetOnly: boolean = $state(false)
+
+  setEditionDefaults(edition: string) {
+    if (editionDefaults[edition]) {
+      const defaults = editionDefaults[edition]
+      Object.keys(defaults).forEach(key => {
+        if (key in this) {
+          // @ts-ignore: Dynamic property assignment
+          this[key] = defaults[key]
+        }
+      })
+    }
+  }
 }
 
 export const settingsStore = new SettingsStore()

--- a/app2/src/lib/stores/settings.svelte.ts
+++ b/app2/src/lib/stores/settings.svelte.ts
@@ -2,6 +2,7 @@ class SettingsStore {
   pageLimit: number = $state(12)
   showQuoteTokens: boolean = $state(false)
   showDeveloperChainDetails: boolean = $state(false)
+  mainnetOnly: boolean = $state(false)
 }
 
 export const settingsStore = new SettingsStore()

--- a/app2/src/routes/+layout.svelte
+++ b/app2/src/routes/+layout.svelte
@@ -36,15 +36,15 @@ onMount(() => {
   runFork$(chainsQuery(ENV()))
   runFork$(channelsQuery())
 
-  keyboardShortcuts.addShortcut(["cmd", "option", "shift", "keya"], () => {
+  keyboardShortcuts.addShortcut(["ctrl", "option", "shift", "keya"], () => {
     uiStore.overrideEdition = "app"
   })
 
-  keyboardShortcuts.addShortcut(["cmd", "option", "shift", "keyb"], () => {
+  keyboardShortcuts.addShortcut(["ctrl", "option", "shift", "keyb"], () => {
     uiStore.overrideEdition = "btc"
   })
 
-  keyboardShortcuts.addShortcut(["cmd", "option", "shift", "keyf"], () => {
+  keyboardShortcuts.addShortcut(["ctrl", "option", "shift", "keyf"], () => {
     uiStore.filterWhitelist = !uiStore.filterWhitelist
   })
 })

--- a/app2/src/routes/+layout.svelte
+++ b/app2/src/routes/+layout.svelte
@@ -12,6 +12,7 @@ import { ENV, MAX_MOBILE_SIZE } from "$lib/constants"
 import { chainsQuery } from "$lib/queries/chains.svelte"
 import { channelsQuery } from "$lib/queries/channels.svelte.ts"
 import { runFork$, runPromise, runSync } from "$lib/runtime"
+import { settingsStore } from "$lib/stores/settings.svelte"
 import { keyboardShortcuts } from "$lib/stores/shortcuts.svelte"
 import { uiStore } from "$lib/stores/ui.svelte"
 import { wallets } from "$lib/stores/wallets.svelte"
@@ -30,7 +31,10 @@ interface Props {
 let { children, data }: Props = $props()
 
 onMount(() => {
+  // Apply all edition-specific default settings
   uiStore.edition = data.edition
+  settingsStore.setEditionDefaults(data.edition)
+
   interceptLogos()
   runExample()
   runFork$(chainsQuery(ENV()))
@@ -71,6 +75,12 @@ $effect(() => {
   document.documentElement.style.setProperty("--color-accent", uiStore.theme.accent)
   document.documentElement.style.setProperty("--color-primary", uiStore.theme.primary)
   document.documentElement.style.setProperty("--color-background", uiStore.theme.background)
+})
+
+// Update settings when edition changes
+$effect(() => {
+  const edition = uiStore.activeEdition
+  settingsStore.setEditionDefaults(edition)
 })
 </script>
 

--- a/app2/src/routes/explorer/transfers/+page.svelte
+++ b/app2/src/routes/explorer/transfers/+page.svelte
@@ -112,7 +112,7 @@ const onNextPage = async () => {
       <Switch
         checked={settingsStore.mainnetOnly}
         label="Mainnet Only"
-        on:change={(e) => {settingsStore.mainnetOnly = e.detail; initializeQuery()}}
+        change={(value) => {settingsStore.mainnetOnly = value; initializeQuery()}}
       />
     </div>
   </div>

--- a/app2/src/routes/explorer/transfers/+page.svelte
+++ b/app2/src/routes/explorer/transfers/+page.svelte
@@ -81,19 +81,6 @@ const onNextPage = async () => {
 </script>
 
 <Sections>
-  <div class="flex justify-between items-center mb-2">
-    <div class="flex items-center space-x-2">
-      <label class="flex items-center gap-2 text-sm">
-        <input
-          type="checkbox"
-          bind:checked={settingsStore.mainnetOnly}
-          class="form-checkbox"
-        />
-        <span>Mainnet Only</span>
-      </label>
-    </div>
-  </div>
-
   <Card class="overflow-auto" divided>
     {#if Option.isSome(transferList.error)}
       <ErrorComponent error={transferList.error.value}/>
@@ -119,4 +106,16 @@ const onNextPage = async () => {
     {onPrevPage}
     {onNextPage}
   />
+  <div class="flex justify-between items-center mb-2">
+    <div class="flex items-center space-x-2">
+      <label class="flex items-center gap-2 text-sm">
+        <input
+          type="checkbox"
+          bind:checked={settingsStore.mainnetOnly}
+          class="form-checkbox"
+        />
+        <span>Mainnet Only</span>
+      </label>
+    </div>
+  </div>
 </Sections>

--- a/app2/src/routes/explorer/transfers/+page.svelte
+++ b/app2/src/routes/explorer/transfers/+page.svelte
@@ -20,31 +20,30 @@ import TransferListItemComponent from "$lib/components/model/TransferListItemCom
 import TransferListItemComponentSkeleton from "$lib/components/model/TransferListItemComponentSkeleton.svelte"
 import Switch from "$lib/components/ui/Switch.svelte"
 
-onMount(() => {
+const initializeQuery = async () => {
   const pageParam = page.url.searchParams.get("page")
+  let effect: Effect.Effect<any>
 
-  const initializeQuery = async () => {
-    let effect: Effect.Effect<any>
-
-    if (pageParam) {
-      if (pageParam.startsWith("-")) {
-        // Greater-than query (prev page)
-        const sortOrder = pageParam.substring(1)
-        // @ts-ignore sorOrder is not strictly a SortOrder, but this is desired behavior
-        effect = transferListPageGtQuery(sortOrder, settingsStore.pageLimit, settingsStore.mainnetOnly)
-      } else {
-        // Less-than query (next page)
-        // @ts-ignore pageParam is not strictly a SortOrder, but this is desired behavior
-        effect = transferListPageLtQuery(pageParam, settingsStore.pageLimit, settingsStore.mainnetOnly)
-      }
+  if (pageParam) {
+    if (pageParam.startsWith("-")) {
+      // Greater-than query (prev page)
+      const sortOrder = pageParam.substring(1)
+      // @ts-ignore sorOrder is not strictly a SortOrder, but this is desired behavior
+      effect = transferListPageGtQuery(sortOrder, settingsStore.pageLimit, settingsStore.mainnetOnly)
     } else {
-      // No page param, load latest
-      effect = transferListLatestQuery(settingsStore.pageLimit, settingsStore.mainnetOnly)
+      // Less-than query (next page)
+      // @ts-ignore pageParam is not strictly a SortOrder, but this is desired behavior
+      effect = transferListPageLtQuery(pageParam, settingsStore.pageLimit, settingsStore.mainnetOnly)
     }
-
-    await transferList.runEffect(effect)
+  } else {
+    // No page param, load latest
+    effect = transferListLatestQuery(settingsStore.pageLimit, settingsStore.mainnetOnly)
   }
 
+  await transferList.runEffect(effect)
+}
+
+onMount(() => {
   initializeQuery()
 
   return () => {
@@ -109,11 +108,11 @@ const onNextPage = async () => {
       {onPrevPage}
       {onNextPage}
     />
-    <div class="flex items-center space-x-2">
+    <div class="flex items-center gap-2">
       <Switch
         checked={settingsStore.mainnetOnly}
         label="Mainnet Only"
-        on:click={() => settingsStore.mainnetOnly = !settingsStore.mainnetOnly}
+        on:change={(e) => {settingsStore.mainnetOnly = e.detail; initializeQuery()}}
       />
     </div>
   </div>

--- a/app2/src/routes/explorer/transfers/+page.svelte
+++ b/app2/src/routes/explorer/transfers/+page.svelte
@@ -18,6 +18,7 @@ import { goto } from "$app/navigation"
 import { settingsStore } from "$lib/stores/settings.svelte"
 import TransferListItemComponent from "$lib/components/model/TransferListItemComponent.svelte"
 import TransferListItemComponentSkeleton from "$lib/components/model/TransferListItemComponentSkeleton.svelte"
+import Switch from "$lib/components/ui/Switch.svelte"
 
 onMount(() => {
   const pageParam = page.url.searchParams.get("page")
@@ -81,6 +82,7 @@ const onNextPage = async () => {
 </script>
 
 <Sections>
+
   <Card class="overflow-auto" divided>
     {#if Option.isSome(transferList.error)}
       <ErrorComponent error={transferList.error.value}/>
@@ -100,22 +102,19 @@ const onNextPage = async () => {
       {/each}
     {/if}
   </Card>
-  <TransferListPagination 
-    data={transferList.data}
-    {onLive}
-    {onPrevPage}
-    {onNextPage}
-  />
-  <div class="flex justify-between items-center mb-2">
+  <div class="flex flex-col sm:flex-row sm:items-center gap-4">
+    <TransferListPagination 
+      data={transferList.data}
+      {onLive}
+      {onPrevPage}
+      {onNextPage}
+    />
     <div class="flex items-center space-x-2">
-      <label class="flex items-center gap-2 text-sm">
-        <input
-          type="checkbox"
-          bind:checked={settingsStore.mainnetOnly}
-          class="form-checkbox"
-        />
-        <span>Mainnet Only</span>
-      </label>
+      <Switch
+        checked={settingsStore.mainnetOnly}
+        label="Mainnet Only"
+        on:click={() => settingsStore.mainnetOnly = !settingsStore.mainnetOnly}
+      />
     </div>
   </div>
 </Sections>

--- a/app2/src/routes/explorer/transfers/+page.svelte
+++ b/app2/src/routes/explorer/transfers/+page.svelte
@@ -30,15 +30,15 @@ onMount(() => {
         // Greater-than query (prev page)
         const sortOrder = pageParam.substring(1)
         // @ts-ignore sorOrder is not strictly a SortOrder, but this is desired behavior
-        effect = transferListPageGtQuery(sortOrder, settingsStore.pageLimit)
+        effect = transferListPageGtQuery(sortOrder, settingsStore.pageLimit, settingsStore.mainnetOnly)
       } else {
         // Less-than query (next page)
         // @ts-ignore pageParam is not strictly a SortOrder, but this is desired behavior
-        effect = transferListPageLtQuery(pageParam, settingsStore.pageLimit)
+        effect = transferListPageLtQuery(pageParam, settingsStore.pageLimit, settingsStore.mainnetOnly)
       }
     } else {
       // No page param, load latest
-      effect = transferListLatestQuery(settingsStore.pageLimit)
+      effect = transferListLatestQuery(settingsStore.pageLimit, settingsStore.mainnetOnly)
     }
 
     await transferList.runEffect(effect)
@@ -53,7 +53,7 @@ onMount(() => {
 
 const onLive = async () => {
   if (Option.isSome(transferList.data)) {
-    await transferList.runEffect(transferListLatestQuery(settingsStore.pageLimit))
+    await transferList.runEffect(transferListLatestQuery(settingsStore.pageLimit, settingsStore.mainnetOnly))
     // Remove page param from URL
     goto("?", { replaceState: true })
   }
@@ -63,7 +63,7 @@ const onPrevPage = async () => {
   if (Option.isSome(transferList.data)) {
     let firstSortOrder = transferList.data.value.at(0)?.sort_order
     if (!firstSortOrder) return
-    await transferList.runEffect(transferListPageGtQuery(firstSortOrder, settingsStore.pageLimit))
+    await transferList.runEffect(transferListPageGtQuery(firstSortOrder, settingsStore.pageLimit, settingsStore.mainnetOnly))
     // Update URL with the new page param, prefixed with '-' for greater-than queries
     goto(`?page=-${firstSortOrder}`, { replaceState: true })
   }
@@ -73,7 +73,7 @@ const onNextPage = async () => {
   if (Option.isSome(transferList.data)) {
     let lastSortOrder = transferList.data.value.at(-1)?.sort_order
     if (!lastSortOrder) return
-    await transferList.runEffect(transferListPageLtQuery(lastSortOrder, settingsStore.pageLimit))
+    await transferList.runEffect(transferListPageLtQuery(lastSortOrder, settingsStore.pageLimit, settingsStore.mainnetOnly))
     // Update URL with the new page param (no prefix for less-than queries)
     goto(`?page=${lastSortOrder}`, { replaceState: true })
   }
@@ -81,6 +81,19 @@ const onNextPage = async () => {
 </script>
 
 <Sections>
+  <div class="flex justify-between items-center mb-2">
+    <div class="flex items-center space-x-2">
+      <label class="flex items-center gap-2 text-sm">
+        <input
+          type="checkbox"
+          bind:checked={settingsStore.mainnetOnly}
+          class="form-checkbox"
+        />
+        <span>Mainnet Only</span>
+      </label>
+    </div>
+  </div>
+
   <Card class="overflow-auto" divided>
     {#if Option.isSome(transferList.error)}
       <ErrorComponent error={transferList.error.value}/>


### PR DESCRIPTION
- **chore(app2): update graphql schema**
- **feat(app2): add option to only query mainnet transfers**
- **fix(app2): use shortcuts that also exist on linux**
- **fix(app2): better edition defaults system**
- **feat(app2): introduce switch component**
- **fix(app2): switch events and reactivity**
- **refactor(app2): use svelte5 event callbacks**
- **feat(app2): mainnet only for packet explorer**
