### PR TITLE
docs: update nixos docs with more recent config op

### DIFF
--- a/docs/astro.config.ts
+++ b/docs/astro.config.ts
@@ -271,8 +271,8 @@ export default defineConfig({
               label: "Infrastructure",
               items: [
                 {
-                  label: "Testnet 9",
-                  link: "/infrastructure/testnet-9",
+                  label: "Testnet 10",
+                  link: "/infrastructure/testnet-10",
                 },
                 {
                   label: "Node Operators",

--- a/docs/src/content/docs/infrastructure/node-operators/getting-started.mdx
+++ b/docs/src/content/docs/infrastructure/node-operators/getting-started.mdx
@@ -17,14 +17,6 @@ Validators are the backbone of the network. Becoming one requires significant to
 
 ## Obtaining uniond
 
-:::note
-
-Currently, directly downloading the `uniond` binary requires access to our private GitHub repository. We are not currently providing the general public access to our GitHub repositories.
-
-If you don't have access to our private GitHub repository, you can still run our node using the public Docker image.
-
-:::
-
 You can obtain `uniond` from a recent [release](https://github.com/unionlabs/union/releases/latest).
 
 :::caution
@@ -88,7 +80,7 @@ First, set some environment variables, which are used throughout initialization.
 
 ```sh title="env.sh"
 export CHAIN_ID=union-testnet-10
-export MONIKER="Unionized Goblin"
+export MONIKER="unionized-goblin"
 export KEY_NAME=alice
 export GENESIS_URL="https://union.build/genesis.json"
 ```

--- a/docs/src/content/docs/infrastructure/node-operators/nixos.mdx
+++ b/docs/src/content/docs/infrastructure/node-operators/nixos.mdx
@@ -46,6 +46,15 @@ Below is an example configuration.nix which can be used in production.
               services.unionvisor = {
                 enable = true;
                 moniker = "your-testnet-moniker";
+                network = "union-testnet-10";
+                seeds = "SEED_NODE_ADDRESS";
+                node-key-json = .path/to/node_key.json;
+                priv-validator-key-json = .path/to/priv_validator_key.json;
+                root = "/var/lib/unionvisor";
+                home = "/var/lib/unionvisor";
+                app-toml = .path/to/app.toml;
+                client-toml = .path/to/client.toml;
+                config-toml = .path/to/config.toml;
               };
 
               # OPTIONAL: Some useful inspection tools for when you SSH into your validator
@@ -64,11 +73,23 @@ Below is an example configuration.nix which can be used in production.
 }
 ```
 
-You can then deploy the configuration by running
+You can then deploy the configuration by running:
 
 ```sh frame="none"
 GIT_LFS_SKIP_SMUDGE=1 nixos-rebuild switch --flake .\#testnet-validator --target-host user@validator.domain -L
 ```
+
+## Interacting with the Node
+
+After the system has been switched to this configuration, Unionvisor will be ran as a `systemd` service.
+
+You can view the logs of Unionvisor with `journalctl`:
+
+```sh frame="none"
+journalctl -xfeu service.unionvisor
+```
+
+You can call the current `uniond` either through Unionvisor binary, or by running the linked binary under `$UNIONVISOR_HOME/uniond`. By default, the `$UNIONVISOR_HOME` will be under `/var/lib/unionvisor`. You can also find the home files of your node containing state and config under `$UNIONVISOR_HOME/home`.
 
 ## Upgrading
 

--- a/docs/src/content/docs/infrastructure/node-operators/nixos.mdx
+++ b/docs/src/content/docs/infrastructure/node-operators/nixos.mdx
@@ -37,6 +37,7 @@ Below is an example configuration.nix which can be used in production.
             {
               system.stateVersion = "23.11";
               # Base configuration for openstack-based VPSs
+              # If using elitak/nixos-infect, use the hardware and network configuration provided by nixos-infect
               imports = [ "${nixpkgs}/nixos/modules/virtualisation/openstack-config.nix" ];
 
               # Allow other validators to reach you

--- a/docs/src/content/docs/joining-testnet/upgrade-history.mdx
+++ b/docs/src/content/docs/joining-testnet/upgrade-history.mdx
@@ -12,6 +12,17 @@ Here you can find records of Union network binary upgrades.
 
 The network `union-testnet-10` has had no binary upgrades since its genesis.
 
+| Upgrade | Height  |
+| ------- | ------- |
+| v1.0.0  | genesis |
+| v1.1.1  | 1380400 |
+| v1.2.0  | 2004000 |
+| v1.2.1* | 2084158 |
+
+:::note
+\* patch version to fix consensus error
+:::
+
 ## union-testnet-9
 
 <Badge text="Deprecated" variant="caution" />


### PR DESCRIPTION
- Updates operator docs with current information
- Updates upgrade history of `union-testnet-10`
- Exposes `union-testnet-10` network information