### PR TITLE
feat(zkgm): introduce stake/unstake/withdrawStake/withdrawRewards tests

### DIFF
--- a/evm/contracts/apps/ucs/03-zkgm/Lib.sol
+++ b/evm/contracts/apps/ucs/03-zkgm/Lib.sol
@@ -273,6 +273,12 @@ library ZkgmLib {
         );
     }
 
+    function encodeWithdrawStakeAck(
+        WithdrawStakeAck memory withdrawStakeAck
+    ) internal pure returns (bytes memory) {
+        return abi.encode(withdrawStakeAck.amount);
+    }
+
     function encodeWithdrawRewards(
         WithdrawRewards memory withdrawRewards
     ) internal pure returns (bytes memory) {

--- a/evm/contracts/apps/ucs/03-zkgm/Store.sol
+++ b/evm/contracts/apps/ucs/03-zkgm/Store.sol
@@ -84,6 +84,12 @@ abstract contract UCS03ZkgmStore is AccessManagedUpgradeable, IZkgmStore {
         return (ZkgmERC20(wrappedGovernanceToken), governanceToken);
     }
 
+    function getGovernanceToken(
+        uint32 channelId
+    ) public view returns (ZkgmERC20, GovernanceToken memory) {
+        return _getGovernanceToken(channelId);
+    }
+
     function _predictStakeManagerAddress() internal view returns (ZkgmERC721) {
         return ZkgmERC721(
             CREATE3.predictDeterministicAddress(STAKE_NFT_MANAGER_SALT)


### PR DESCRIPTION
Introduce staking tests

 - test_verify_stake_ok - Valid staking with governance token transfer and NFT minting                                                                                                
 - test_verify_unstake_ok - Valid unstaking from STAKED state with NFT escrow                                                                                                         
 - test_verify_withdrawStake_ok - Valid withdrawal after unstaking completion time                                                                                                    
 - test_verify_withdrawRewards_ok - Valid reward withdrawal from STAKED position                                                                                                 
 - test_verify_stake_invalidGovernanceToken - Rejects wrong governance token                                                                                                          
 - test_verify_stake_invalidMetadataImage - Rejects mismatched metadata                                                                                                               
 - test_verify_stake_cannotBeForwarded - Prevents stake instruction forwarding                                                                                                        
 - test_verify_unstake_notStakable - Prevents unstaking from STAKING state                                                                                                            
 - test_verify_withdrawStake_notWithdrawable - Prevents premature withdrawal                                                                                                          
 - test_verify_withdrawRewards_notWithdrawable - Prevents reward withdrawal from non-STAKED                                                                                           
 - test_onAckPacket_stake_success/failure - Handles stake completion/refund                                                                                                           
 - test_onAckPacket_unstake_success - Sets UNSTAKING state with completion time                                                                                                       
 - test_onAckPacket_withdrawStake_success - Transfers tokens and handles rewards/slashing                                                                                             
 - test_onAckPacket_withdrawRewards_success - Mints rewards and returns NFT                                                                                                           
 - test_onTimeoutPacket_stake/unstake - Refunds tokens and returns NFTs on timeout                                                                                                    
 - test_registerGovernanceToken_ok/alreadySet - Channel governance token management                                                                                                   
 - test_staking_batch_ok - Multiple stake operations in single transaction                                                                                                            