### PR TITLE
Update @cosmjs__amino@0.33.1.patch

### DIFF
--- a/patches/@cosmjs__amino@0.33.1.patch
+++ b/patches/@cosmjs__amino@0.33.1.patch
@@ -1,23 +1,29 @@
-diff --git a/build/pubkeys.js b/build/pubkeys.js
-index e9844ef8c6439c1665e723ce076790e752b8442a..b130b770bf593d35ecb4473e66001ccc4ad49779 100644
---- a/build/pubkeys.js
-+++ b/build/pubkeys.js
-@@ -9,6 +9,10 @@ function isSecp256k1Pubkey(pubkey) {
-     return pubkey.type === "tendermint/PubKeySecp256k1";
- }
- exports.isSecp256k1Pubkey = isSecp256k1Pubkey;
-+function isBn254Pubkey(pubkey) {
-+    return pubkey.type === "tendermint/PubKeyBn254";
-+}
-+exports.isBn254Pubkey = isBn254Pubkey;
- exports.pubkeyType = {
-     /** @see https://github.com/tendermint/tendermint/blob/v0.33.0/crypto/ed25519/ed25519.go#L22 */
-     secp256k1: "tendermint/PubKeySecp256k1",
-@@ -16,6 +20,7 @@ exports.pubkeyType = {
-     ed25519: "tendermint/PubKeyEd25519",
-     /** @see https://github.com/tendermint/tendermint/blob/v0.33.0/crypto/sr25519/codec.go#L12 */
-     sr25519: "tendermint/PubKeySr25519",
-+    bn254: "tendermint/PubKeyBn254",
-     multisigThreshold: "tendermint/PubKeyMultisigThreshold",
- };
- function isSinglePubkey(pubkey) {
+function isSecp256k1Pubkey(pubkey) {
+    return pubkey?.type === "tendermint/PubKeySecp256k1";
+}
+exports.isSecp256k1Pubkey = isSecp256k1Pubkey;
+
+function isBn254Pubkey(pubkey) {
+    return pubkey?.type === "tendermint/PubKeyBn254";
+}
+exports.isBn254Pubkey = isBn254Pubkey;
+
+exports.pubkeyType = {
+    /** @see https://github.com/tendermint/tendermint/blob/v0.33.0/crypto/ed25519/ed25519.go#L22 */
+    secp256k1: "tendermint/PubKeySecp256k1",
+    ed25519: "tendermint/PubKeyEd25519",
+    /** @see https://github.com/tendermint/tendermint/blob/v0.33.0/crypto/sr25519/codec.go#L12 */
+    sr25519: "tendermint/PubKeySr25519",
+    bn254: "tendermint/PubKeyBn254",
+    multisigThreshold: "tendermint/PubKeyMultisigThreshold",
+};
+
+function isSinglePubkey(pubkey) {
+    return (
+        isSecp256k1Pubkey(pubkey) ||
+        isBn254Pubkey(pubkey) ||
+        pubkey?.type === "tendermint/PubKeyEd25519" ||
+        pubkey?.type === "tendermint/PubKeySr25519"
+    );
+}
+exports.isSinglePubkey = isSinglePubkey;


### PR DESCRIPTION
Add support for Bn254 public key type with null-safe checks

- Introduced `isBn254Pubkey()` function to support Tendermint Bn254 public keys.
- Added `bn254` to `pubkeyType` map.
- Used optional chaining (`pubkey?.type`) in all type check functions to avoid potential TypeErrors when input is null or undefined.

(just a novice suggestion from a novice user)