### PR TITLE
chore(devshell): add package-version-server

### DIFF
--- a/.zed/settings.json
+++ b/.zed/settings.json
@@ -93,6 +93,11 @@
         "ignore_system_version": false
       }
     },
+    "package-version-server": {
+      "binary": {
+        "ignore_system_version": false
+      }
+    },
     "vscode-html-language-server": {
       "binary": {
         "ignore_system_version": false,

--- a/flake.nix
+++ b/flake.nix
@@ -572,6 +572,7 @@
                 graphviz
                 emmet-language-server
                 typescript-go
+                package-version-server
                 nodePackages_latest.graphqurl
                 nodePackages_latest.svelte-language-server
                 nodePackages_latest."@astrojs/language-server"


### PR DESCRIPTION
Adds `package-version-server` to the devshell - a language server that provides hover information for dependencies in `package.json` files, showing version details and package metadata.

Also configures the LSP binary settings for Zed editor.