### PR TITLE
docs(ucs): introduce ucs07

### DIFF
--- a/docs/src/content/docs/ucs/07.mdx
+++ b/docs/src/content/docs/ucs/07.mdx
@@ -47,14 +47,12 @@ The colon (`:`) separates the chain identifier from the token specification. The
 | `sui-coin` | Sui | Yes | Coin objects on Sui |
 | `sui-token` | Sui | Yes | Token objects on Sui |
 | `starknet-erc20` | Starknet | Yes | ERC20 tokens on Starknet |
-| `starknet-native` | Starknet | No | Native STRK token |
 
 ### Native Token Kinds
 
 The following token kinds represent chain-native assets and do **not** include a denomination:
 
 - `evm-native` — The native gas token of an EVM chain (ETH, MATIC, etc.)
-- `starknet-native` — The native STRK token on Starknet
 
 Since each chain has exactly one native token, no disambiguation is required.
 


### PR DESCRIPTION
This PR introduces the UCS07 specification documentation.

Note that for simplicity's sake, I kept the universal_chain_id as a required component of a valid UCS07.