### PR TITLE
Fix: update broken CometBLS light client link in new-chain docs

### DIFF
--- a/docs/src/content/docs/connect/new-chain.mdx
+++ b/docs/src/content/docs/connect/new-chain.mdx
@@ -20,7 +20,7 @@ If your chain is not yet [connected to Union](/protocol/chains/overview/), then 
 You'll need to upload two contracts:
 
 - [union-ibc](https://github.com/unionlabs/union/tree/main/cosmwasm/union-ibc/core): Union's modular IBC stack.
-- [cometbls-light-client](https://github.com/unionlabs/union/tree/main/cosmwasm/union-ibc/lightclient/cometbls): Light-client tracking [CometBLS](/architecture/cometbls) consensus.
+- [cometbls-light-client](https://github.com/unionlabs/union/tree/main/cosmwasm/ibc-union/lightclient/cometbls): Light-client tracking [CometBLS](/architecture/cometbls) consensus.
 
 
 ### Cosmos


### PR DESCRIPTION
Updated the documentation link for the CometBLS light client in docs/src/content/docs/connect/new-chain.mdx to point to the correct path (cosmwasm/ibc-union/lightclient/cometbls) on GitHub. This resolves a 404 error and ensures users are directed to the current implementation directory. No other content was changed.