### PR TITLE
ci: bump actions/checkout to v5

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -18,7 +18,7 @@ jobs:
   check:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           lfs: true
           fetch-depth: 0

--- a/.github/workflows/deploy-app2.yml
+++ b/.github/workflows/deploy-app2.yml
@@ -32,7 +32,7 @@ jobs:
     environment: 'app2-preview'
     if: github.event_name == 'pull_request'
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           lfs: true
       - uses: cachix/install-nix-action@v31
@@ -77,7 +77,7 @@ jobs:
       ENVIRONMENT: 'preview'
     if: github.event_name == 'workflow_dispatch'
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           lfs: true
       - uses: cachix/install-nix-action@v31
@@ -105,7 +105,7 @@ jobs:
     environment: 'app2-staging'
     if: github.event_name == 'push' && github.ref == 'refs/heads/main'
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           lfs: true
       - uses: cachix/install-nix-action@v31
@@ -133,7 +133,7 @@ jobs:
     environment: 'app2-production'
     if: github.event_name == 'push' && github.ref == 'refs/heads/release/app2'
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           lfs: true
       - uses: cachix/install-nix-action@v31

--- a/.github/workflows/deploy-ceremony.yml
+++ b/.github/workflows/deploy-ceremony.yml
@@ -32,7 +32,7 @@ jobs:
     environment: 'ceremony-preview'
     if: github.event_name == 'pull_request'
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           lfs: true
       - uses: cachix/install-nix-action@v31
@@ -73,7 +73,7 @@ jobs:
       npm_config_yes: true
     if: github.event_name == 'workflow_dispatch'
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           lfs: true
       - uses: cachix/install-nix-action@v31
@@ -97,7 +97,7 @@ jobs:
     environment: 'ceremony-staging'
     if: github.event_name == 'push' && github.ref == 'refs/heads/main'
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           lfs: true
       - uses: cachix/install-nix-action@v31
@@ -121,7 +121,7 @@ jobs:
     environment: 'ceremony-production'
     if: github.event_name == 'push' && github.ref == 'refs/heads/release/ceremony'
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           lfs: true
       - uses: cachix/install-nix-action@v31

--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -35,7 +35,7 @@ jobs:
     environment: 'docs-preview'
     if: github.event_name == 'pull_request'
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           lfs: true
       - uses: cachix/install-nix-action@v31
@@ -76,7 +76,7 @@ jobs:
       npm_config_yes: true
     if: github.event_name == 'workflow_dispatch'
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           lfs: true
       - uses: cachix/install-nix-action@v31
@@ -100,7 +100,7 @@ jobs:
     environment: 'docs-production'
     if: github.event_name == 'push' && github.ref == 'refs/heads/main'
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           lfs: true
       - uses: cachix/install-nix-action@v31

--- a/.github/workflows/deploy-zkgm-dev.yml
+++ b/.github/workflows/deploy-zkgm-dev.yml
@@ -32,7 +32,7 @@ jobs:
     environment: 'zkgm-dev-preview'
     if: github.event_name == 'pull_request'
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           lfs: true
       - uses: cachix/install-nix-action@v31
@@ -73,7 +73,7 @@ jobs:
       npm_config_yes: true
     if: github.event_name == 'workflow_dispatch'
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           lfs: true
       - uses: cachix/install-nix-action@v31
@@ -97,7 +97,7 @@ jobs:
     environment: 'zkgm-dev-staging'
     if: github.event_name == 'push' && github.ref == 'refs/heads/main'
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           lfs: true
       - uses: cachix/install-nix-action@v31
@@ -121,7 +121,7 @@ jobs:
     environment: 'zkgm-dev-production'
     if: github.event_name == 'push' && github.ref == 'refs/heads/release/zkgm-dev'
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           lfs: true
       - uses: cachix/install-nix-action@v31

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -21,7 +21,7 @@ jobs:
     # only create an issue if it failed in a scheduled run
     if: github.event_name == 'schedule' && failure()
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - uses: JasonEtco/create-an-issue@v2
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release-component.yml
+++ b/.github/workflows/release-component.yml
@@ -86,7 +86,7 @@ jobs:
     needs: [eval-tag]
     runs-on: ubuntu-24.04
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           lfs: true
       - uses: cachix/install-nix-action@v30
@@ -110,7 +110,7 @@ jobs:
     needs: [eval-tag]
     runs-on: ubuntu-24.04-arm
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           lfs: true
       - uses: cachix/install-nix-action@v30
@@ -133,7 +133,7 @@ jobs:
     needs: [eval-tag]
     runs-on: ubuntu-24.04
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           lfs: true
       - uses: cachix/install-nix-action@v30
@@ -164,7 +164,7 @@ jobs:
     needs: [eval-tag]
     runs-on: ubuntu-24.04-arm
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           lfs: true
       - uses: cachix/install-nix-action@v30
@@ -258,7 +258,7 @@ jobs:
           COMPONENT: ${{ needs.eval-tag.outputs.component }}
           TAG: ${{ needs.eval-tag.outputs.version }}
         run: docker manifest push "localhost:5000/unionlabs/$COMPONENT:$TAG"
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           lfs: true
           fetch-depth: 0

--- a/.github/workflows/typescript-sdk-preview.yml
+++ b/.github/workflows/typescript-sdk-preview.yml
@@ -31,7 +31,7 @@ jobs:
     runs-on: ['ubuntu-latest']
     steps:
       - name: 'Checkout'
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           fetch-depth: 0
 

--- a/.github/workflows/typescript-sdk-publish.yml
+++ b/.github/workflows/typescript-sdk-publish.yml
@@ -33,7 +33,7 @@ jobs:
       id-token: write
     steps:
       - name: 'Checkout'
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: 'Setup bun'
         uses: oven-sh/setup-bun@v2


### PR DESCRIPTION
GitHub-hosted runners now use Node 24, so actions/checkout@v5 is required. Minimum runner version v2.327.1. Workflows only updated—no functional changes.

See: https://github.com/actions/checkout/releases/tag/v5.0.0