### PR TITLE
Fix light client status to properly handle frozen state

### DIFF
--- a/cosmwasm/ibc-union/lightclient/sui/src/client.rs
+++ b/cosmwasm/ibc-union/lightclient/sui/src/client.rs
@@ -81,9 +81,15 @@ impl IbcClient for SuiLightClient {
 
     fn status(
         _ctx: ibc_union_light_client::IbcClientCtx<Self>,
-        _client_state: &Self::ClientState,
+        client_state: &Self::ClientState,
     ) -> Status {
-        Status::Active
+        let ClientState::V1(cs) = client_state;
+
+        if cs.frozen_height != 0 {
+            Status::Frozen
+        } else {
+            Status::Active
+        }
     }
 
     fn verify_creation(


### PR DESCRIPTION
Light clients were incorrectly returning Status::Active regardless of whether the client was frozen or not. Fixed the status method to return Status::Frozen when the frozen_height of the client state is not 0.