### PR TITLE
fix(hubble): drain should not stop enricher

### DIFF
--- a/hubble/src/indexer/enricher.rs
+++ b/hubble/src/indexer/enricher.rs
@@ -29,10 +29,6 @@ enum EnricherLoopResult {
 
 impl<T: FetcherClient> Indexer<T> {
     pub async fn run_enricher(&self, fetcher_client: T) -> Result<(), IndexerError> {
-        if self.drain {
-            return Ok(());
-        }
-
         loop {
             match self.run_enricher_loop(&fetcher_client).await {
                 Ok(EnricherLoopResult::RunAgain) => {


### PR DESCRIPTION
currently hubble stops enricher when 'draining', but it shouldn't. 

background: drain should flush all indexed events on the 'indexing' side (the part that'll run in spitzer). when migrating, we'll first start draining, to ensure no events in hubble are in-flight, then we'll migrate the hubble state into spitzer and start spitzer which will do the logic that's deactivated in hubble in when draining