### PR TITLE
chore: remove redundant words in comment

### DIFF
--- a/docs/src/styles/twoslash.css
+++ b/docs/src/styles/twoslash.css
@@ -176,7 +176,7 @@ pre .query {
   /* we need to place a fake and un-selectable copy of the error which _isn't_ broken out
   /* behind the actual error message.
 
-  /* This sections keeps both of those two in in sync  */
+  /* This sections keeps both of those two in sync  */
 
 pre .error,
 pre .error-behind {

--- a/lib/ssz/src/tree_hash/merkle_hasher.rs
+++ b/lib/ssz/src/tree_hash/merkle_hasher.rs
@@ -151,7 +151,7 @@ fn get_parent(i: usize) -> usize {
 ///
 /// It is a logic error to provide `i == 0`.
 ///
-/// E.g., if `i` is 1, depth is 0. If `i` is is 1, depth is 1.
+/// E.g., if `i` is 1, depth is 0. If `i` is 1, depth is 1.
 fn get_depth(i: usize) -> usize {
     let total_bits = mem::size_of::<usize>() * 8;
     total_bits - i.leading_zeros() as usize - 1

--- a/lib/unionlabs/src/aptos/account.rs
+++ b/lib/unionlabs/src/aptos/account.rs
@@ -18,7 +18,7 @@ impl AccountAddress {
     /// Returns whether the address is a "special" address. Addresses are considered
     /// special if the first 63 characters of the hex string are zero. In other words,
     /// an address is special if the first 31 bytes are zero and the last byte is
-    /// smaller than than `0b10000` (16). In other words, special is defined as an address
+    /// smaller than `0b10000` (16). In other words, special is defined as an address
     /// that matches the following regex: `^0x0{63}[0-9a-f]$`. In short form this means
     /// the addresses in the range from `0x0` to `0xf` (inclusive) are special.
     ///

--- a/unionvisor/src/bundle.rs
+++ b/unionvisor/src/bundle.rs
@@ -149,7 +149,7 @@ impl Bundle {
         )
     }
 
-    /// Provides the full path the the versions directory
+    /// Provides the full path the versions directory
     pub fn versions_path(&self) -> PathBuf {
         self.path.join(&self.meta.versions_directory)
     }


### PR DESCRIPTION
remove redundant words in comment