### PR TITLE
chore: remove redundant words in comment

### DIFF
--- a/lib/ssz/src/tree_hash.rs
+++ b/lib/ssz/src/tree_hash.rs
@@ -101,7 +101,7 @@ pub fn mix_in_type(root: &H256, type_index: usize) -> H256 {
 /// ## Specification
 ///
 /// ```plaintext
-/// mix_in_selector: Given a Merkle root root and a type selector selector ("uint256" little-endian
+/// mix_in_selector: Given a Merkle root and a type selector selector ("uint256" little-endian
 /// serialization) return hash(root + selector).
 /// ```
 ///

--- a/lib/unionlabs/src/aptos/account.rs
+++ b/lib/unionlabs/src/aptos/account.rs
@@ -18,7 +18,7 @@ impl AccountAddress {
     /// Returns whether the address is a "special" address. Addresses are considered
     /// special if the first 63 characters of the hex string are zero. In other words,
     /// an address is special if the first 31 bytes are zero and the last byte is
-    /// smaller than than `0b10000` (16). In other words, special is defined as an address
+    /// smaller than `0b10000` (16). In other words, special is defined as an address
     /// that matches the following regex: `^0x0{63}[0-9a-f]$`. In short form this means
     /// the addresses in the range from `0x0` to `0xf` (inclusive) are special.
     ///


### PR DESCRIPTION
remove redundant words in comment