### PR TITLE
Add guards for zero gameCount to prevent U256 underflow

### DIFF
--- a/lib/base-client/src/lib.rs
+++ b/lib/base-client/src/lib.rs
@@ -21,7 +21,7 @@ pub async fn finalized_l2_block_number_of_l1_block_number(
         l1_provider,
         l1_block_number,
         l1_dispute_game_factory_proxy,
-        count - U256::ONE,
+        count.saturating_sub(U256::ONE),
     )
     .await
 }

--- a/lib/bob-client/src/lib.rs
+++ b/lib/bob-client/src/lib.rs
@@ -21,7 +21,7 @@ pub async fn finalized_l2_block_number_of_l1_block_number(
         l1_provider,
         l1_block_number,
         l1_dispute_game_factory_proxy,
-        count - U256::ONE,
+        count.saturating_sub(U256::ONE),
     )
     .await
 }

--- a/voyager/plugins/client-update/base/src/main.rs
+++ b/voyager/plugins/client-update/base/src/main.rs
@@ -618,6 +618,14 @@ impl Module {
         .await
         .map_err(|err| ErrorObject::owned(-1, ErrorReporter(err).to_string(), None::<()>))?;
 
+        if game_index.is_zero() {
+            return Err(ErrorObject::owned(
+                -1,
+                "no dispute games at this L1 block height".to_string(),
+                None::<()>,
+            ));
+        }
+
         let game_index = game_index - U256::ONE;
 
         let dispute_game_factory_account_proof = self

--- a/voyager/plugins/client-update/bob/src/main.rs
+++ b/voyager/plugins/client-update/bob/src/main.rs
@@ -630,6 +630,14 @@ impl Module {
         .await
         .map_err(|err| ErrorObject::owned(-1, ErrorReporter(err).to_string(), None::<()>))?;
 
+        if game_index.is_zero() {
+            return Err(ErrorObject::owned(
+                -1,
+                "no dispute games at this L1 block height".to_string(),
+                None::<()>,
+            ));
+        }
+
         let game_index = game_index - U256::ONE;
 
         let dispute_game_factory_account_proof = self


### PR DESCRIPTION
Introduce explicit zero-count checks in voyager client-update plugins and use saturating subtraction in base-client and bob-client when deriving the latest game index from gameCount. This prevents U256 underflow when no dispute games exist at a given L1 block and returns a clear error to callers instead of panicking.