### PR TITLE
Fix Typos in Comments

### DIFF
--- a/typescript-sdk/src/query/offchain/ucs03-channels.ts
+++ b/typescript-sdk/src/query/offchain/ucs03-channels.ts
@@ -92,7 +92,7 @@ export const getQuoteToken = async (
 
   let wrappingTokens = wrapping.value.v1_ibc_union_tokens
 
-  // if it is, quote token is the unwrapped verison of the wrapped token.
+  // if it is, quote token is the unwrapped version of the wrapped token.
   // @ts-expect-error
   if (wrappingTokens.length > 0) {
     // @ts-expect-error

--- a/typescript-sdk/src/utilities/index.ts
+++ b/typescript-sdk/src/utilities/index.ts
@@ -28,7 +28,7 @@ export function raise(error: unknown): never {
 
 /**
  * generates salts to be used on transfer submission
- * used to prevent transfer hash colissions
+ * used to prevent transfer hash collisions
  */
 export function generateSalt(): Hex {
   const rawSalt = new Uint8Array(32)

--- a/unionvisor/src/bundle.rs
+++ b/unionvisor/src/bundle.rs
@@ -159,7 +159,7 @@ impl Bundle {
         self.path.join("genesis.json")
     }
 
-    /// Construct the path to the fallback verison, based on the [`BundleMeta`]
+    /// Construct the path to the fallback version, based on the [`BundleMeta`]
     pub fn fallback_path(&self) -> Result<ValidVersionPath, ValidateVersionPathError> {
         let fallback_version = &self.meta.fallback_version.clone();
         self.path_to(fallback_version).validate()


### PR DESCRIPTION


**Description:**  
This pull request corrects minor typos in code comments across TypeScript and Rust files:
- Fixes the spelling of "version" and "collisions" in comments for better clarity and consistency.
