### PR TITLE
feat(cosmwasm): introduce escrow vault for fungibility layer

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4666,6 +4666,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "cw-escrow-vault"
+version = "0.0.0"
+dependencies = [
+ "bincode 2.0.1",
+ "cosmwasm-schema 2.2.2",
+ "cosmwasm-std 2.2.2",
+ "cw20",
+ "depolama",
+ "embed-commit",
+ "frissitheto",
+ "hex-literal",
+ "ibc-union-spec",
+ "serde",
+ "thiserror 2.0.12",
+ "ucs03-zkgm",
+ "unionlabs",
+]
+
+[[package]]
 name = "cw-multi-test"
 version = "2.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -248,6 +248,7 @@ members = [
   "cosmwasm/osmosis-tokenfactory-token-minter",
   "cosmwasm/cw20-token-minter",
   "cosmwasm/cw-account",
+  "cosmwasm/cw-escrow-vault",
   "cosmwasm/ucs03-zkgm-token-minter-api",
   "cosmwasm/osmosis-tokenfactory-token-owner",
   "cosmwasm/cw20-base",
@@ -380,7 +381,9 @@ ibc-union-msg          = { path = "cosmwasm/ibc-union/core/msg", default-feature
 
 frissitheto = { path = "lib/frissitheto", default-features = false }
 
-cw-account                        = { path = "cosmwasm/cw-account", default-features = false }
+cw-account      = { path = "cosmwasm/cw-account", default-features = false }
+cw-escrow-vault = { path = "cosmwasm/cw-escrow-vault", default-features = false }
+
 cw20-base                         = { path = "cosmwasm/cw20-base", default-features = false }
 cw20-token-minter                 = { path = "cosmwasm/cw20-token-minter", default-features = false }
 osmosis-tokenfactory-token-minter = { path = "cosmwasm/osmosis-tokenfactory-token-minter", default-features = false }

--- a/cosmwasm/cosmwasm.nix
+++ b/cosmwasm/cosmwasm.nix
@@ -908,6 +908,8 @@ _: {
 
       cw-account = crane.buildWasmContract "cosmwasm/cw-account" { };
 
+      cw-escrow-vault = crane.buildWasmContract "cosmwasm/cw-escrow-vault" { };
+
       cw20-base = crane.buildWasmContract "cosmwasm/cw20-base" { };
 
       cw20-wrapped-tokenfactory = crane.buildWasmContract "cosmwasm/cw20-wrapped-tokenfactory" { };
@@ -967,6 +969,7 @@ _: {
             ibc-union
             multicall
             cw-account
+            cw-escrow-vault
             ;
           cosmwasm-scripts =
             {

--- a/cosmwasm/cw-escrow-vault/Cargo.toml
+++ b/cosmwasm/cw-escrow-vault/Cargo.toml
@@ -1,0 +1,32 @@
+[package]
+name    = "cw-escrow-vault"
+version = "0.0.0"
+
+authors      = { workspace = true }
+edition      = { workspace = true }
+license-file = { workspace = true }
+publish      = { workspace = true }
+repository   = { workspace = true }
+
+[lib]
+crate-type = ["cdylib", "rlib"]
+
+[dependencies]
+bincode         = { workspace = true }
+cosmwasm-schema = { workspace = true }
+cosmwasm-std    = { workspace = true, features = ["cosmwasm_1_3"] }
+cw20            = "2.0.0"
+depolama        = { workspace = true }
+embed-commit    = { workspace = true }
+frissitheto     = { workspace = true }
+ibc-union-spec  = { workspace = true, features = ["serde", "ethabi", "bincode"] }
+serde           = { workspace = true, features = ["derive"] }
+thiserror       = { workspace = true }
+ucs03-zkgm      = { workspace = true, features = ["library"] }
+unionlabs       = { workspace = true, features = ["schemars", "bincode"] }
+
+[dev-dependencies]
+hex-literal = { workspace = true }
+
+[lints]
+workspace = true

--- a/cosmwasm/cw-escrow-vault/README.md
+++ b/cosmwasm/cw-escrow-vault/README.md
@@ -1,0 +1,140 @@
+# CW Escrow Vault
+
+## Overview
+
+The CW Escrow Vault is a CosmWasm smart contract that acts as a solver in the UCS03 ZKGM protocol, enabling fungible cross-chain asset transfers between Cosmos and EVM chains. It manages the escrow and release of native and CW20 tokens, serving as the Cosmos-side counterparty to the U.sol contract on EVM chains.
+
+## Purpose in the ZKGM Protocol
+
+In the UCS03 ZKGM protocol, cross-chain transfers use a sophisticated filling mechanism where:
+
+1. **Market Makers/Solvers** can fill orders by providing liquidity on the destination chain
+2. **Acknowledgements** carry information about who filled the order (the beneficiary)
+3. **Base tokens** are sent to the filler as compensation on the source chain
+
+The CW Escrow Vault implements the **ISolver interface** to participate as an automated market maker in this system, creating a fungible lane between chains.
+
+## Architecture
+
+### Key Components
+
+- **CW Escrow Vault (Cosmos)**: This contract - acts as a solver that fills orders with escrowed tokens
+- **U.sol (EVM)**: The EVM counterpart - mints/burns synthetic tokens and acts as a solver
+- **UCS03 ZKGM Protocol**: The cross-chain messaging protocol with open filling mechanism
+
+### Fungible Lane Configuration
+
+Both vaults are configured as solvers where:
+
+- For Cosmos → EVM: Escrow Vault stores U.sol address as `counterparty_beneficiary`
+- For EVM → Cosmos: Escrow Vault returns zero address to trigger token burning
+- When filling orders, the vault returns the appropriate beneficiary in the acknowledgement
+- The source chain either sends base tokens to the beneficiary or burns them (if beneficiary is 0)
+
+## Transfer Flow
+
+### Forward Transfer (Cosmos → EVM)
+
+1. **User initiates transfer**: Sends native/CW20 tokens via ZKGM with a TokenOrderV2
+2. **Packet sent to EVM**: ZKGM sends packet across IBC to the destination chain
+3. **U.sol fills the order**:
+   - Mints synthetic tokens to the receiver
+   - Returns CW Escrow Vault address as beneficiary in acknowledgement
+4. **Base tokens sent to vault**: ZKGM on Cosmos sends base tokens to the Escrow Vault
+5. **Tokens held in escrow**: Vault holds tokens for future reverse transfers
+
+### Reverse Transfer (EVM → Cosmos)
+
+1. **User initiates transfer**: Sends synthetic tokens on EVM via ZKGM with a TokenOrderV2
+2. **Packet sent to Cosmos**: ZKGM sends packet across IBC to the destination chain
+3. **Escrow Vault fills the order**:
+   - Releases escrowed tokens to the receiver
+   - Returns zero address (0x0) as beneficiary in acknowledgement
+4. **Base tokens burned**: ZKGM on EVM burns the base tokens (synthetic tokens) since beneficiary is 0x0
+5. **Balance maintained**: Burning on EVM and releasing from escrow on Cosmos maintains token supply
+
+## Implementation Details
+
+### Solver Interface
+
+The contract implements the ZKGM solver interface:
+
+```rust
+pub enum QueryMsg {
+    IsSolver,           // Returns success to indicate solver capability
+    AllowMarketMakers,  // Returns true to allow other market makers
+}
+
+pub enum ExecuteMsg {
+    DoSolve {
+        packet: Packet,
+        order: CwTokenOrderV2,
+        path: Uint256,
+        caller: Addr,
+        relayer: Addr,
+        relayer_msg: Bytes,
+        intent: bool,
+    }
+}
+```
+
+### Order Filling Logic
+
+When `DoSolve` is called:
+
+1. **Intent Validation**: If flagged as intent, checks packet hash is whitelisted
+2. **Lane Validation**: Verifies a fungible lane exists for the (path, channel, token) tuple
+3. **Fee Distribution**:
+   - Calculates fee as `base_amount - quote_amount`
+   - Sends fee to the relayer
+4. **Token Transfer**: Sends `quote_amount` to the receiver
+5. **Return Beneficiary**: Returns the configured `counterparty_beneficiary` address
+
+### Configuration
+
+#### Setting Fungible Counterparties
+
+```rust
+SetFungibleCounterparty {
+    path: Uint256,                    // Routing path identifier
+    channel_id: ChannelId,            // IBC channel
+    base_token: Bytes,               // Token on source chain
+    counterparty_beneficiary: Bytes, // U.sol address on EVM
+    escrowed_denom: String,          // Local token to use for filling
+}
+```
+
+#### Intent Whitelisting
+
+```rust
+WhitelistIntents {
+    hashes_whitelist: Vec<(H256, bool)>, // Packet hashes and approval
+}
+```
+
+## Security Features
+
+- **Admin-only configuration**: Only admin can set fungible lanes and whitelist intents
+- **ZKGM-only execution**: Only the ZKGM contract can call `DoSolve`
+- **Lane validation**: Orders are only filled for configured fungible lanes
+- **Intent protection**: Intent-based orders require whitelisting
+
+## Benefits
+
+1. **Capital Efficiency**: No need for separate liquidity pools - uses escrowed tokens
+2. **Instant Filling**: Acts as always-available market maker for configured lanes
+3. **Fee Incentives**: Relayers earn fees for submitting packets
+4. **True Fungibility**: Maintains 1:1 backing between native and synthetic tokens
+5. **Trustless Operation**: Smart contract automation eliminates counterparty risk
+
+## Integration
+
+To integrate with the Escrow Vault:
+
+1. **Deploy the vault** with admin and ZKGM contract addresses
+2. **Configure fungible lanes** for each token and channel pair
+3. **Set counterparty beneficiary** to the corresponding vault on the other chain
+4. **Optionally fund the vault** with tokens for filling orders
+5. **Optionally whitelist intents** for pre-approved transfers
+
+The vault will automatically participate as a solver in the ZKGM protocol, filling orders and maintaining fungibility between chains.

--- a/cosmwasm/cw-escrow-vault/src/contract.rs
+++ b/cosmwasm/cw-escrow-vault/src/contract.rs
@@ -1,0 +1,190 @@
+use cosmwasm_schema::cw_serde;
+use cosmwasm_std::{
+    entry_point, to_json_binary, wasm_execute, BankMsg, Binary, Coin, CosmosMsg, Deps, DepsMut,
+    Env, MessageInfo, Response, StdResult, Uint128,
+};
+use cw20::Cw20ExecuteMsg;
+use depolama::StorageExt;
+use frissitheto::UpgradeMsg;
+use ibc_union_spec::path::commit_packets;
+use unionlabs::primitives::U256;
+
+use crate::{
+    error::Error,
+    msg::{ExecuteMsg, InstantiateMsg, QueryMsg},
+    state::{Admin, FungibleCounterparty, FungibleLane, IntentWhitelist, Zkgm},
+};
+
+#[entry_point]
+pub fn instantiate(_: DepsMut, _: Env, _: MessageInfo, _: ()) -> StdResult<Response> {
+    panic!("this contract cannot be instantiated directly, but must be migrated from an existing instantiated contract.");
+}
+
+#[cw_serde]
+pub struct MigrateMsg {}
+
+#[entry_point]
+pub fn migrate(
+    deps: DepsMut,
+    _: Env,
+    msg: UpgradeMsg<InstantiateMsg, MigrateMsg>,
+) -> Result<Response, Error> {
+    msg.run(
+        deps,
+        |deps, msg| {
+            deps.storage.write_item::<Admin>(&msg.admin);
+            Ok((Response::new(), None))
+        },
+        |_, _, _| Ok((Response::default(), None)),
+    )
+}
+
+fn ensure_zkgm(deps: Deps, info: &MessageInfo) -> Result<(), Error> {
+    let admin = deps.storage.read_item::<Zkgm>()?;
+    if info.sender != admin {
+        return Err(Error::OnlyZkgm);
+    }
+    Ok(())
+}
+
+fn ensure_admin(deps: Deps, info: &MessageInfo) -> Result<(), Error> {
+    let admin = deps.storage.read_item::<Admin>()?;
+    if info.sender != admin {
+        return Err(Error::OnlyAdmin);
+    }
+    Ok(())
+}
+
+#[entry_point]
+pub fn execute(
+    deps: DepsMut,
+    _env: Env,
+    info: MessageInfo,
+    msg: ExecuteMsg,
+) -> Result<Response, Error> {
+    match msg {
+        ExecuteMsg::WhitelistIntents { hashes_whitelist } => {
+            ensure_admin(deps.as_ref(), &info)?;
+            for (packet_hash, allowed) in hashes_whitelist {
+                deps.storage
+                    .write::<IntentWhitelist>(&packet_hash, &allowed);
+            }
+            Ok(Response::new())
+        }
+        ExecuteMsg::SetFungibleCounterparty {
+            path,
+            channel_id,
+            base_token,
+            counterparty_beneficiary,
+            escrowed_denom,
+        } => {
+            ensure_admin(deps.as_ref(), &info)?;
+            let is_cw20 = deps
+                .querier
+                .query_wasm_contract_info(escrowed_denom.clone())
+                .is_ok();
+            deps.storage.write::<FungibleCounterparty>(
+                &(
+                    U256::from_be_bytes(path.to_be_bytes()),
+                    channel_id,
+                    base_token,
+                ),
+                &FungibleLane {
+                    counterparty_beneficiary,
+                    escrowed_denom,
+                    is_cw20,
+                },
+            );
+            Ok(Response::new())
+        }
+        ExecuteMsg::DoSolve {
+            packet,
+            order,
+            path,
+            caller: _,
+            relayer,
+            relayer_msg: _,
+            intent,
+        } => {
+            ensure_zkgm(deps.as_ref(), &info)?;
+            if intent {
+                let whitelisted = deps
+                    .storage
+                    .read::<IntentWhitelist>(&commit_packets(&[packet.clone()]))
+                    .unwrap_or(false);
+                if !whitelisted {
+                    return Err(Error::IntentMustBeWhitelisted);
+                }
+            }
+
+            let fungible_lane = deps
+                .storage
+                .maybe_read::<FungibleCounterparty>(&(
+                    U256::from_be_bytes(path.to_be_bytes()),
+                    packet.destination_channel_id,
+                    order.base_token,
+                ))?
+                .ok_or_else(|| Error::LaneIsNotFungible {
+                    channel_id: packet.destination_channel_id,
+                })?;
+
+            let mut messages = Vec::<CosmosMsg>::with_capacity(2);
+            let mut push_transfer = move |to, amount: Uint128| -> StdResult<()> {
+                if !amount.is_zero() {
+                    if fungible_lane.is_cw20 {
+                        messages.push(
+                            wasm_execute(
+                                fungible_lane.escrowed_denom.clone(),
+                                &Cw20ExecuteMsg::Transfer {
+                                    recipient: to,
+                                    amount,
+                                },
+                                vec![],
+                            )?
+                            .into(),
+                        );
+                    } else {
+                        messages.push(
+                            BankMsg::Send {
+                                to_address: to,
+                                amount: vec![Coin::new(
+                                    amount,
+                                    fungible_lane.escrowed_denom.clone(),
+                                )],
+                            }
+                            .into(),
+                        );
+                    }
+                }
+                Ok(())
+            };
+
+            let fee = order
+                .base_amount
+                .checked_sub(order.quote_amount)
+                .map_err(|_| Error::BaseAmountMustCoverQuoteAmount)?;
+            push_transfer(relayer.into(), fee.try_into().expect("impossible"))?;
+
+            let receiver = deps
+                .api
+                .addr_validate(
+                    str::from_utf8(order.receiver.as_ref()).map_err(|_| Error::InvalidReceiver)?,
+                )
+                .map_err(|_| Error::InvalidReceiver)?;
+            push_transfer(
+                receiver.into(),
+                order.quote_amount.try_into().expect("impossible"),
+            )?;
+
+            Ok(Response::new().set_data(fungible_lane.counterparty_beneficiary.to_vec()))
+        }
+    }
+}
+
+#[entry_point]
+pub fn query(_: Deps, _: Env, msg: QueryMsg) -> StdResult<Binary> {
+    match msg {
+        QueryMsg::IsSolver => to_json_binary(&()),
+        QueryMsg::AllowMarketMakers => to_json_binary(&true),
+    }
+}

--- a/cosmwasm/cw-escrow-vault/src/error.rs
+++ b/cosmwasm/cw-escrow-vault/src/error.rs
@@ -1,0 +1,30 @@
+use cosmwasm_std::StdError;
+use frissitheto::UpgradeError;
+use ibc_union_spec::ChannelId;
+
+#[derive(Debug, thiserror::Error)]
+pub enum Error {
+    #[error(transparent)]
+    StdError(#[from] StdError),
+
+    #[error("migration error: {0}")]
+    Migrate(#[from] UpgradeError),
+
+    #[error("sender is not admin")]
+    OnlyAdmin,
+
+    #[error("sender is not zkgm")]
+    OnlyZkgm,
+
+    #[error("base amount must cover quote amount")]
+    BaseAmountMustCoverQuoteAmount,
+
+    #[error("receiver must be a valid bech32 address")]
+    InvalidReceiver,
+
+    #[error("intent packet hashes must be whitelisted to be executed")]
+    IntentMustBeWhitelisted,
+
+    #[error("the lane has not been configured to be fungible")]
+    LaneIsNotFungible { channel_id: ChannelId },
+}

--- a/cosmwasm/cw-escrow-vault/src/lib.rs
+++ b/cosmwasm/cw-escrow-vault/src/lib.rs
@@ -1,0 +1,4 @@
+pub mod contract;
+pub mod error;
+pub mod msg;
+pub mod state;

--- a/cosmwasm/cw-escrow-vault/src/msg.rs
+++ b/cosmwasm/cw-escrow-vault/src/msg.rs
@@ -1,0 +1,41 @@
+use cosmwasm_schema::cw_serde;
+use cosmwasm_std::{Addr, Uint256};
+use depolama::Bytes;
+use ibc_union_spec::{ChannelId, Packet};
+use ucs03_zkgm::com::CwTokenOrderV2;
+use unionlabs::primitives::H256;
+
+#[cw_serde]
+pub struct InstantiateMsg {
+    pub zkgm: Addr,
+    pub admin: Addr,
+}
+
+#[cw_serde]
+pub enum ExecuteMsg {
+    WhitelistIntents {
+        hashes_whitelist: Vec<(H256, bool)>,
+    },
+    SetFungibleCounterparty {
+        path: Uint256,
+        channel_id: ChannelId,
+        base_token: Bytes,
+        counterparty_beneficiary: Bytes,
+        escrowed_denom: String,
+    },
+    DoSolve {
+        packet: Packet,
+        order: Box<CwTokenOrderV2>,
+        path: Uint256,
+        caller: Addr,
+        relayer: Addr,
+        relayer_msg: Bytes,
+        intent: bool,
+    },
+}
+
+#[cw_serde]
+pub enum QueryMsg {
+    IsSolver,
+    AllowMarketMakers,
+}

--- a/cosmwasm/cw-escrow-vault/src/state.rs
+++ b/cosmwasm/cw-escrow-vault/src/state.rs
@@ -1,0 +1,80 @@
+use cosmwasm_std::{Addr, StdError, StdResult};
+use depolama::{key::KeyCodecViaEncoding, value::ValueCodecViaEncoding, Prefix, Store, ValueCodec};
+use ibc_union_spec::ChannelId;
+use unionlabs::{
+    encoding::Bincode,
+    primitives::{Bytes, H256, U256},
+};
+
+pub enum IntentWhitelist {}
+impl Store for IntentWhitelist {
+    const PREFIX: Prefix = Prefix::new(b"intent_whitelist");
+
+    type Key = H256;
+    type Value = bool;
+}
+impl KeyCodecViaEncoding for IntentWhitelist {
+    type Encoding = Bincode;
+}
+impl ValueCodecViaEncoding for IntentWhitelist {
+    type Encoding = Bincode;
+}
+
+#[derive(bincode::Encode, bincode::Decode)]
+pub struct FungibleLane {
+    pub counterparty_beneficiary: Bytes,
+    pub escrowed_denom: String,
+    pub is_cw20: bool,
+}
+
+pub enum FungibleCounterparty {}
+impl Store for FungibleCounterparty {
+    const PREFIX: Prefix = Prefix::new(b"fungible_counterparty");
+
+    type Key = (U256, ChannelId, Bytes);
+    type Value = FungibleLane;
+}
+impl KeyCodecViaEncoding for FungibleCounterparty {
+    type Encoding = Bincode;
+}
+impl ValueCodecViaEncoding for FungibleCounterparty {
+    type Encoding = Bincode;
+}
+
+pub enum Admin {}
+impl Store for Admin {
+    const PREFIX: Prefix = Prefix::new(b"admin");
+
+    type Key = ();
+    type Value = Addr;
+}
+impl ValueCodec<Addr> for Admin {
+    fn encode_value(value: &Addr) -> Bytes {
+        value.as_bytes().into()
+    }
+
+    fn decode_value(raw: &Bytes) -> StdResult<Addr> {
+        String::from_utf8(raw.to_vec())
+            .map(Addr::unchecked)
+            .map_err(|e| StdError::generic_err(format!("invalid value: {e}")))
+    }
+}
+
+pub enum Zkgm {}
+impl Store for Zkgm {
+    const PREFIX: Prefix = Prefix::new(b"zkgm");
+
+    type Key = ();
+    type Value = Addr;
+}
+impl ValueCodec<Addr> for Zkgm {
+    fn encode_value(value: &Addr) -> Bytes {
+        value.as_bytes().into()
+    }
+
+    fn decode_value(raw: &Bytes) -> StdResult<Addr> {
+        String::from_utf8(raw.to_vec())
+            .map(Addr::unchecked)
+            .map_err(|e| StdError::generic_err(format!("invalid value: {e}")))
+    }
+}

--- a/cosmwasm/ibc-union/app/ucs03-zkgm/src/com.rs
+++ b/cosmwasm/ibc-union/app/ucs03-zkgm/src/com.rs
@@ -1,6 +1,6 @@
 use alloy_primitives::U256;
+use cosmwasm_schema::cw_serde;
 use cosmwasm_std::Uint256;
-use serde::{Deserialize, Serialize};
 use unionlabs::primitives::Bytes;
 
 pub const INSTR_VERSION_0: u8 = 0x00;
@@ -165,8 +165,7 @@ alloy_sol_types::sol! {
     }
 }
 
-#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
-#[serde(deny_unknown_fields, rename_all = "snake_case")]
+#[cw_serde]
 pub struct CwTokenOrderV2 {
     pub sender: Bytes,
     pub receiver: Bytes,

--- a/cosmwasm/ibc-union/core/src/state.rs
+++ b/cosmwasm/ibc-union/core/src/state.rs
@@ -1,7 +1,10 @@
 use std::{collections::BTreeSet, marker::PhantomData};
 
 use cosmwasm_std::{Addr, StdError, StdResult};
-use depolama::{value::ValueCodecViaEncoding, KeyCodec, Prefix, Store, ValueCodec};
+use depolama::{
+    value::{ValueCodecViaEncoding, ValueUnitEncoding},
+    KeyCodec, Prefix, Store, ValueCodec,
+};
 use ibc_union_spec::{Channel, ChannelId, ClientId, Connection, ConnectionId};
 use unionlabs::{
     encoding::Bincode,
@@ -386,15 +389,8 @@ impl KeyCodec<Addr> for WhitelistedRelayers {
             .map_err(|e| StdError::generic_err(format!("invalid key: {e}")))
     }
 }
-
-impl ValueCodec<()> for WhitelistedRelayers {
-    fn encode_value(_: &()) -> Bytes {
-        Bytes::new(&[0])
-    }
-
-    fn decode_value(_: &Bytes) -> StdResult<()> {
-        Ok(())
-    }
+impl ValueCodecViaEncoding for WhitelistedRelayers {
+    type Encoding = ValueUnitEncoding;
 }
 
 fn read_fixed_bytes<const N: usize>(raw: &Bytes) -> StdResult<[u8; N]> {

--- a/lib/depolama/src/key.rs
+++ b/lib/depolama/src/key.rs
@@ -1,4 +1,5 @@
 use cosmwasm_std::{StdError, StdResult};
+use unionlabs_encoding::{Decode, DecodeAs, Encode, EncodeAs, Encoding};
 use unionlabs_primitives::Bytes;
 
 use crate::Store;
@@ -27,22 +28,6 @@ pub trait KeyCodec<Key> {
     fn decode_key(raw: &Bytes) -> StdResult<Key>;
 }
 
-impl<T: Store<Key = ()>> KeyCodec<()> for T {
-    fn encode_key((): &()) -> Bytes {
-        [].into()
-    }
-
-    fn decode_key(raw: &Bytes) -> StdResult<()> {
-        if raw.is_empty() {
-            Ok(())
-        } else {
-            Err(StdError::generic_err(format!(
-                "key must be empty, found {raw}"
-            )))
-        }
-    }
-}
-
 /// The raw store key for the store for the given key.
 pub fn raw_key<S: Store>(key: &S::Key) -> Bytes {
     S::PREFIX
@@ -50,4 +35,81 @@ pub fn raw_key<S: Store>(key: &S::Key) -> Bytes {
         .copied()
         .chain(S::encode_key(key))
         .collect()
+}
+
+/// Encode the stored key via the specified [`Encoding`].
+///
+/// ```rust
+/// # use depolama::{Prefix, Store, key::KeyCodecViaEncoding, value::ValueCodecViaEncoding, key::KeyUnitEncoding};
+/// # use unionlabs_encoding::{Decode, Encode ,Encoding};
+/// # enum EthAbi {}
+/// # impl Encoding for EthAbi {}
+/// # impl Encode<EthAbi> for &'_ Struct {
+/// #     fn encode(self) -> Vec<u8> { todo!() }
+/// # }
+/// # impl Decode<EthAbi> for Struct {
+/// #     type Error = ();
+/// #     fn decode(_: &[u8]) -> Result<Self, Self::Error> { todo!() }
+/// # }
+/// struct Struct {
+///     // some fields
+/// }
+///
+/// enum EthAbiStore {}
+///
+/// impl Store for EthAbiStore {
+///     const PREFIX: Prefix = Prefix::new(b"prefix");
+///
+///     type Key = Struct;
+///     type Value = ();
+/// }
+///
+/// impl ValueCodecViaEncoding for EthAbiStore {
+///     type Encoding = KeyUnitEncoding;
+/// }
+/// impl KeyCodecViaEncoding for EthAbiStore {
+///     type Encoding = EthAbi;
+/// }
+/// ```
+pub trait KeyCodecViaEncoding: Store<Key: Decode<Self::Encoding>>
+where
+    for<'a> &'a Self::Key: Encode<Self::Encoding>,
+{
+    /// The encoding to use.
+    type Encoding: Encoding;
+}
+
+impl<S> KeyCodec<S::Key> for S
+where
+    S: KeyCodecViaEncoding<Key: Decode<S::Encoding>>,
+    for<'a> &'a S::Key: Encode<S::Encoding>,
+{
+    fn encode_key(value: &S::Key) -> Bytes {
+        value.encode_as::<S::Encoding>().into()
+    }
+
+    fn decode_key(raw: &Bytes) -> StdResult<S::Key> {
+        <S::Key>::decode_as::<S::Encoding>(raw)
+            .map_err(|e| StdError::generic_err(format!("unable to decode: {e:?}")))
+    }
+}
+
+/// Default unit key encoding to avoid any dependency to an encoding.
+pub struct KeyUnitEncoding;
+
+impl Encoding for KeyUnitEncoding {}
+impl Encode<KeyUnitEncoding> for &() {
+    fn encode(self) -> Vec<u8> {
+        vec![]
+    }
+}
+impl Decode<KeyUnitEncoding> for () {
+    type Error = ();
+    fn decode(_: &[u8]) -> Result<Self, Self::Error> {
+        Ok(())
+    }
+}
+
+impl<T: Store<Key = ()>> KeyCodecViaEncoding for T {
+    type Encoding = KeyUnitEncoding;
 }

--- a/lib/depolama/src/value.rs
+++ b/lib/depolama/src/value.rs
@@ -78,3 +78,24 @@ where
             .map_err(|e| StdError::generic_err(format!("unable to decode: {e:?}")))
     }
 }
+
+/// Default unit key encoding to avoid any dependency to an encoding. We encode
+/// a single byte because `CosmWasm` has limitations and make it impossible to
+/// differentiate non existing key if the value is empty.
+pub struct ValueUnitEncoding;
+
+impl Encoding for ValueUnitEncoding {}
+impl Encode<ValueUnitEncoding> for &() {
+    fn encode(self) -> Vec<u8> {
+        vec![0]
+    }
+}
+impl Decode<ValueUnitEncoding> for () {
+    type Error = ();
+    fn decode(x: &[u8]) -> Result<Self, Self::Error> {
+        match x {
+            &[0] => Ok(()),
+            _ => Err(()),
+        }
+    }
+}


### PR DESCRIPTION
  A CosmWasm contract that acts as a solver in the zkgm protocol, enabling fungible token transfers across IBC channels by managing escrowed assets.

  Key Features

  - Dual Token Support: Handles both native Cosmos tokens (via BankMsg) and CW20 tokens
  - Fungible Lane Configuration: Maps (channel_id, base_token) pairs to counterparty beneficiaries for cross-chain settlement
  - Intent Whitelisting: Controls which packet hashes can be filled before finality
  - Solver Interface: Implements DoSolve to release escrowed tokens and return beneficiary addresses for acknowledgments

  How It Works

  1. Admin configures fungible lanes linking channels/tokens to counterparty beneficiaries
  2. When zkgm calls DoSolve, the contract validates the order and releases escrowed tokens
  3. Relayers receive fees (base_amount - quote_amount)
  4. Returns the counterparty beneficiary address for source chain repayment (symmetric vault)

  Security

  - Access controlled: Only zkgm can call DoSolve, only admin can configure lanes
  - Validates base_amount ≥ quote_amount to prevent underflows
  - Intent packets must be whitelisted to prevent unauthorized pre-finality fills
