### PR TITLE
refactor: remove debug console.log statements from EVM client

### DIFF
--- a/typescript-sdk/src/evm/client.ts
+++ b/typescript-sdk/src/evm/client.ts
@@ -183,10 +183,7 @@ export const createEvmClient = (parameters: EvmClientParameters) => {
           if (approveResponse.isErr()) {
             return approveResponse
           }
-          console.log("approval", approveResponse.value)
         }
-
-        console.log({ sourceChannel, ucs03address, baseToken, quoteToken, amount }) // useful for debugging app
 
         return await transferAssetFromEvm(client, {
           baseToken,


### PR DESCRIPTION
Remove debugging console.log statements from typescript-sdk/src/evm/client.ts:
- Remove approval response logging
- Remove transfer parameters logging marked as `useful for debugging app`