### PR TITLE
fix: Prevent Recursive Call in Update module.go

### DIFF
--- a/11-cometbls/module.go
+++ b/11-cometbls/module.go
@@ -41,7 +41,7 @@ func (AppModuleBasic) RegisterLegacyAminoCodec(*codec.LegacyAmino) {}
 // RegisterInterfaces registers module concrete types into protobuf Any. This allows core IBC
 // to unmarshal tendermint light client types.
 func (AppModuleBasic) RegisterInterfaces(registry codectypes.InterfaceRegistry) {
-	RegisterInterfaces(registry)
+    RegisterCometBLSInterfaces(registry)
 }
 
 // DefaultGenesis performs a no-op. Genesis is not supported for the tendermint light client.


### PR DESCRIPTION
Summary
This PR fixes a recursive call bug in the RegisterInterfaces method of the AppModuleBasic struct.

What was the issue?
Previously, the method was defined as: func (AppModuleBasic) RegisterInterfaces(registry codectypes.InterfaceRegistry) {
    RegisterInterfaces(registry)
This leads to an infinite recursive call, as the method was calling itself instead of the intended package-level RegisterInterfaces function. This results in a stack overflow panic at runtime.

What was changed?
Renamed the package-level RegisterInterfaces function to RegisterCometBLSInterfaces and updated the method accordingly: func (AppModuleBasic) RegisterInterfaces(registry codectypes.InterfaceRegistry) {
    RegisterCometBLSInterfaces(registry)

Why is this important?
Prevents runtime panic due to infinite recursion

Makes the code more maintainable and less prone to name shadowing errors