### PR TITLE
fix: package set and entrypoint

### DIFF
--- a/mpc/mpc.nix
+++ b/mpc/mpc.nix
@@ -16,26 +16,25 @@ _: {
       mpc-coordinator = crane.buildWorkspaceMember "mpc/coordinator" attrs;
     in
     {
-      packages =
-        mpc-coordinator
-        // mpc-client
-        // {
-          mpc-client-image = pkgs.dockerTools.buildImage {
-            name = "${self'.packages.mpc-client.name}-image";
-            copyToRoot = pkgs.buildEnv {
-              name = "image-root";
-              paths = [
-                pkgs.coreutils-full
-                pkgs.cacert
-                pkgs.ncurses
-              ];
-              pathsToLink = [ "/bin" ];
-            };
-            config = {
-              Entrypoint = [ (pkgs.lib.getExe self'.packages.mpc-client) ];
-              Env = [ "SSL_CERT_FILE=${pkgs.cacert}/etc/ssl/certs/ca-bundle.crt" ];
-            };
+      packages = {
+        mpc-coordinator = mpc-coordinator;
+        mpc-client = mpc-client;
+        mpc-client-image = pkgs.dockerTools.buildImage {
+          name = "${self'.packages.mpc-client.name}-image";
+          copyToRoot = pkgs.buildEnv {
+            name = "image-root";
+            paths = [
+              pkgs.coreutils-full
+              pkgs.cacert
+              pkgs.ncurses
+            ];
+            pathsToLink = [ "/bin" ];
+          };
+          config = {
+            Entrypoint = [ "${pkgs.lib.getExe self'.packages.mpc-client}" ];
+            Env = [ "SSL_CERT_FILE=${pkgs.cacert}/etc/ssl/certs/ca-bundle.crt" ];
           };
         };
+      };
     };
 }


### PR DESCRIPTION
changed `packages` to an attribute set instead of `//` to avoid errors with derivations.
aso wrapped the entrypoint in `"${...}"` so Docker gets strings, not derivations.

**chngs**

* `packages = { mpc-coordinator = mpc-coordinator; mpc-client = mpc-client; mpc-client-image = ...; }`
* `entrypoint = [ "${pkgs.lib.getExe self'.packages.mpc-client}" ]`
