### PR TITLE
fix: harden GitHub Actions workflows

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -25,6 +25,6 @@ jobs:
       - name: Check for LFS files
         run: ./.github/scripts/lfs.sh
       - name: Lint commit messages
-        uses: wagoid/commitlint-github-action@v5
+        uses: wagoid/commitlint-github-action@9763196e10f27aef304c9b8b660d31d97fce0f99 # v5
         with:
           failOnWarnings: false

--- a/.github/workflows/deploy-app2.yml
+++ b/.github/workflows/deploy-app2.yml
@@ -18,7 +18,6 @@ concurrency:
 
 env:
   NODE_OPTIONS: '--no-warnings'
-  ACTIONS_RUNNER_DEBUG: true
 
 jobs:
   deploy-preview:
@@ -35,7 +34,7 @@ jobs:
       - uses: actions/checkout@v4
         with:
           lfs: true
-      - uses: cachix/install-nix-action@v31
+      - uses: cachix/install-nix-action@51f3067b56fe8ae331890c77d4e454f6d60615ff # v31
         with:
           extra_nix_config: |
             trusted-public-keys = cache.nixos.org-1:6NCHdD59X431o0gWypbMrAURkbJ16ZPMQFGspcDShjY= cache.garnix.io:CTFPyKSLcx5RMJKfLo5EEPUObbA78b0YQ2DTCJXqr9g= union.cachix.org-1:TV9o8jexzNVbM1VNBOq9fu8NK+hL6ZhOyOh0quATy+M=
@@ -61,7 +60,7 @@ jobs:
           } >> $GITHUB_ENV
 
       - name: Comment Site Deploy Results
-        uses: thollander/actions-comment-pull-request@v2
+        uses: thollander/actions-comment-pull-request@fabd468d3a1a0b97feee5f6b9e499eab0dd903f6 # v2
         with:
           message: |
             # App 2 🤌
@@ -80,7 +79,7 @@ jobs:
       - uses: actions/checkout@v4
         with:
           lfs: true
-      - uses: cachix/install-nix-action@v31
+      - uses: cachix/install-nix-action@51f3067b56fe8ae331890c77d4e454f6d60615ff # v31
         with:
           extra_nix_config: |
             trusted-public-keys = cache.nixos.org-1:6NCHdD59X431o0gWypbMrAURkbJ16ZPMQFGspcDShjY= cache.garnix.io:CTFPyKSLcx5RMJKfLo5EEPUObbA78b0YQ2DTCJXqr9g= union.cachix.org-1:TV9o8jexzNVbM1VNBOq9fu8NK+hL6ZhOyOh0quATy+M=
@@ -108,7 +107,7 @@ jobs:
       - uses: actions/checkout@v4
         with:
           lfs: true
-      - uses: cachix/install-nix-action@v31
+      - uses: cachix/install-nix-action@51f3067b56fe8ae331890c77d4e454f6d60615ff # v31
         with:
           extra_nix_config: |
             trusted-public-keys = cache.nixos.org-1:6NCHdD59X431o0gWypbMrAURkbJ16ZPMQFGspcDShjY= cache.garnix.io:CTFPyKSLcx5RMJKfLo5EEPUObbA78b0YQ2DTCJXqr9g= union.cachix.org-1:TV9o8jexzNVbM1VNBOq9fu8NK+hL6ZhOyOh0quATy+M=
@@ -136,7 +135,7 @@ jobs:
       - uses: actions/checkout@v4
         with:
           lfs: true
-      - uses: cachix/install-nix-action@v31
+      - uses: cachix/install-nix-action@51f3067b56fe8ae331890c77d4e454f6d60615ff # v31
         with:
           extra_nix_config: |
             trusted-public-keys = cache.nixos.org-1:6NCHdD59X431o0gWypbMrAURkbJ16ZPMQFGspcDShjY= cache.garnix.io:CTFPyKSLcx5RMJKfLo5EEPUObbA78b0YQ2DTCJXqr9g= union.cachix.org-1:TV9o8jexzNVbM1VNBOq9fu8NK+hL6ZhOyOh0quATy+M=

--- a/.github/workflows/deploy-ceremony.yml
+++ b/.github/workflows/deploy-ceremony.yml
@@ -18,7 +18,6 @@ concurrency:
 
 env:
   NODE_OPTIONS: '--no-warnings'
-  ACTIONS_RUNNER_DEBUG: true
   ASTRO_TELEMETRY_DISABLED: true
 
 jobs:
@@ -35,7 +34,7 @@ jobs:
       - uses: actions/checkout@v4
         with:
           lfs: true
-      - uses: cachix/install-nix-action@v31
+      - uses: cachix/install-nix-action@51f3067b56fe8ae331890c77d4e454f6d60615ff # v31
         with:
           extra_nix_config: |
             trusted-public-keys = cache.nixos.org-1:6NCHdD59X431o0gWypbMrAURkbJ16ZPMQFGspcDShjY= cache.garnix.io:CTFPyKSLcx5RMJKfLo5EEPUObbA78b0YQ2DTCJXqr9g= union.cachix.org-1:TV9o8jexzNVbM1VNBOq9fu8NK+hL6ZhOyOh0quATy+M=
@@ -58,7 +57,7 @@ jobs:
           } >> $GITHUB_ENV
 
       - name: Comment Site Deploy Results
-        uses: thollander/actions-comment-pull-request@v2
+        uses: thollander/actions-comment-pull-request@fabd468d3a1a0b97feee5f6b9e499eab0dd903f6 # v2
         with:
           message: |
             # Ceremony 🤌
@@ -76,7 +75,7 @@ jobs:
       - uses: actions/checkout@v4
         with:
           lfs: true
-      - uses: cachix/install-nix-action@v31
+      - uses: cachix/install-nix-action@51f3067b56fe8ae331890c77d4e454f6d60615ff # v31
         with:
           extra_nix_config: |
             trusted-public-keys = cache.nixos.org-1:6NCHdD59X431o0gWypbMrAURkbJ16ZPMQFGspcDShjY= cache.garnix.io:CTFPyKSLcx5RMJKfLo5EEPUObbA78b0YQ2DTCJXqr9g= union.cachix.org-1:TV9o8jexzNVbM1VNBOq9fu8NK+hL6ZhOyOh0quATy+M=
@@ -100,7 +99,7 @@ jobs:
       - uses: actions/checkout@v4
         with:
           lfs: true
-      - uses: cachix/install-nix-action@v31
+      - uses: cachix/install-nix-action@51f3067b56fe8ae331890c77d4e454f6d60615ff # v31
         with:
           extra_nix_config: |
             trusted-public-keys = cache.nixos.org-1:6NCHdD59X431o0gWypbMrAURkbJ16ZPMQFGspcDShjY= cache.garnix.io:CTFPyKSLcx5RMJKfLo5EEPUObbA78b0YQ2DTCJXqr9g= union.cachix.org-1:TV9o8jexzNVbM1VNBOq9fu8NK+hL6ZhOyOh0quATy+M=
@@ -124,7 +123,7 @@ jobs:
       - uses: actions/checkout@v4
         with:
           lfs: true
-      - uses: cachix/install-nix-action@v31
+      - uses: cachix/install-nix-action@51f3067b56fe8ae331890c77d4e454f6d60615ff # v31
         with:
           extra_nix_config: |
             trusted-public-keys = cache.nixos.org-1:6NCHdD59X431o0gWypbMrAURkbJ16ZPMQFGspcDShjY= cache.garnix.io:CTFPyKSLcx5RMJKfLo5EEPUObbA78b0YQ2DTCJXqr9g= union.cachix.org-1:TV9o8jexzNVbM1VNBOq9fu8NK+hL6ZhOyOh0quATy+M=

--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -21,7 +21,6 @@ concurrency:
 
 env:
   NODE_OPTIONS: '--no-warnings'
-  ACTIONS_RUNNER_DEBUG: true
   ASTRO_TELEMETRY_DISABLED: true
 
 jobs:
@@ -38,7 +37,7 @@ jobs:
       - uses: actions/checkout@v4
         with:
           lfs: true
-      - uses: cachix/install-nix-action@v31
+      - uses: cachix/install-nix-action@51f3067b56fe8ae331890c77d4e454f6d60615ff # v31
         with:
           extra_nix_config: |
             trusted-public-keys = cache.nixos.org-1:6NCHdD59X431o0gWypbMrAURkbJ16ZPMQFGspcDShjY= cache.garnix.io:CTFPyKSLcx5RMJKfLo5EEPUObbA78b0YQ2DTCJXqr9g= union.cachix.org-1:TV9o8jexzNVbM1VNBOq9fu8NK+hL6ZhOyOh0quATy+M=
@@ -61,7 +60,7 @@ jobs:
           } >> $GITHUB_ENV
 
       - name: Comment Site Deploy Results
-        uses: thollander/actions-comment-pull-request@v2
+        uses: thollander/actions-comment-pull-request@fabd468d3a1a0b97feee5f6b9e499eab0dd903f6 # v2
         with:
           message: |
             # Docs 🤌
@@ -79,7 +78,7 @@ jobs:
       - uses: actions/checkout@v4
         with:
           lfs: true
-      - uses: cachix/install-nix-action@v31
+      - uses: cachix/install-nix-action@51f3067b56fe8ae331890c77d4e454f6d60615ff # v31
         with:
           extra_nix_config: |
             trusted-public-keys = cache.nixos.org-1:6NCHdD59X431o0gWypbMrAURkbJ16ZPMQFGspcDShjY= cache.garnix.io:CTFPyKSLcx5RMJKfLo5EEPUObbA78b0YQ2DTCJXqr9g= union.cachix.org-1:TV9o8jexzNVbM1VNBOq9fu8NK+hL6ZhOyOh0quATy+M=
@@ -103,7 +102,7 @@ jobs:
       - uses: actions/checkout@v4
         with:
           lfs: true
-      - uses: cachix/install-nix-action@v31
+      - uses: cachix/install-nix-action@51f3067b56fe8ae331890c77d4e454f6d60615ff # v31
         with:
           extra_nix_config: |
             trusted-public-keys = cache.nixos.org-1:6NCHdD59X431o0gWypbMrAURkbJ16ZPMQFGspcDShjY= cache.garnix.io:CTFPyKSLcx5RMJKfLo5EEPUObbA78b0YQ2DTCJXqr9g= union.cachix.org-1:TV9o8jexzNVbM1VNBOq9fu8NK+hL6ZhOyOh0quATy+M=

--- a/.github/workflows/deploy-zkgm-dev.yml
+++ b/.github/workflows/deploy-zkgm-dev.yml
@@ -18,7 +18,6 @@ concurrency:
 
 env:
   NODE_OPTIONS: '--no-warnings'
-  ACTIONS_RUNNER_DEBUG: true
   ASTRO_TELEMETRY_DISABLED: true
 
 jobs:
@@ -35,7 +34,7 @@ jobs:
       - uses: actions/checkout@v4
         with:
           lfs: true
-      - uses: cachix/install-nix-action@v31
+      - uses: cachix/install-nix-action@51f3067b56fe8ae331890c77d4e454f6d60615ff # v31
         with:
           extra_nix_config: |
             trusted-public-keys = cache.nixos.org-1:6NCHdD59X431o0gWypbMrAURkbJ16ZPMQFGspcDShjY= cache.garnix.io:CTFPyKSLcx5RMJKfLo5EEPUObbA78b0YQ2DTCJXqr9g= union.cachix.org-1:TV9o8jexzNVbM1VNBOq9fu8NK+hL6ZhOyOh0quATy+M=
@@ -58,7 +57,7 @@ jobs:
           } >> $GITHUB_ENV
 
       - name: Comment Site Deploy Results
-        uses: thollander/actions-comment-pull-request@v2
+        uses: thollander/actions-comment-pull-request@fabd468d3a1a0b97feee5f6b9e499eab0dd903f6 # v2
         with:
           message: |
             # zkgm.dev 🦀
@@ -76,7 +75,7 @@ jobs:
       - uses: actions/checkout@v4
         with:
           lfs: true
-      - uses: cachix/install-nix-action@v31
+      - uses: cachix/install-nix-action@51f3067b56fe8ae331890c77d4e454f6d60615ff # v31
         with:
           extra_nix_config: |
             trusted-public-keys = cache.nixos.org-1:6NCHdD59X431o0gWypbMrAURkbJ16ZPMQFGspcDShjY= cache.garnix.io:CTFPyKSLcx5RMJKfLo5EEPUObbA78b0YQ2DTCJXqr9g= union.cachix.org-1:TV9o8jexzNVbM1VNBOq9fu8NK+hL6ZhOyOh0quATy+M=
@@ -100,7 +99,7 @@ jobs:
       - uses: actions/checkout@v4
         with:
           lfs: true
-      - uses: cachix/install-nix-action@v31
+      - uses: cachix/install-nix-action@51f3067b56fe8ae331890c77d4e454f6d60615ff # v31
         with:
           extra_nix_config: |
             trusted-public-keys = cache.nixos.org-1:6NCHdD59X431o0gWypbMrAURkbJ16ZPMQFGspcDShjY= cache.garnix.io:CTFPyKSLcx5RMJKfLo5EEPUObbA78b0YQ2DTCJXqr9g= union.cachix.org-1:TV9o8jexzNVbM1VNBOq9fu8NK+hL6ZhOyOh0quATy+M=
@@ -124,7 +123,7 @@ jobs:
       - uses: actions/checkout@v4
         with:
           lfs: true
-      - uses: cachix/install-nix-action@v31
+      - uses: cachix/install-nix-action@51f3067b56fe8ae331890c77d4e454f6d60615ff # v31
         with:
           extra_nix_config: |
             trusted-public-keys = cache.nixos.org-1:6NCHdD59X431o0gWypbMrAURkbJ16ZPMQFGspcDShjY= cache.garnix.io:CTFPyKSLcx5RMJKfLo5EEPUObbA78b0YQ2DTCJXqr9g= union.cachix.org-1:TV9o8jexzNVbM1VNBOq9fu8NK+hL6ZhOyOh0quATy+M=

--- a/.github/workflows/nightly-e2e-lst.yml
+++ b/.github/workflows/nightly-e2e-lst.yml
@@ -10,7 +10,7 @@ jobs:
       - uses: actions/checkout@v4
         with:
           lfs: true
-      - uses: cachix/install-nix-action@v31
+      - uses: cachix/install-nix-action@51f3067b56fe8ae331890c77d4e454f6d60615ff # v31
         with:
           extra_nix_config: |
             trusted-public-keys = cache.nixos.org-1:6NCHdD59X431o0gWypbMrAURkbJ16ZPMQFGspcDShjY= cache.garnix.io:CTFPyKSLcx5RMJKfLo5EEPUObbA78b0YQ2DTCJXqr9g= union.cachix.org-1:TV9o8jexzNVbM1VNBOq9fu8NK+hL6ZhOyOh0quATy+M=

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -22,7 +22,7 @@ jobs:
     if: github.event_name == 'schedule' && failure()
     steps:
       - uses: actions/checkout@v4
-      - uses: JasonEtco/create-an-issue@v2
+      - uses: JasonEtco/create-an-issue@1b14a70e4d8dc185e5cc76d3bec9eab20257b2c5 # v2
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}

--- a/.github/workflows/package-release.yml
+++ b/.github/workflows/package-release.yml
@@ -26,7 +26,7 @@ jobs:
       - uses: actions/checkout@v4
         with:
           lfs: true
-      - uses: cachix/install-nix-action@v31
+      - uses: cachix/install-nix-action@51f3067b56fe8ae331890c77d4e454f6d60615ff # v31
         with:
           extra_nix_config: |
             trusted-public-keys = cache.nixos.org-1:6NCHdD59X431o0gWypbMrAURkbJ16ZPMQFGspcDShjY= cache.garnix.io:CTFPyKSLcx5RMJKfLo5EEPUObbA78b0YQ2DTCJXqr9g= union.cachix.org-1:TV9o8jexzNVbM1VNBOq9fu8NK+hL6ZhOyOh0quATy+M=
@@ -37,7 +37,7 @@ jobs:
         run: |
           nix build .#ts-sdk
       - name: Create Release Pull Request or Publish
-        uses: changesets/action@v1
+        uses: changesets/action@6a0a831ff30acef54f2c6aa1cbbc1096b066edaf # v1
         with:
           version: pnpm changeset-version
           publish: pnpm changeset-publish

--- a/.github/workflows/package-snapshot.yml
+++ b/.github/workflows/package-snapshot.yml
@@ -17,7 +17,7 @@ jobs:
       - uses: actions/checkout@v4
         with:
           lfs: true
-      - uses: cachix/install-nix-action@v31
+      - uses: cachix/install-nix-action@51f3067b56fe8ae331890c77d4e454f6d60615ff # v31
         with:
           extra_nix_config: |
             trusted-public-keys = cache.nixos.org-1:6NCHdD59X431o0gWypbMrAURkbJ16ZPMQFGspcDShjY= cache.garnix.io:CTFPyKSLcx5RMJKfLo5EEPUObbA78b0YQ2DTCJXqr9g= union.cachix.org-1:TV9o8jexzNVbM1VNBOq9fu8NK+hL6ZhOyOh0quATy+M=
@@ -34,7 +34,7 @@ jobs:
           chmod -R u+w ./snapshot-pkg
       - uses: actions/setup-node@v4
         with: {node-version: 22}
-      - uses: pnpm/action-setup@v3
+      - uses: pnpm/action-setup@a3252b78c470c02df07e9d59298aecedc3ccdd6d # v3
         with:
           version: 10
           run_install: false

--- a/.github/workflows/release-component.yml
+++ b/.github/workflows/release-component.yml
@@ -104,7 +104,7 @@ jobs:
       - uses: actions/checkout@v4
         with:
           lfs: true
-      - uses: cachix/install-nix-action@v30
+      - uses: cachix/install-nix-action@08dcb3a5e62fa31e2da3d490afc4176ef55ecd72 # v30
         with:
           extra_nix_config: |
             trusted-public-keys = cache.nixos.org-1:6NCHdD59X431o0gWypbMrAURkbJ16ZPMQFGspcDShjY= cache.garnix.io:CTFPyKSLcx5RMJKfLo5EEPUObbA78b0YQ2DTCJXqr9g= union.cachix.org-1:TV9o8jexzNVbM1VNBOq9fu8NK+hL6ZhOyOh0quATy+M=
@@ -128,7 +128,7 @@ jobs:
       - uses: actions/checkout@v4
         with:
           lfs: true
-      - uses: cachix/install-nix-action@v30
+      - uses: cachix/install-nix-action@08dcb3a5e62fa31e2da3d490afc4176ef55ecd72 # v30
         with:
           extra_nix_config: |
             trusted-public-keys = cache.nixos.org-1:6NCHdD59X431o0gWypbMrAURkbJ16ZPMQFGspcDShjY= cache.garnix.io:CTFPyKSLcx5RMJKfLo5EEPUObbA78b0YQ2DTCJXqr9g= union.cachix.org-1:TV9o8jexzNVbM1VNBOq9fu8NK+hL6ZhOyOh0quATy+M=
@@ -152,7 +152,7 @@ jobs:
       - uses: actions/checkout@v4
         with:
           lfs: true
-      - uses: cachix/install-nix-action@v30
+      - uses: cachix/install-nix-action@08dcb3a5e62fa31e2da3d490afc4176ef55ecd72 # v30
         with:
           extra_nix_config: |
             trusted-public-keys = cache.nixos.org-1:6NCHdD59X431o0gWypbMrAURkbJ16ZPMQFGspcDShjY= cache.garnix.io:CTFPyKSLcx5RMJKfLo5EEPUObbA78b0YQ2DTCJXqr9g= union.cachix.org-1:TV9o8jexzNVbM1VNBOq9fu8NK+hL6ZhOyOh0quATy+M=
@@ -184,7 +184,7 @@ jobs:
       - uses: actions/checkout@v4
         with:
           lfs: true
-      - uses: cachix/install-nix-action@v30
+      - uses: cachix/install-nix-action@08dcb3a5e62fa31e2da3d490afc4176ef55ecd72 # v30
         with:
           extra_nix_config: |
             trusted-public-keys = cache.nixos.org-1:6NCHdD59X431o0gWypbMrAURkbJ16ZPMQFGspcDShjY= cache.garnix.io:CTFPyKSLcx5RMJKfLo5EEPUObbA78b0YQ2DTCJXqr9g= union.cachix.org-1:TV9o8jexzNVbM1VNBOq9fu8NK+hL6ZhOyOh0quATy+M=
@@ -220,7 +220,7 @@ jobs:
         ports:
           - 5000:5000
     steps:
-      - uses: docker/login-action@v3
+      - uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
@@ -290,7 +290,7 @@ jobs:
           echo "downloaded & installed regctl"
           regctl registry set --tls disabled localhost:5000
           regctl image mod "localhost:5000/unionlabs/$COMPONENT:$TAG" --to-oci --create "$TAG" --annotation org.opencontainers.image.description="$(cat "$GITHUB_WORKSPACE/.github/container-descriptions/$COMPONENT.txt")"
-      - uses: docker/login-action@v3
+      - uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
@@ -351,7 +351,7 @@ jobs:
             echo "FILES=**/$COMPONENT-*" >> $GITHUB_OUTPUT
           fi
           tree
-      - uses: softprops/action-gh-release@v2
+      - uses: softprops/action-gh-release@153bb8e04406b158c6c84fc1615b65b24149a1fe # v2
         with:
           body_path: release.md
           prerelease: ${{ contains(needs.eval-tag.outputs.version, '-rc') || contains(needs.eval-tag.outputs.version, 'alpha') }}


### PR DESCRIPTION
Re-submission of #5440. Had a problem with my fork and had to delete it, which closed the original PR. Apologies for the noise.

## Summary

This PR pins all GitHub Actions to immutable commit SHAs instead of mutable version tags and extracts any unsafe expressions from run blocks into env mappings.

## How to verify

Review the diff, each change is mechanical and preserves workflow behavior:
- **SHA pinning**: `action@v3` becomes `action@abc123 # v3`, original version preserved as comment
- No workflow logic, triggers, or permissions are modified

I've been researching CI/CD supply chain attack vectors and submitting fixes to affected repos. Based on that research I built a scanner called Runner Guard and open sourced it [here](https://github.com/Vigilant-LLC/runner-guard) so you can scan yourself if you want to. I'll be posting more advisories over the next few weeks [on Twitter](https://x.com/vigilance_one) if you want to stay in the loop.

If you have any questions, reach out. I'll be monitoring comms.

\- Chris (dagecko)
