### PR TITLE
chore: Update outdated GitHub Actions versions

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -18,7 +18,7 @@ jobs:
   check:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           lfs: true
           fetch-depth: 0

--- a/.github/workflows/deploy-app2.yml
+++ b/.github/workflows/deploy-app2.yml
@@ -32,7 +32,7 @@ jobs:
     environment: 'app2-preview'
     if: github.event_name == 'pull_request'
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           lfs: true
       - uses: cachix/install-nix-action@v31
@@ -77,7 +77,7 @@ jobs:
       ENVIRONMENT: 'preview'
     if: github.event_name == 'workflow_dispatch'
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           lfs: true
       - uses: cachix/install-nix-action@v31
@@ -105,7 +105,7 @@ jobs:
     environment: 'app2-staging'
     if: github.event_name == 'push' && github.ref == 'refs/heads/main'
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           lfs: true
       - uses: cachix/install-nix-action@v31
@@ -133,7 +133,7 @@ jobs:
     environment: 'app2-production'
     if: github.event_name == 'push' && github.ref == 'refs/heads/release/app2'
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           lfs: true
       - uses: cachix/install-nix-action@v31

--- a/.github/workflows/deploy-ceremony.yml
+++ b/.github/workflows/deploy-ceremony.yml
@@ -32,7 +32,7 @@ jobs:
     environment: 'ceremony-preview'
     if: github.event_name == 'pull_request'
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           lfs: true
       - uses: cachix/install-nix-action@v31
@@ -73,7 +73,7 @@ jobs:
       npm_config_yes: true
     if: github.event_name == 'workflow_dispatch'
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           lfs: true
       - uses: cachix/install-nix-action@v31
@@ -97,7 +97,7 @@ jobs:
     environment: 'ceremony-staging'
     if: github.event_name == 'push' && github.ref == 'refs/heads/main'
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           lfs: true
       - uses: cachix/install-nix-action@v31
@@ -121,7 +121,7 @@ jobs:
     environment: 'ceremony-production'
     if: github.event_name == 'push' && github.ref == 'refs/heads/release/ceremony'
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           lfs: true
       - uses: cachix/install-nix-action@v31

--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -35,7 +35,7 @@ jobs:
     environment: 'docs-preview'
     if: github.event_name == 'pull_request'
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           lfs: true
       - uses: cachix/install-nix-action@v31
@@ -76,7 +76,7 @@ jobs:
       npm_config_yes: true
     if: github.event_name == 'workflow_dispatch'
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           lfs: true
       - uses: cachix/install-nix-action@v31
@@ -100,7 +100,7 @@ jobs:
     environment: 'docs-production'
     if: github.event_name == 'push' && github.ref == 'refs/heads/main'
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           lfs: true
       - uses: cachix/install-nix-action@v31

--- a/.github/workflows/deploy-zkgm-dev.yml
+++ b/.github/workflows/deploy-zkgm-dev.yml
@@ -32,7 +32,7 @@ jobs:
     environment: 'zkgm-dev-preview'
     if: github.event_name == 'pull_request'
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           lfs: true
       - uses: cachix/install-nix-action@v31
@@ -73,7 +73,7 @@ jobs:
       npm_config_yes: true
     if: github.event_name == 'workflow_dispatch'
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           lfs: true
       - uses: cachix/install-nix-action@v31
@@ -97,7 +97,7 @@ jobs:
     environment: 'zkgm-dev-staging'
     if: github.event_name == 'push' && github.ref == 'refs/heads/main'
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           lfs: true
       - uses: cachix/install-nix-action@v31
@@ -121,7 +121,7 @@ jobs:
     environment: 'zkgm-dev-production'
     if: github.event_name == 'push' && github.ref == 'refs/heads/release/zkgm-dev'
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           lfs: true
       - uses: cachix/install-nix-action@v31

--- a/.github/workflows/nightly-e2e-lst.yml
+++ b/.github/workflows/nightly-e2e-lst.yml
@@ -7,7 +7,7 @@ jobs:
   deploy-preview:
     runs-on: ['ubuntu-latest']
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           lfs: true
       - uses: cachix/install-nix-action@v31

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -21,7 +21,7 @@ jobs:
     # only create an issue if it failed in a scheduled run
     if: github.event_name == 'schedule' && failure()
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - uses: JasonEtco/create-an-issue@v2
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/package-release.yml
+++ b/.github/workflows/package-release.yml
@@ -23,7 +23,7 @@ jobs:
       id-token: write
       pull-requests: write
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           lfs: true
       - uses: cachix/install-nix-action@v31

--- a/.github/workflows/package-snapshot.yml
+++ b/.github/workflows/package-snapshot.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           lfs: true
       - uses: cachix/install-nix-action@v31
@@ -32,9 +32,9 @@ jobs:
           rm -rf ./snapshot-pkg
           rsync -a --copy-links ./result/ ./snapshot-pkg/
           chmod -R u+w ./snapshot-pkg
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v6
         with: {node-version: 22}
-      - uses: pnpm/action-setup@v3
+      - uses: pnpm/action-setup@v4
         with:
           version: 10
           run_install: false

--- a/.github/workflows/release-component.yml
+++ b/.github/workflows/release-component.yml
@@ -86,7 +86,7 @@ jobs:
     needs: [eval-tag]
     runs-on: ubuntu-24.04
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           lfs: true
       - uses: cachix/install-nix-action@v30
@@ -100,7 +100,7 @@ jobs:
         run: |
           nix build .#packages.x86_64-linux."$COMPONENT"-image --accept-flake-config
           cp -Lr result x86_64-linux."$COMPONENT"-image
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@v6
         with:
           name: x86_64-linux.${{ needs.eval-tag.outputs.component }}-image
           path: x86_64-linux.${{ needs.eval-tag.outputs.component }}-image
@@ -110,7 +110,7 @@ jobs:
     needs: [eval-tag]
     runs-on: ubuntu-24.04-arm
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           lfs: true
       - uses: cachix/install-nix-action@v30
@@ -124,7 +124,7 @@ jobs:
         run: |
           nix build .#packages.aarch64-linux."$COMPONENT"-image --accept-flake-config
           cp -Lr result aarch64-linux."$COMPONENT"-image
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@v6
         with:
           name: aarch64-linux.${{ needs.eval-tag.outputs.component }}-image
           path: aarch64-linux.${{ needs.eval-tag.outputs.component }}-image
@@ -133,7 +133,7 @@ jobs:
     needs: [eval-tag]
     runs-on: ubuntu-24.04
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           lfs: true
       - uses: cachix/install-nix-action@v30
@@ -155,7 +155,7 @@ jobs:
           else
             cp result/bin/"$COMPONENT" "$COMPONENT"-x86_64-linux
           fi
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@v6
         with:
           name: ${{ needs.eval-tag.outputs.component }}-x86_64-linux
           path: ${{ needs.eval-tag.outputs.component }}-x86_64-linux
@@ -164,7 +164,7 @@ jobs:
     needs: [eval-tag]
     runs-on: ubuntu-24.04-arm
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           lfs: true
       - uses: cachix/install-nix-action@v30
@@ -186,7 +186,7 @@ jobs:
           else
             cp result/bin/"$COMPONENT" "$COMPONENT"-aarch64-linux
           fi
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@v6
         with:
           name: ${{ needs.eval-tag.outputs.component }}-aarch64-linux
           path: ${{ needs.eval-tag.outputs.component }}-aarch64-linux
@@ -209,12 +209,12 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
       - name: Download aarch64-linux.${{ needs.eval-tag.outputs.component }}-image
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v7
         with:
           name: aarch64-linux.${{ needs.eval-tag.outputs.component }}-image
           path: .
       - name: Download x86_64-linux.${{ needs.eval-tag.outputs.component }}-image
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v7
         with:
           name: x86_64-linux.${{ needs.eval-tag.outputs.component }}-image
           path: .
@@ -258,7 +258,7 @@ jobs:
           COMPONENT: ${{ needs.eval-tag.outputs.component }}
           TAG: ${{ needs.eval-tag.outputs.version }}
         run: docker manifest push "localhost:5000/unionlabs/$COMPONENT:$TAG"
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           lfs: true
           fetch-depth: 0
@@ -293,7 +293,7 @@ jobs:
     needs: [download-binaries-x86_64, download-binaries-aarch64, eval-tag]
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/download-artifact@v4
+      - uses: actions/download-artifact@v7
       - id: prep-artifacts
         env:
           COMPONENT: ${{ needs.eval-tag.outputs.component }}


### PR DESCRIPTION
This PR updates outdated GitHub Action versions.

- Updated `pnpm/action-setup` from `v3` to `v4` in `.github/workflows/package-snapshot.yml`
- Updated `actions/checkout` from `v4` to `v6` in `.github/workflows/release-component.yml`
- Updated `actions/checkout` from `v4` to `v6` in `.github/workflows/deploy-zkgm-dev.yml`
- Updated `actions/setup-node` from `v4` to `v6` in `.github/workflows/package-snapshot.yml`
- Updated `actions/checkout` from `v4` to `v6` in `.github/workflows/nightly.yml`
- Updated `actions/checkout` from `v4` to `v6` in `.github/workflows/package-release.yml`
- Updated `actions/checkout` from `v4` to `v6` in `.github/workflows/nightly-e2e-lst.yml`
- Updated `actions/checkout` from `v4` to `v6` in `.github/workflows/check.yml`
- Updated `actions/download-artifact` from `v4` to `v7` in `.github/workflows/release-component.yml`
- Updated `actions/checkout` from `v4` to `v6` in `.github/workflows/deploy-ceremony.yml`
- Updated `actions/upload-artifact` from `v4` to `v6` in `.github/workflows/release-component.yml`
- Updated `actions/checkout` from `v4` to `v6` in `.github/workflows/package-snapshot.yml`
- Updated `actions/checkout` from `v4` to `v6` in `.github/workflows/deploy-app2.yml`
- Updated `actions/checkout` from `v4` to `v6` in `.github/workflows/deploy-docs.yml`
