### PR TITLE
feat(devshell): configure zed to use devShell LSPs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -84,7 +84,6 @@ sui/*/build
 .tsup
 docs/generated
 dev-dist
-.zed
 rustc-ice*
 .docs
 profiles/

--- a/.zed/settings.json
+++ b/.zed/settings.json
@@ -1,0 +1,49 @@
+// Zed settings to use Union's devShell
+{
+  "languages": {
+    "TypeScript": {
+      "language_servers": ["typescript-language-server", "!vtsls"]
+    },
+    "TSX": {
+      "language_servers": ["typescript-language-server", "!vtsls"]
+    },
+    "JavaScript": {
+      "language_servers": ["typescript-language-server", "!vtsls"]
+    },
+    "Svelte": {
+      "language_servers": ["svelte-language-server"]
+    }
+  },
+  "lsp": {
+    "typescript-language-server": {
+      "binary": {
+        "ignore_system_version": false
+      }
+    },
+    "vscode-html-language-server": {
+      "binary": {
+        "ignore_system_version": false,
+        "path": "vscode-html-language-server",
+        "arguments": ["--stdio"]
+      }
+    },
+    "astro-language-server": {
+      "binary": {
+        "ignore_system_version": false,
+        "path": "astro-ls",
+        "arguments": ["--stdio"]
+      }
+    },
+    "svelte-language-server": {
+      "binary": {
+        "ignore_system_version": false
+      }
+    },
+    "nixd": {
+      "binary": {
+        "ignore_system_version": false
+      }
+    }
+  },
+  "load_direnv": "direct"
+}


### PR DESCRIPTION
Configures [Zed](https://zed.dev/) to use Union's devShell. Zed is an extremely fast IDE written in Rust with optional Helix keybindings and excellent AI Agent (like Claude Code) integration. It works over SSH so you can connect to your NixOS VM from macOS.

<img width="331" height="367" alt="Screenshot 2025-11-21 at 15 24 31" src="https://github.com/user-attachments/assets/2f91118e-65b0-4f03-b731-94d8516d62ed" />
