### PR TITLE
Stub implementation for `misbehaviour` function in `SuiLightClient`

### DIFF
--- a/cosmwasm/ibc-union/lightclient/sui/src/client.rs
+++ b/cosmwasm/ibc-union/lightclient/sui/src/client.rs
@@ -158,15 +158,20 @@ impl IbcClient for SuiLightClient {
 
         Ok(state_update)
     }
+/// Misbehaviour verification is currently not supported for SuiLightClient.
+/// This function is required by the IbcClient trait, but left unimplemented.
+/// A proper implementation would require double-signing detection, header checks, etc.
+fn misbehaviour(
+    _ctx: ibc_union_light_client::IbcClientCtx<Self>,
+    _caller: cosmwasm_std::Addr,
+    _misbehaviour: Self::Misbehaviour,
+    _relayer: cosmwasm_std::Addr,
+) -> Result<Self::ClientState, ibc_union_light_client::IbcClientError<Self>> {
+    Err(ibc_union_light_client::IbcClientError::custom(
+        "misbehaviour verification is not implemented for SuiLightClient",
+    ))
+}
 
-    fn misbehaviour(
-        _ctx: ibc_union_light_client::IbcClientCtx<Self>,
-        _caller: cosmwasm_std::Addr,
-        _misbehaviour: Self::Misbehaviour,
-        _relayer: cosmwasm_std::Addr,
-    ) -> Result<Self::ClientState, ibc_union_light_client::IbcClientError<Self>> {
-        todo!()
-    }
 }
 
 pub enum CommitteeStore {}


### PR DESCRIPTION
Added a stub implementation for the `misbehaviour` function required by the `IbcClient` trait in `SuiLightClient`.

The function now returns a custom error message indicating that misbehaviour verification is not supported for this light client.

This avoids build failures caused by the `todo!()` macro and clarifies the intended behavior for future contributors.
