### PR TITLE
chore: execute goimports to format the code

### DIFF
--- a/11-cometbls/zk_verifier_test.go
+++ b/11-cometbls/zk_verifier_test.go
@@ -2,9 +2,10 @@ package cometbls
 
 import (
 	"encoding/hex"
-	"github.com/stretchr/testify/assert"
 	"testing"
 	"time"
+
+	"github.com/stretchr/testify/assert"
 )
 
 func TestVerifier(t *testing.T) {

--- a/galoisd/cmd/galoisd/cmd/client.go
+++ b/galoisd/cmd/galoisd/cmd/client.go
@@ -3,13 +3,15 @@ package cmd
 import (
 	"context"
 	"crypto/tls"
+	"log"
+	"time"
+
 	provergrpc "galois/grpc/api/v3"
+
 	"github.com/spf13/cobra"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/credentials"
 	"google.golang.org/grpc/credentials/insecure"
-	"log"
-	"time"
 )
 
 const (

--- a/galoisd/cmd/galoisd/main.go
+++ b/galoisd/cmd/galoisd/main.go
@@ -5,6 +5,7 @@ package main
 
 import (
 	"galois/cmd/galoisd/cmd"
+
 	"github.com/spf13/cobra"
 )
 


### PR DESCRIPTION
execute goimports to format the code