### PR TITLE
chore(evm): authority/channel isolation tests

### DIFF
--- a/evm/tests/src/05-app/ZkgmAuthority.t.sol
+++ b/evm/tests/src/05-app/ZkgmAuthority.t.sol
@@ -1,0 +1,384 @@
+pragma solidity ^0.8.27;
+
+import "forge-std/Test.sol";
+import "./Zkgm.t.sol";
+
+contract ZkgmAuthorityTest is Test {
+    using LibString for *;
+
+    TestIBCHandler handler;
+    TestERC20 erc20;
+    ZkgmERC20 erc20Impl;
+    TestWETH weth;
+    TestZkgm zkgm;
+    Manager manager;
+
+    address authority;
+
+    function setUp() public {
+        authority = makeAddr("authority");
+
+        weth = new TestWETH();
+        erc20 = new TestERC20("Test", "T", 18);
+        handler = new TestIBCHandler();
+        erc20Impl = new ZkgmERC20();
+
+        vm.startPrank(authority);
+        manager = Manager(
+            address(
+                new ERC1967Proxy(
+                    address(new Manager()),
+                    abi.encodeCall(Manager.initialize, (authority))
+                )
+            )
+        );
+        vm.stopPrank();
+
+        ERC1967Proxy proxy = new ERC1967Proxy(
+            address(new TestZkgm(handler, weth, erc20Impl)),
+            abi.encodeCall(UCS03Zkgm.initialize, (address(manager)))
+        );
+        zkgm = TestZkgm(payable(address(proxy)));
+        zkgm.doCreateStakeNFTManager();
+
+        erc20.mint(address(this), type(uint128).max);
+        erc20.approve(address(zkgm), type(uint256).max);
+    }
+
+    // Test registerGovernanceToken function access control
+    function test_registerGovernanceToken_authorized(
+        uint32 channelId,
+        bytes memory unwrappedToken,
+        bytes32 metadataImage
+    ) public {
+        vm.assume(channelId > 0);
+        vm.assume(unwrappedToken.length > 0);
+        vm.assume(metadataImage != bytes32(0));
+
+        vm.prank(authority);
+        zkgm.registerGovernanceToken(
+            channelId,
+            GovernanceToken({
+                unwrappedToken: unwrappedToken,
+                metadataImage: metadataImage
+            })
+        );
+
+        (bytes memory storedToken, bytes32 storedImage) =
+            zkgm.channelGovernanceToken(channelId);
+        assertEq(
+            keccak256(storedToken),
+            keccak256(unwrappedToken),
+            "Unwrapped token not stored correctly"
+        );
+        assertEq(
+            storedImage, metadataImage, "Metadata image not stored correctly"
+        );
+    }
+
+    function test_registerGovernanceToken_unauthorized(
+        address nonAuthority,
+        uint32 channelId,
+        bytes memory unwrappedToken,
+        bytes32 metadataImage
+    ) public {
+        vm.assume(channelId > 0);
+        vm.assume(unwrappedToken.length > 0);
+        vm.assume(metadataImage != bytes32(0));
+        vm.assume(nonAuthority != authority);
+        vm.assume(nonAuthority != address(0));
+
+        vm.prank(nonAuthority);
+        vm.expectRevert(
+            abi.encodeWithSelector(
+                IAccessManaged.AccessManagedUnauthorized.selector, nonAuthority
+            )
+        );
+        zkgm.registerGovernanceToken(
+            channelId,
+            GovernanceToken({
+                unwrappedToken: unwrappedToken,
+                metadataImage: metadataImage
+            })
+        );
+    }
+
+    function test_registerGovernanceToken_alreadySet(
+        uint32 channelId,
+        bytes memory unwrappedToken1,
+        bytes memory unwrappedToken2,
+        bytes32 metadataImage1,
+        bytes32 metadataImage2
+    ) public {
+        vm.assume(channelId > 0);
+        vm.assume(unwrappedToken1.length > 0);
+        vm.assume(unwrappedToken2.length > 0);
+        vm.assume(keccak256(unwrappedToken1) != keccak256(unwrappedToken2));
+        vm.assume(metadataImage1 != bytes32(0));
+        vm.assume(metadataImage2 != bytes32(0));
+
+        vm.startPrank(authority);
+        zkgm.registerGovernanceToken(
+            channelId,
+            GovernanceToken({
+                unwrappedToken: unwrappedToken1,
+                metadataImage: metadataImage1
+            })
+        );
+
+        vm.expectRevert(ZkgmLib.ErrChannelGovernanceTokenAlreadySet.selector);
+        zkgm.registerGovernanceToken(
+            channelId,
+            GovernanceToken({
+                unwrappedToken: unwrappedToken2,
+                metadataImage: metadataImage2
+            })
+        );
+        vm.stopPrank();
+    }
+
+    // Test overwriteGovernanceToken function access control
+    function test_overwriteGovernanceToken_authorized(
+        uint32 channelId,
+        bytes memory unwrappedToken1,
+        bytes memory unwrappedToken2,
+        bytes32 metadataImage1,
+        bytes32 metadataImage2
+    ) public {
+        vm.assume(channelId > 0);
+        vm.assume(unwrappedToken1.length > 0);
+        vm.assume(unwrappedToken2.length > 0);
+        vm.assume(metadataImage1 != bytes32(0));
+        vm.assume(metadataImage2 != bytes32(0));
+
+        vm.startPrank(authority);
+        zkgm.registerGovernanceToken(
+            channelId,
+            GovernanceToken({
+                unwrappedToken: unwrappedToken1,
+                metadataImage: metadataImage1
+            })
+        );
+
+        zkgm.overwriteGovernanceToken(
+            channelId,
+            GovernanceToken({
+                unwrappedToken: unwrappedToken2,
+                metadataImage: metadataImage2
+            })
+        );
+        vm.stopPrank();
+
+        (bytes memory storedToken, bytes32 storedImage) =
+            zkgm.channelGovernanceToken(channelId);
+        assertEq(
+            keccak256(storedToken),
+            keccak256(unwrappedToken2),
+            "Unwrapped token not overwritten correctly"
+        );
+        assertEq(
+            storedImage,
+            metadataImage2,
+            "Metadata image not overwritten correctly"
+        );
+    }
+
+    function test_overwriteGovernanceToken_unauthorized(
+        address nonAuthority,
+        uint32 channelId,
+        bytes memory unwrappedToken,
+        bytes32 metadataImage
+    ) public {
+        vm.assume(channelId > 0);
+        vm.assume(unwrappedToken.length > 0);
+        vm.assume(metadataImage != bytes32(0));
+        vm.assume(nonAuthority != authority);
+        vm.assume(nonAuthority != address(0));
+
+        vm.prank(nonAuthority);
+        vm.expectRevert(
+            abi.encodeWithSelector(
+                IAccessManaged.AccessManagedUnauthorized.selector, nonAuthority
+            )
+        );
+        zkgm.overwriteGovernanceToken(
+            channelId,
+            GovernanceToken({
+                unwrappedToken: unwrappedToken,
+                metadataImage: metadataImage
+            })
+        );
+    }
+
+    // Test pause function access control
+    function test_pause_authorized() public {
+        vm.prank(authority);
+        zkgm.pause();
+
+        assertTrue(zkgm.paused(), "Contract should be paused");
+    }
+
+    function test_pause_unauthorized(
+        address nonAuthority
+    ) public {
+        vm.assume(nonAuthority != authority);
+        vm.assume(nonAuthority != address(0));
+
+        vm.prank(nonAuthority);
+        vm.expectRevert(
+            abi.encodeWithSelector(
+                IAccessManaged.AccessManagedUnauthorized.selector, nonAuthority
+            )
+        );
+        zkgm.pause();
+
+        assertFalse(zkgm.paused(), "Contract should not be paused");
+    }
+
+    // Test unpause function access control
+    function test_unpause_authorized() public {
+        vm.prank(authority);
+        zkgm.pause();
+        assertTrue(zkgm.paused(), "Contract should be paused");
+
+        vm.prank(authority);
+        zkgm.unpause();
+
+        assertFalse(zkgm.paused(), "Contract should be unpaused");
+    }
+
+    function test_unpause_unauthorized(
+        address nonAuthority
+    ) public {
+        vm.assume(nonAuthority != authority);
+        vm.assume(nonAuthority != address(0));
+
+        vm.prank(authority);
+        zkgm.pause();
+        assertTrue(zkgm.paused(), "Contract should be paused");
+
+        vm.prank(nonAuthority);
+        vm.expectRevert(
+            abi.encodeWithSelector(
+                IAccessManaged.AccessManagedUnauthorized.selector, nonAuthority
+            )
+        );
+        zkgm.unpause();
+
+        assertTrue(zkgm.paused(), "Contract should remain paused");
+    }
+
+    function test_setBucketConfig_unauthorized(
+        address nonAuthority,
+        address token,
+        uint256 capacity,
+        uint256 refillRate,
+        bool reset
+    ) public {
+        vm.assume(token != address(0));
+        vm.assume(nonAuthority != authority);
+        vm.assume(nonAuthority != address(0));
+
+        vm.prank(nonAuthority);
+        vm.expectRevert(
+            abi.encodeWithSelector(
+                IAccessManaged.AccessManagedUnauthorized.selector, nonAuthority
+            )
+        );
+        zkgm.setBucketConfig(token, capacity, refillRate, reset);
+    }
+
+    // Test upgradeToAndCall function (UUPSUpgradeable implementation)
+    function test_upgradeToAndCall_authorized() public {
+        TestZkgm newImplementation = new TestZkgm(handler, weth, erc20Impl);
+
+        vm.prank(authority);
+        zkgm.upgradeToAndCall(address(newImplementation), hex"");
+
+        bytes32 implementationSlot =
+            0x360894a13ba1a3210667c828492db98dca3e2076cc3735a920a3ca505d382bbc;
+        bytes32 currentImpl = vm.load(address(zkgm), implementationSlot);
+        assertEq(
+            address(uint160(uint256(currentImpl))),
+            address(newImplementation),
+            "Implementation not upgraded correctly"
+        );
+    }
+
+    function test_upgradeToAndCall_unauthorized(
+        address nonAuthority
+    ) public {
+        vm.assume(nonAuthority != authority);
+        vm.assume(nonAuthority != address(0));
+
+        TestZkgm newImplementation = new TestZkgm(handler, weth, erc20Impl);
+
+        vm.prank(nonAuthority);
+        vm.expectRevert(
+            abi.encodeWithSelector(
+                IAccessManaged.AccessManagedUnauthorized.selector, nonAuthority
+            )
+        );
+        zkgm.upgradeToAndCall(address(newImplementation), hex"");
+    }
+
+    // Test behavior of functions when contract is paused
+    function test_paused_functionality(
+        uint32 channelId,
+        uint64 timeoutHeight,
+        uint64 timeoutTimestamp,
+        bytes32 salt,
+        address caller
+    ) public {
+        vm.assume(channelId > 0);
+
+        Instruction memory instruction = Instruction({
+            version: ZkgmLib.INSTR_VERSION_0,
+            opcode: ZkgmLib.OP_MULTIPLEX,
+            operand: ZkgmLib.encodeMultiplex(
+                Multiplex({
+                    sender: abi.encodePacked(caller),
+                    eureka: false,
+                    contractAddress: abi.encodePacked(address(0x1234)),
+                    contractCalldata: hex""
+                })
+            )
+        });
+
+        vm.prank(authority);
+        zkgm.pause();
+        assertTrue(zkgm.paused(), "Contract should be paused");
+
+        vm.prank(address(handler));
+        vm.expectRevert(PausableUpgradeable.EnforcedPause.selector);
+        zkgm.send(channelId, timeoutHeight, timeoutTimestamp, salt, instruction);
+
+        IBCPacket memory packet = IBCPacket({
+            sourceChannelId: channelId,
+            destinationChannelId: channelId,
+            data: ZkgmLib.encode(
+                ZkgmPacket({salt: salt, path: 0, instruction: instruction})
+            ),
+            timeoutHeight: timeoutHeight,
+            timeoutTimestamp: timeoutTimestamp
+        });
+
+        vm.prank(address(handler));
+        vm.expectRevert(PausableUpgradeable.EnforcedPause.selector);
+        zkgm.onRecvPacket(caller, packet, address(0), "");
+
+        vm.prank(address(handler));
+        vm.expectRevert(PausableUpgradeable.EnforcedPause.selector);
+        zkgm.onRecvIntentPacket(caller, packet, address(0), "");
+
+        vm.prank(address(handler));
+        vm.expectRevert(PausableUpgradeable.EnforcedPause.selector);
+        zkgm.onAcknowledgementPacket(caller, packet, "", address(0));
+
+        vm.prank(address(handler));
+        vm.expectRevert(PausableUpgradeable.EnforcedPause.selector);
+        zkgm.onTimeoutPacket(caller, packet, address(0));
+    }
+
+    receive() external payable {}
+}

--- a/evm/tests/src/05-app/ZkgmChannelIsolation.t.sol
+++ b/evm/tests/src/05-app/ZkgmChannelIsolation.t.sol
@@ -1,0 +1,461 @@
+pragma solidity ^0.8.27;
+
+import "forge-std/Test.sol";
+import "./Zkgm.t.sol";
+
+contract ZkgmChannelTokenIsolationTest is Test {
+    using LibString for *;
+
+    TestIBCHandler handler;
+    TestERC20 erc20;
+    ZkgmERC20 erc20Impl;
+    TestWETH weth;
+    TestZkgm zkgm;
+    Manager manager;
+
+    function setUp() public {
+        weth = new TestWETH();
+        erc20 = new TestERC20("Test", "T", 18);
+        handler = new TestIBCHandler();
+        erc20Impl = new ZkgmERC20();
+        manager = Manager(
+            address(
+                new ERC1967Proxy(
+                    address(new Manager()),
+                    abi.encodeCall(Manager.initialize, (address(this)))
+                )
+            )
+        );
+        ERC1967Proxy proxy = new ERC1967Proxy(
+            address(new TestZkgm(handler, weth, erc20Impl)),
+            abi.encodeCall(UCS03Zkgm.initialize, (address(manager)))
+        );
+        zkgm = TestZkgm(payable(address(proxy)));
+        zkgm.doCreateStakeNFTManager();
+
+        erc20.approve(address(zkgm), type(uint256).max);
+    }
+
+    function test_channel_specific_token_isolation(
+        uint32 channelA,
+        uint32 channelB,
+        uint256 pathA,
+        uint256 pathB,
+        uint256 amount,
+        uint256 decreaseAmount1,
+        uint256 decreaseAmount2
+    ) public {
+        vm.assume(channelA > 0);
+        vm.assume(channelB > 0);
+        vm.assume(channelA != channelB);
+
+        vm.assume(pathA < type(uint192).max);
+        vm.assume(pathB < type(uint192).max);
+
+        vm.assume(amount > 0 && amount < type(uint128).max);
+        vm.assume(decreaseAmount1 > 0 && decreaseAmount1 <= amount);
+        vm.assume(
+            decreaseAmount2 > 0 && decreaseAmount2 <= (amount - decreaseAmount1)
+        );
+
+        address baseToken = address(erc20);
+
+        zkgm.doIncreaseOutstanding(channelA, pathA, baseToken, amount);
+
+        zkgm.doIncreaseOutstanding(channelB, pathB, baseToken, amount);
+
+        assertEq(
+            zkgm.channelBalance(channelA, pathA, baseToken),
+            amount,
+            "Channel A balance incorrect"
+        );
+        assertEq(
+            zkgm.channelBalance(channelB, pathB, baseToken),
+            amount,
+            "Channel B balance incorrect"
+        );
+
+        zkgm.doDecreaseOutstanding(channelA, pathA, baseToken, decreaseAmount1);
+
+        assertEq(
+            zkgm.channelBalance(channelA, pathA, baseToken),
+            amount - decreaseAmount1,
+            "Channel A balance not decreased correctly"
+        );
+        assertEq(
+            zkgm.channelBalance(channelB, pathB, baseToken),
+            amount,
+            "Channel B balance incorrectly affected"
+        );
+
+        zkgm.doDecreaseOutstanding(channelB, pathB, baseToken, decreaseAmount1);
+
+        assertEq(
+            zkgm.channelBalance(channelA, pathA, baseToken),
+            amount - decreaseAmount1,
+            "Channel A balance incorrectly affected"
+        );
+        assertEq(
+            zkgm.channelBalance(channelB, pathB, baseToken),
+            amount - decreaseAmount1,
+            "Channel B balance not decreased correctly"
+        );
+
+        zkgm.doDecreaseOutstanding(channelA, pathA, baseToken, decreaseAmount2);
+
+        assertEq(
+            zkgm.channelBalance(channelA, pathA, baseToken),
+            amount - decreaseAmount1 - decreaseAmount2,
+            "Channel A final balance incorrect"
+        );
+        assertEq(
+            zkgm.channelBalance(channelB, pathB, baseToken),
+            amount - decreaseAmount1,
+            "Channel B final balance incorrect"
+        );
+
+        uint256 remainingBalanceA = amount - decreaseAmount1 - decreaseAmount2;
+        vm.expectRevert(); // Should revert due to underflow
+        zkgm.doDecreaseOutstanding(
+            channelA, pathA, baseToken, remainingBalanceA + 1
+        );
+
+        zkgm.doDecreaseOutstanding(
+            channelB, pathB, baseToken, amount - decreaseAmount1
+        );
+        assertEq(
+            zkgm.channelBalance(channelB, pathB, baseToken),
+            0,
+            "Channel B balance not fully decreased"
+        );
+
+        assertEq(
+            zkgm.channelBalance(channelA, pathA, baseToken),
+            remainingBalanceA,
+            "Channel A balance incorrectly changed"
+        );
+    }
+
+    function test_channel_specific_token_isolation_v2(
+        uint32 channelA,
+        uint32 channelB,
+        uint256 pathA,
+        uint256 pathB,
+        bytes32 metadataImage,
+        uint256 amount,
+        uint256 decreaseAmount1,
+        uint256 decreaseAmount2
+    ) public {
+        vm.assume(channelA > 0);
+        vm.assume(channelB > 0);
+        vm.assume(channelA != channelB);
+
+        vm.assume(pathA < type(uint192).max);
+        vm.assume(pathB < type(uint192).max);
+
+        vm.assume(metadataImage != bytes32(0));
+
+        vm.assume(amount > 0 && amount < type(uint128).max);
+        vm.assume(decreaseAmount1 > 0 && decreaseAmount1 <= amount);
+        vm.assume(
+            decreaseAmount2 > 0 && decreaseAmount2 <= (amount - decreaseAmount1)
+        );
+
+        address baseToken = address(erc20);
+
+        zkgm.doIncreaseOutstandingV2(
+            channelA, pathA, baseToken, metadataImage, amount
+        );
+
+        zkgm.doIncreaseOutstandingV2(
+            channelB, pathB, baseToken, metadataImage, amount
+        );
+
+        assertEq(
+            zkgm.channelBalanceV2(channelA, pathA, baseToken, metadataImage),
+            amount,
+            "Channel A V2 balance incorrect"
+        );
+        assertEq(
+            zkgm.channelBalanceV2(channelB, pathB, baseToken, metadataImage),
+            amount,
+            "Channel B V2 balance incorrect"
+        );
+
+        zkgm.doDecreaseOutstandingV2(
+            channelA, pathA, baseToken, metadataImage, decreaseAmount1
+        );
+
+        assertEq(
+            zkgm.channelBalanceV2(channelA, pathA, baseToken, metadataImage),
+            amount - decreaseAmount1,
+            "Channel A V2 balance not decreased correctly"
+        );
+        assertEq(
+            zkgm.channelBalanceV2(channelB, pathB, baseToken, metadataImage),
+            amount,
+            "Channel B V2 balance incorrectly affected"
+        );
+
+        zkgm.doDecreaseOutstandingV2(
+            channelB, pathB, baseToken, metadataImage, decreaseAmount1
+        );
+
+        assertEq(
+            zkgm.channelBalanceV2(channelA, pathA, baseToken, metadataImage),
+            amount - decreaseAmount1,
+            "Channel A V2 balance incorrectly affected"
+        );
+        assertEq(
+            zkgm.channelBalanceV2(channelB, pathB, baseToken, metadataImage),
+            amount - decreaseAmount1,
+            "Channel B V2 balance not decreased correctly"
+        );
+
+        zkgm.doDecreaseOutstandingV2(
+            channelA, pathA, baseToken, metadataImage, decreaseAmount2
+        );
+
+        assertEq(
+            zkgm.channelBalanceV2(channelA, pathA, baseToken, metadataImage),
+            amount - decreaseAmount1 - decreaseAmount2,
+            "Channel A final V2 balance incorrect"
+        );
+        assertEq(
+            zkgm.channelBalanceV2(channelB, pathB, baseToken, metadataImage),
+            amount - decreaseAmount1,
+            "Channel B final V2 balance incorrect"
+        );
+
+        uint256 remainingBalanceA = amount - decreaseAmount1 - decreaseAmount2;
+        vm.expectRevert(); // Should revert due to underflow
+        zkgm.doDecreaseOutstandingV2(
+            channelA, pathA, baseToken, metadataImage, remainingBalanceA + 1
+        );
+
+        zkgm.doDecreaseOutstandingV2(
+            channelB, pathB, baseToken, metadataImage, amount - decreaseAmount1
+        );
+        assertEq(
+            zkgm.channelBalanceV2(channelB, pathB, baseToken, metadataImage),
+            0,
+            "Channel B V2 balance not fully decreased"
+        );
+
+        assertEq(
+            zkgm.channelBalanceV2(channelA, pathA, baseToken, metadataImage),
+            remainingBalanceA,
+            "Channel A V2 balance incorrectly changed"
+        );
+    }
+
+    // This test checks for the even more complex case where we use the same token address
+    // with different metadata images across different channels
+    function test_channel_and_metadata_isolation(
+        uint32 channelA,
+        uint32 channelB,
+        uint256 pathA,
+        uint256 pathB,
+        bytes32 metadataImage1,
+        bytes32 metadataImage2,
+        uint256 amount,
+        uint256 decreaseAmount
+    ) public {
+        vm.assume(channelA > 0);
+        vm.assume(channelB > 0);
+        vm.assume(channelA != channelB);
+
+        vm.assume(pathA < type(uint192).max);
+        vm.assume(pathB < type(uint192).max);
+
+        vm.assume(metadataImage1 != bytes32(0));
+        vm.assume(metadataImage2 != bytes32(0));
+        vm.assume(metadataImage1 != metadataImage2);
+
+        vm.assume(amount > 0 && amount < type(uint128).max);
+        vm.assume(decreaseAmount > 0 && decreaseAmount <= amount / 2); // Ensure we can decrease twice
+
+        address baseToken = address(erc20);
+
+        zkgm.doIncreaseOutstandingV2(
+            channelA, pathA, baseToken, metadataImage1, amount
+        );
+        zkgm.doIncreaseOutstandingV2(
+            channelA, pathA, baseToken, metadataImage2, amount
+        );
+        zkgm.doIncreaseOutstandingV2(
+            channelB, pathB, baseToken, metadataImage1, amount
+        );
+        zkgm.doIncreaseOutstandingV2(
+            channelB, pathB, baseToken, metadataImage2, amount
+        );
+
+        assertEq(
+            zkgm.channelBalanceV2(channelA, pathA, baseToken, metadataImage1),
+            amount,
+            "Channel A metadata1 balance incorrect"
+        );
+        assertEq(
+            zkgm.channelBalanceV2(channelA, pathA, baseToken, metadataImage2),
+            amount,
+            "Channel A metadata2 balance incorrect"
+        );
+        assertEq(
+            zkgm.channelBalanceV2(channelB, pathB, baseToken, metadataImage1),
+            amount,
+            "Channel B metadata1 balance incorrect"
+        );
+        assertEq(
+            zkgm.channelBalanceV2(channelB, pathB, baseToken, metadataImage2),
+            amount,
+            "Channel B metadata2 balance incorrect"
+        );
+
+        zkgm.doDecreaseOutstandingV2(
+            channelA, pathA, baseToken, metadataImage1, decreaseAmount
+        );
+
+        assertEq(
+            zkgm.channelBalanceV2(channelA, pathA, baseToken, metadataImage1),
+            amount - decreaseAmount,
+            "Target balance not decreased correctly"
+        );
+        assertEq(
+            zkgm.channelBalanceV2(channelA, pathA, baseToken, metadataImage2),
+            amount,
+            "Wrong metadata balance affected"
+        );
+        assertEq(
+            zkgm.channelBalanceV2(channelB, pathB, baseToken, metadataImage1),
+            amount,
+            "Wrong channel balance affected"
+        );
+        assertEq(
+            zkgm.channelBalanceV2(channelB, pathB, baseToken, metadataImage2),
+            amount,
+            "Wrong channel and metadata balance affected"
+        );
+
+        vm.expectRevert(); // Should revert due to underflow
+        zkgm.doDecreaseOutstandingV2(
+            channelA, pathA, baseToken, metadataImage1, amount
+        );
+
+        zkgm.doDecreaseOutstandingV2(
+            channelA, pathA, baseToken, metadataImage2, decreaseAmount
+        );
+        zkgm.doDecreaseOutstandingV2(
+            channelB, pathB, baseToken, metadataImage1, decreaseAmount
+        );
+        zkgm.doDecreaseOutstandingV2(
+            channelB, pathB, baseToken, metadataImage2, decreaseAmount
+        );
+
+        assertEq(
+            zkgm.channelBalanceV2(channelA, pathA, baseToken, metadataImage1),
+            amount - decreaseAmount,
+            "Final Channel A metadata1 balance incorrect"
+        );
+        assertEq(
+            zkgm.channelBalanceV2(channelA, pathA, baseToken, metadataImage2),
+            amount - decreaseAmount,
+            "Final Channel A metadata2 balance incorrect"
+        );
+        assertEq(
+            zkgm.channelBalanceV2(channelB, pathB, baseToken, metadataImage1),
+            amount - decreaseAmount,
+            "Final Channel B metadata1 balance incorrect"
+        );
+        assertEq(
+            zkgm.channelBalanceV2(channelB, pathB, baseToken, metadataImage2),
+            amount - decreaseAmount,
+            "Final Channel B metadata2 balance incorrect"
+        );
+
+        zkgm.doDecreaseOutstandingV2(
+            channelA, pathA, baseToken, metadataImage1, amount - decreaseAmount
+        );
+        assertEq(
+            zkgm.channelBalanceV2(channelA, pathA, baseToken, metadataImage1),
+            0,
+            "Failed to zero out first combination"
+        );
+
+        assertEq(
+            zkgm.channelBalanceV2(channelA, pathA, baseToken, metadataImage2),
+            amount - decreaseAmount,
+            "Other balances incorrectly changed"
+        );
+        assertEq(
+            zkgm.channelBalanceV2(channelB, pathB, baseToken, metadataImage1),
+            amount - decreaseAmount,
+            "Other balances incorrectly changed"
+        );
+        assertEq(
+            zkgm.channelBalanceV2(channelB, pathB, baseToken, metadataImage2),
+            amount - decreaseAmount,
+            "Other balances incorrectly changed"
+        );
+    }
+
+    // Test extreme cases with very large and very small values
+    function test_channel_isolation_edge_cases(
+        uint32 channelA,
+        uint32 channelB,
+        uint256 smallAmount,
+        uint256 largeAmount
+    ) public {
+        vm.assume(channelA > 0);
+        vm.assume(channelB > 0);
+        vm.assume(channelA != channelB);
+
+        vm.assume(smallAmount > 0 && smallAmount < 10);
+
+        vm.assume(
+            largeAmount > type(uint128).max
+                && largeAmount < type(uint256).max - 1000
+        );
+
+        address baseToken = address(erc20);
+
+        zkgm.doIncreaseOutstanding(channelA, 0, baseToken, smallAmount);
+        zkgm.doIncreaseOutstanding(channelB, 0, baseToken, largeAmount);
+
+        assertEq(
+            zkgm.channelBalance(channelA, 0, baseToken),
+            smallAmount,
+            "Channel A small balance incorrect"
+        );
+        assertEq(
+            zkgm.channelBalance(channelB, 0, baseToken),
+            largeAmount,
+            "Channel B large balance incorrect"
+        );
+
+        zkgm.doDecreaseOutstanding(channelA, 0, baseToken, smallAmount);
+
+        assertEq(
+            zkgm.channelBalance(channelA, 0, baseToken),
+            0,
+            "Channel A balance not zeroed"
+        );
+        assertEq(
+            zkgm.channelBalance(channelB, 0, baseToken),
+            largeAmount,
+            "Channel B balance incorrectly affected"
+        );
+
+        zkgm.doDecreaseOutstanding(channelB, 0, baseToken, smallAmount);
+
+        assertEq(
+            zkgm.channelBalance(channelB, 0, baseToken),
+            largeAmount - smallAmount,
+            "Channel B balance not decreased correctly"
+        );
+
+        vm.expectRevert();
+        zkgm.doDecreaseOutstanding(channelA, 0, baseToken, 1);
+    }
+
+    receive() external payable {}
+}


### PR DESCRIPTION
Introduce tests for zkgm authority, ensuring privileged functions are correctly restricted. Also add more channel isolation verification, including same token address from different channels etc...