### PR TITLE
feat(app): Add confirmation modals for account deletion and social unlinking

### DIFF
--- a/app2/src/lib/dashboard/components/AccountInfo.svelte
+++ b/app2/src/lib/dashboard/components/AccountInfo.svelte
@@ -1,59 +1,34 @@
 <script lang="ts">
-import { AccountError } from "$lib/dashboard/errors"
 import { dashboard } from "$lib/dashboard/stores/user.svelte"
-import { runPromise } from "$lib/runtime"
-import { extractErrorDetails } from "@unionlabs/sdk/utils"
-import { Effect, Option, pipe } from "effect"
-import { errorStore } from "../stores/errors.svelte"
+import { Option } from "effect"
+import DeleteAccountModal from "./DeleteAccountModal.svelte"
 
-let isDeleting = false
+let showDeleteModal = $state(false)
 
 function handleDelete() {
-  const effect = pipe(
-    Effect.sync(() =>
-      confirm("Are you sure you want to delete your account? This action cannot be undone.")
-    ),
-    Effect.flatMap((confirmed) =>
-      confirmed
-        ? pipe(
-          Effect.sync(() => {
-            isDeleting = true
-          }),
-          Effect.flatMap(() => dashboard.deleteAccount()),
-          Effect.catchAll((error) => {
-            errorStore.showError(
-              new AccountError({
-                cause: extractErrorDetails(error),
-                operation: "delete",
-              }),
-            )
-            return Effect.succeed(undefined)
-          }),
-          Effect.ensuring(
-            Effect.sync(() => {
-              isDeleting = false
-            }),
-          ),
-        )
-        : Effect.succeed(undefined)
-    ),
-  )
+  showDeleteModal = true
+}
 
-  return runPromise(effect)
+function handleCloseModal() {
+  showDeleteModal = false
 }
 </script>
 
 {#if Option.isSome(dashboard.user)}
-  <div class="text-center text-zinc-400 pb-12 text-xs">
-    <h1 class="text-zinc-200 text-sm">Account Info:</h1>
+  <div class="text-center text-zinc-400 pb-12 text-xs flex flex-col">
+    <h2 class="text-zinc-200 text-sm">Account Info:</h2>
     <p><span class="text-zinc-300">Email:</span> {dashboard.user.value.email}</p>
     <p><span class="text-zinc-300">ID:</span> {dashboard.user.value.id}</p>
     <button
-      on:click={handleDelete}
-      class:pointer-events-none={isDeleting}
-      class="hover:text-rose-500 underline cursor-pointer disabled:opacity-50"
+      onclick={handleDelete}
+      class="hover:text-rose-500 text-rose-400 text-xs font-medium mt-3"
     >
-      {isDeleting ? "Deleting..." : "Delete Account"}
+      Delete Account
     </button>
   </div>
 {/if}
+
+<DeleteAccountModal
+  isOpen={showDeleteModal}
+  onClose={handleCloseModal}
+/>

--- a/app2/src/lib/dashboard/components/DeleteAccountModal.svelte
+++ b/app2/src/lib/dashboard/components/DeleteAccountModal.svelte
@@ -1,0 +1,180 @@
+<script lang="ts">
+import { AccountError } from "$lib/dashboard/errors"
+import { dashboard } from "$lib/dashboard/stores/user.svelte"
+import { runPromise } from "$lib/runtime"
+import { extractErrorDetails } from "@unionlabs/sdk/utils"
+import { Effect, Option, pipe } from "effect"
+import { errorStore } from "../stores/errors.svelte"
+
+interface Props {
+  isOpen: boolean
+  onClose: () => void
+}
+
+let { isOpen, onClose }: Props = $props()
+
+let step: "initial" | "confirm" = $state("initial")
+let userInput = $state("")
+let countdown = $state(5)
+let isDeleting = $state(false)
+let countdownInterval: number | null = null
+
+const userId = $derived(
+  Option.isSome(dashboard.user) ? dashboard.user.value.id : "",
+)
+
+function resetModal() {
+  step = "initial"
+  userInput = ""
+  countdown = 5
+  if (countdownInterval) {
+    clearInterval(countdownInterval)
+    countdownInterval = null
+  }
+}
+
+function handleClose() {
+  resetModal()
+  onClose()
+}
+
+function proceedToConfirm() {
+  step = "confirm"
+  startCountdown()
+}
+
+function startCountdown() {
+  countdownInterval = window.setInterval(() => {
+    countdown--
+    if (countdown <= 0 && countdownInterval) {
+      clearInterval(countdownInterval)
+      countdownInterval = null
+    }
+  }, 1000)
+}
+
+function handlePaste(e: Event) {
+  e.preventDefault()
+  return false
+}
+
+function handleDelete() {
+  const effect = pipe(
+    Effect.sync(() => {
+      isDeleting = true
+    }),
+    Effect.flatMap(() => dashboard.deleteAccount()),
+    Effect.catchAll((error) => {
+      errorStore.showError(
+        new AccountError({
+          cause: extractErrorDetails(error),
+          operation: "delete",
+        }),
+      )
+      return Effect.succeed(undefined)
+    }),
+    Effect.ensuring(
+      Effect.sync(() => {
+        isDeleting = false
+        handleClose()
+      }),
+    ),
+  )
+
+  return runPromise(effect)
+}
+
+$effect(() => {
+  if (!isOpen) {
+    resetModal()
+  }
+})
+</script>
+
+{#if isOpen}
+  <div class="fixed inset-0 bg-black/80 backdrop-blur-sm z-50 flex items-center justify-center p-4">
+    <div class="bg-zinc-900 border border-zinc-800 rounded-lg max-w-md w-full p-6">
+      {#if step === "initial"}
+        <h2 class="text-xl font-semibold text-white mb-4">Delete Account</h2>
+
+        <div class="bg-rose-950/30 border border-rose-900/50 rounded-lg p-4 mb-6">
+          <p class="text-rose-400 font-medium mb-2">⚠️ SERIOUS WARNING</p>
+          <p class="text-zinc-300 text-sm">
+            This will permanently delete your account. You will lose everything. You will lose all
+            of your XP, your rank, and all of your achievements.
+          </p>
+        </div>
+
+        <p class="text-zinc-400 text-sm mb-4">
+          To proceed, please type your account ID exactly as shown below:
+        </p>
+
+        <div class="bg-zinc-800/50 rounded p-3 mb-4">
+          <code class="text-zinc-200 text-sm font-mono select-none">{userId}</code>
+        </div>
+
+        <input
+          type="text"
+          bind:value={userInput}
+          onpaste={handlePaste}
+          placeholder="Type your account ID here"
+          class="w-full bg-zinc-800 border border-zinc-700 rounded px-3 py-2 text-zinc-200 placeholder:text-zinc-500 focus:outline-none focus:border-zinc-600 mb-4"
+        />
+
+        <div class="flex gap-3">
+          <button
+            onclick={handleClose}
+            class="flex-1 px-4 py-2 bg-zinc-800 text-zinc-300 rounded hover:bg-zinc-700 transition-colors"
+          >
+            Cancel
+          </button>
+          <button
+            onclick={proceedToConfirm}
+            disabled={userInput !== userId}
+            class="flex-1 px-4 py-2 bg-rose-600 text-white rounded hover:bg-rose-700 disabled:bg-zinc-800 disabled:text-zinc-500 disabled:cursor-not-allowed transition-colors"
+          >
+            Continue
+          </button>
+        </div>
+      {/if}
+
+      {#if step === "confirm"}
+        <h2 class="text-xl font-semibold text-white mb-4">Final Confirmation</h2>
+
+        <div class="bg-rose-950/30 border border-rose-900/50 rounded-lg p-4 mb-6">
+          <p class="text-rose-400 font-medium mb-2">⚠️ THIS ACTION CANNOT BE UNDONE</p>
+          <p class="text-zinc-300 text-sm">
+            You are about to permanently delete your account. All your data, settings, and history
+            will be lost forever. This cannot be undone. You will lose all of your XP, your rank,
+            and any achievements. You will never get this back.
+          </p>
+        </div>
+
+        <p class="text-zinc-400 text-sm mb-6">
+          {#if countdown > 0}
+            Please wait {countdown} seconds before you can delete your account.
+          {:else}
+            You can now delete your account.
+          {/if}
+        </p>
+
+        <div class="flex gap-3">
+          <button
+            onclick={handleClose}
+            disabled={isDeleting}
+            class="flex-1 px-4 py-2 bg-zinc-800 text-zinc-300 rounded hover:bg-zinc-700 disabled:opacity-50 disabled:cursor-not-allowed transition-colors"
+          >
+            Cancel
+          </button>
+          <button
+            onclick={handleDelete}
+            disabled={countdown > 0 || isDeleting}
+            class="flex-1 px-4 py-2 bg-rose-600 text-white rounded hover:bg-rose-700 disabled:bg-zinc-800 disabled:text-zinc-500 disabled:cursor-not-allowed transition-colors"
+          >
+            {isDeleting ? "Deleting..." : "Delete Account"}
+          </button>
+        </div>
+      {/if}
+    </div>
+  </div>
+{/if}

--- a/app2/src/lib/dashboard/components/SocialConnections.svelte
+++ b/app2/src/lib/dashboard/components/SocialConnections.svelte
@@ -5,8 +5,8 @@ import { runPromise } from "$lib/runtime"
 import { cn } from "$lib/utils"
 import { Option } from "effect"
 import { Effect } from "effect"
-import UnlinkAccountModal from "./UnlinkAccountModal.svelte"
 import type { AuthProvider } from "../stores/user.svelte"
+import UnlinkAccountModal from "./UnlinkAccountModal.svelte"
 
 let unlinkModalOpen = $state(false)
 let providerToUnlink = $state<AuthProvider | null>(null)
@@ -29,7 +29,11 @@ function handleProviderClick(provider: AuthProvider, isConnected: boolean) {
     <!-- GitHub Connection -->
     <button
       class="w-full bg-transparent hover:bg-zinc-900 rounded-lg p-2.5 flex items-center justify-between cursor-pointer transition-colors duration-200 ease-in-out focus:outline-none text-sm font-medium capitalize relative h-11 group"
-      onclick={() => handleProviderClick("github", Option.isSome(dashboard.connections?.github) && dashboard.connections.github.value)}
+      onclick={() =>
+      handleProviderClick(
+        "github",
+        Option.isSome(dashboard.connections?.github) && dashboard.connections.github.value,
+      )}
     >
       <div class="flex items-center gap-2">
         <span
@@ -80,7 +84,12 @@ function handleProviderClick(provider: AuthProvider, isConnected: boolean) {
     <!-- Twitter Connection -->
     <button
       class="w-full bg-transparent hover:bg-zinc-900 rounded-lg p-2.5 flex items-center justify-between cursor-pointer transition-colors duration-200 ease-in-out focus:outline-none text-sm font-medium capitalize relative h-11 group"
-      onclick={() => handleProviderClick("twitter", Option.isSome(dashboard.connections?.twitter) && dashboard.connections.twitter.value)}
+      onclick={() =>
+      handleProviderClick(
+        "twitter",
+        Option.isSome(dashboard.connections?.twitter)
+          && dashboard.connections.twitter.value,
+      )}
     >
       <div class="flex items-center gap-2">
         <span
@@ -131,7 +140,12 @@ function handleProviderClick(provider: AuthProvider, isConnected: boolean) {
     <!-- Discord Connection -->
     <button
       class="w-full bg-transparent hover:bg-zinc-900 rounded-lg p-2.5 flex items-center justify-between cursor-pointer transition-colors duration-200 ease-in-out focus:outline-none text-sm font-medium capitalize relative h-11 group"
-      onclick={() => handleProviderClick("discord", Option.isSome(dashboard.connections?.discord) && dashboard.connections.discord.value)}
+      onclick={() =>
+      handleProviderClick(
+        "discord",
+        Option.isSome(dashboard.connections?.discord)
+          && dashboard.connections.discord.value,
+      )}
     >
       <div class="flex items-center gap-2">
         <span

--- a/app2/src/lib/dashboard/components/SocialConnections.svelte
+++ b/app2/src/lib/dashboard/components/SocialConnections.svelte
@@ -5,6 +5,20 @@ import { runPromise } from "$lib/runtime"
 import { cn } from "$lib/utils"
 import { Option } from "effect"
 import { Effect } from "effect"
+import UnlinkAccountModal from "./UnlinkAccountModal.svelte"
+import type { AuthProvider } from "../stores/user.svelte"
+
+let unlinkModalOpen = $state(false)
+let providerToUnlink = $state<AuthProvider | null>(null)
+
+function handleProviderClick(provider: AuthProvider, isConnected: boolean) {
+  if (isConnected) {
+    providerToUnlink = provider
+    unlinkModalOpen = true
+  } else {
+    runPromise(dashboard.linkIdentity(provider))
+  }
+}
 </script>
 
 <Card class="flex flex-col gap-3 lg:gap-3 lg:w-64">
@@ -15,12 +29,7 @@ import { Effect } from "effect"
     <!-- GitHub Connection -->
     <button
       class="w-full bg-transparent hover:bg-zinc-900 rounded-lg p-2.5 flex items-center justify-between cursor-pointer transition-colors duration-200 ease-in-out focus:outline-none text-sm font-medium capitalize relative h-11 group"
-      onclick={() =>
-      runPromise(
-        Option.isSome(dashboard.connections?.github) && dashboard.connections.github.value
-          ? dashboard.unlinkIdentity("github")
-          : dashboard.linkIdentity("github"),
-      )}
+      onclick={() => handleProviderClick("github", Option.isSome(dashboard.connections?.github) && dashboard.connections.github.value)}
     >
       <div class="flex items-center gap-2">
         <span
@@ -71,12 +80,7 @@ import { Effect } from "effect"
     <!-- Twitter Connection -->
     <button
       class="w-full bg-transparent hover:bg-zinc-900 rounded-lg p-2.5 flex items-center justify-between cursor-pointer transition-colors duration-200 ease-in-out focus:outline-none text-sm font-medium capitalize relative h-11 group"
-      onclick={() =>
-      runPromise(
-        Option.isSome(dashboard.connections?.twitter) && dashboard.connections.twitter.value
-          ? dashboard.unlinkIdentity("twitter")
-          : dashboard.linkIdentity("twitter"),
-      )}
+      onclick={() => handleProviderClick("twitter", Option.isSome(dashboard.connections?.twitter) && dashboard.connections.twitter.value)}
     >
       <div class="flex items-center gap-2">
         <span
@@ -127,12 +131,7 @@ import { Effect } from "effect"
     <!-- Discord Connection -->
     <button
       class="w-full bg-transparent hover:bg-zinc-900 rounded-lg p-2.5 flex items-center justify-between cursor-pointer transition-colors duration-200 ease-in-out focus:outline-none text-sm font-medium capitalize relative h-11 group"
-      onclick={() =>
-      runPromise(
-        Option.isSome(dashboard.connections?.discord) && dashboard.connections.discord.value
-          ? dashboard.unlinkIdentity("discord")
-          : dashboard.linkIdentity("discord"),
-      )}
+      onclick={() => handleProviderClick("discord", Option.isSome(dashboard.connections?.discord) && dashboard.connections.discord.value)}
     >
       <div class="flex items-center gap-2">
         <span
@@ -181,3 +180,12 @@ import { Effect } from "effect"
     </button>
   </div>
 </Card>
+
+<UnlinkAccountModal
+  isOpen={unlinkModalOpen}
+  onClose={() => {
+    unlinkModalOpen = false
+    providerToUnlink = null
+  }}
+  provider={providerToUnlink}
+/>

--- a/app2/src/lib/dashboard/components/UnlinkAccountModal.svelte
+++ b/app2/src/lib/dashboard/components/UnlinkAccountModal.svelte
@@ -22,7 +22,7 @@ let isUnlinking = $state(false)
 let countdownInterval: number | null = null
 
 const providerName = $derived(
-  provider ? provider.charAt(0).toUpperCase() + provider.slice(1) : ""
+  provider ? provider.charAt(0).toUpperCase() + provider.slice(1) : "",
 )
 
 const confirmText = $derived(provider ? `unlink ${provider} and delete my xp` : "")
@@ -63,7 +63,9 @@ function handlePaste(e: Event) {
 }
 
 function handleUnlink() {
-  if (!provider) return
+  if (!provider) {
+    return
+  }
 
   const effect = pipe(
     Effect.sync(() => {
@@ -106,14 +108,16 @@ $effect(() => {
         <div class="bg-rose-950/30 border border-rose-900/50 rounded-lg p-4 mb-6">
           <p class="text-rose-400 font-medium mb-2">⚠️ WARNING</p>
           <p class="text-zinc-300 text-sm">
-            Unlinking your {providerName} account will permanently remove all rewards and XP 
-            associated with this linked account. This action cannot be undone and you will lose 
-            all progress tied to this connection.
+            Unlinking your {providerName} account will permanently remove all rewards and XP
+            associated with this linked account. This action cannot be undone and you will lose all
+            progress tied to this connection.
           </p>
         </div>
 
         <p class="text-zinc-400 text-sm mb-4">
-          To proceed, please type <span class="font-mono bg-zinc-800 px-2 py-1 rounded">{confirmText}</span> exactly as shown:
+          To proceed, please type <span class="font-mono bg-zinc-800 px-2 py-1 rounded">{
+            confirmText
+          }</span> exactly as shown:
         </p>
 
         <input
@@ -147,10 +151,10 @@ $effect(() => {
         <div class="bg-rose-950/30 border border-rose-900/50 rounded-lg p-4 mb-6">
           <p class="text-rose-400 font-medium mb-2">⚠️ THIS ACTION CANNOT BE UNDONE</p>
           <p class="text-zinc-300 text-sm">
-            You are about to permanently unlink your {providerName} account. All rewards, XP, 
-            and achievements associated with this linked account will be lost forever. You will 
-            need to reconnect this account later if you want to use it again, but your previous 
-            rewards and progress will not be restored.
+            You are about to permanently unlink your {providerName} account. All rewards, XP, and
+            achievements associated with this linked account will be lost forever. You will need to
+            reconnect this account later if you want to use it again, but your previous rewards and
+            progress will not be restored.
           </p>
         </div>
 

--- a/app2/src/lib/dashboard/components/UnlinkAccountModal.svelte
+++ b/app2/src/lib/dashboard/components/UnlinkAccountModal.svelte
@@ -1,0 +1,184 @@
+<script lang="ts">
+import { AccountError } from "$lib/dashboard/errors"
+import { dashboard } from "$lib/dashboard/stores/user.svelte"
+import { runPromise } from "$lib/runtime"
+import { extractErrorDetails } from "@unionlabs/sdk/utils"
+import { Effect, Option, pipe } from "effect"
+import { errorStore } from "../stores/errors.svelte"
+import type { AuthProvider } from "../stores/user.svelte"
+
+interface Props {
+  isOpen: boolean
+  onClose: () => void
+  provider: AuthProvider | null
+}
+
+let { isOpen, onClose, provider }: Props = $props()
+
+let step: "initial" | "confirm" = $state("initial")
+let userInput = $state("")
+let countdown = $state(5)
+let isUnlinking = $state(false)
+let countdownInterval: number | null = null
+
+const providerName = $derived(
+  provider ? provider.charAt(0).toUpperCase() + provider.slice(1) : ""
+)
+
+const confirmText = $derived(provider ? `unlink ${provider} and delete my xp` : "")
+
+function resetModal() {
+  step = "initial"
+  userInput = ""
+  countdown = 5
+  if (countdownInterval) {
+    clearInterval(countdownInterval)
+    countdownInterval = null
+  }
+}
+
+function handleClose() {
+  resetModal()
+  onClose()
+}
+
+function proceedToConfirm() {
+  step = "confirm"
+  startCountdown()
+}
+
+function startCountdown() {
+  countdownInterval = window.setInterval(() => {
+    countdown--
+    if (countdown <= 0 && countdownInterval) {
+      clearInterval(countdownInterval)
+      countdownInterval = null
+    }
+  }, 1000)
+}
+
+function handlePaste(e: Event) {
+  e.preventDefault()
+  return false
+}
+
+function handleUnlink() {
+  if (!provider) return
+
+  const effect = pipe(
+    Effect.sync(() => {
+      isUnlinking = true
+    }),
+    Effect.flatMap(() => dashboard.unlinkIdentity(provider)),
+    Effect.catchAll((error) => {
+      errorStore.showError(
+        new AccountError({
+          cause: extractErrorDetails(error),
+          operation: "unlink",
+        }),
+      )
+      return Effect.succeed(undefined)
+    }),
+    Effect.ensuring(
+      Effect.sync(() => {
+        isUnlinking = false
+        handleClose()
+      }),
+    ),
+  )
+
+  return runPromise(effect)
+}
+
+$effect(() => {
+  if (!isOpen) {
+    resetModal()
+  }
+})
+</script>
+
+{#if isOpen && provider}
+  <div class="fixed inset-0 bg-black/80 backdrop-blur-sm z-50 flex items-center justify-center p-4">
+    <div class="bg-zinc-900 border border-zinc-800 rounded-lg max-w-md w-full p-6">
+      {#if step === "initial"}
+        <h2 class="text-xl font-semibold text-white mb-4">Unlink {providerName} Account</h2>
+
+        <div class="bg-rose-950/30 border border-rose-900/50 rounded-lg p-4 mb-6">
+          <p class="text-rose-400 font-medium mb-2">⚠️ WARNING</p>
+          <p class="text-zinc-300 text-sm">
+            Unlinking your {providerName} account will permanently remove all rewards and XP 
+            associated with this linked account. This action cannot be undone and you will lose 
+            all progress tied to this connection.
+          </p>
+        </div>
+
+        <p class="text-zinc-400 text-sm mb-4">
+          To proceed, please type <span class="font-mono bg-zinc-800 px-2 py-1 rounded">{confirmText}</span> exactly as shown:
+        </p>
+
+        <input
+          type="text"
+          bind:value={userInput}
+          onpaste={handlePaste}
+          placeholder="Type the confirmation text here"
+          class="w-full bg-zinc-800 border border-zinc-700 rounded px-3 py-2 text-zinc-200 placeholder:text-zinc-500 focus:outline-none focus:border-zinc-600 mb-4"
+        />
+
+        <div class="flex gap-3">
+          <button
+            onclick={handleClose}
+            class="flex-1 px-4 py-2 bg-zinc-800 text-zinc-300 rounded hover:bg-zinc-700 transition-colors"
+          >
+            Cancel
+          </button>
+          <button
+            onclick={proceedToConfirm}
+            disabled={userInput !== confirmText}
+            class="flex-1 px-4 py-2 bg-rose-600 text-white rounded hover:bg-rose-700 disabled:bg-zinc-800 disabled:text-zinc-500 disabled:cursor-not-allowed transition-colors"
+          >
+            Continue
+          </button>
+        </div>
+      {/if}
+
+      {#if step === "confirm"}
+        <h2 class="text-xl font-semibold text-white mb-4">Final Confirmation</h2>
+
+        <div class="bg-rose-950/30 border border-rose-900/50 rounded-lg p-4 mb-6">
+          <p class="text-rose-400 font-medium mb-2">⚠️ THIS ACTION CANNOT BE UNDONE</p>
+          <p class="text-zinc-300 text-sm">
+            You are about to permanently unlink your {providerName} account. All rewards, XP, 
+            and achievements associated with this linked account will be lost forever. You will 
+            need to reconnect this account later if you want to use it again, but your previous 
+            rewards and progress will not be restored.
+          </p>
+        </div>
+
+        <p class="text-zinc-400 text-sm mb-6">
+          {#if countdown > 0}
+            Please wait {countdown} seconds before you can unlink your account.
+          {:else}
+            You can now unlink your {providerName} account.
+          {/if}
+        </p>
+
+        <div class="flex gap-3">
+          <button
+            onclick={handleClose}
+            disabled={isUnlinking}
+            class="flex-1 px-4 py-2 bg-zinc-800 text-zinc-300 rounded hover:bg-zinc-700 disabled:opacity-50 disabled:cursor-not-allowed transition-colors"
+          >
+            Cancel
+          </button>
+          <button
+            onclick={handleUnlink}
+            disabled={countdown > 0 || isUnlinking}
+            class="flex-1 px-4 py-2 bg-rose-600 text-white rounded hover:bg-rose-700 disabled:bg-zinc-800 disabled:text-zinc-500 disabled:cursor-not-allowed transition-colors"
+          >
+            {isUnlinking ? "Unlinking..." : `Unlink ${providerName}`}
+          </button>
+        </div>
+      {/if}
+    </div>
+  </div>
+{/if}


### PR DESCRIPTION
## Summary
- Added confirmation modals for both account deletion and social account unlinking
- Both modals implement a two-step confirmation process with security measures
- Users must type specific confirmation text to proceed with destructive actions

## Changes

### Account Deletion Modal
- Created `DeleteAccountModal.svelte` component
- Users must type their account ID to confirm deletion
- 5-second countdown timer before final deletion
- Updated `AccountInfo.svelte` to use the modal

### Social Account Unlinking Modal  
- Created `UnlinkAccountModal.svelte` component
- Users must type "unlink {provider} and delete my xp" to confirm
- Same two-step flow and countdown timer as deletion modal
- Updated `SocialConnections.svelte` to use the modal instead of direct unlinking
- Clear warnings about losing rewards and XP permanently