### PR TITLE
Fix CommunityTax to 2% in v1_2_0 upgrade

### DIFF
--- a/uniond/app/upgrades/v1_2_0/upgrade.go
+++ b/uniond/app/upgrades/v1_2_0/upgrade.go
@@ -220,8 +220,8 @@ func CreateUpgradeHandler(mm *module.Manager, configurator module.Configurator, 
 		if err != nil {
 			return nil, err
 		}
-		// set community tax to 100% to take all rewards
-		distrParams.CommunityTax = math.LegacyMustNewDecFromStr("1")
+		// Set CommunityTax to 2% to ensure validators and delegators receive staking rewards.
+		distrParams.CommunityTax = math.LegacyMustNewDecFromStr("0.02")
 		keepers.DistributionKeeper.Params.Set(ctx, distrParams)
 
 		// Update x/feemarket


### PR DESCRIPTION
I modified the communityTax reward to be 0.02 which is 2% from the original 1 which means 100% because setting the communityTax to 100% means all staking rewards will be directed to community which is unusual for a Blockchain as it disincentivizes staking and validator participation which are critical for the security and decetralization of the network.

So I changed to a reasonable amount of 2% as most Cosmos SDK chains set communityTax between 2-10%.

But if this is temporary please add a clear comment to revert it post-TGE Example:
// Set CommunityTax to 100% temporarily for TGE; to be reverted to 2% via governance post-TGE distrParams.CommunityTax = math.LegacyMustNewDecFromStr("1")