### PR TITLE
fix: improve panic message in zkgm-filter execute message handling

### DIFF
--- a/voyager/plugins/zkgm-filter/src/main.rs
+++ b/voyager/plugins/zkgm-filter/src/main.rs
@@ -810,7 +810,7 @@ fn valid_checksum_cosmos(tx_bytes: &[u8]) -> (bool, Option<Bech32<Bytes>>) {
 
     match execute_msg {
         ucs03_zkgm::msg::ExecuteMsg::Send { salt, .. } => (valid_checksum(salt), Some(msg.sender)),
-        _ => panic!("????? {execute_msg:?}"),
+        _ => panic!("unexpected ExecuteMsg variant: {execute_msg:?}"),а
     }
 }
 


### PR DESCRIPTION
Replace unclear `?????` panic message with descriptive `unexpected ExecuteMsg variant`to improve debugging experience and code professionalism.