### PR TITLE
fix(galoisd): correct signature/validator count check in Poll

### DIFF
--- a/galoisd/grpc/bls12381_server.go
+++ b/galoisd/grpc/bls12381_server.go
@@ -105,10 +105,10 @@ func (p *proverServerBls12381) Poll(ctx context.Context, pollReq *grpc.PollReque
 	if len(req.UntrustedCommit.Validators) > lightclient.MaxVal {
 		return nil, fmt.Errorf("The circuit can handle a maximum of %d validators", lightclient.MaxVal)
 	}
-	if len(req.TrustedCommit.Signatures) > len(req.TrustedCommit.Signatures) {
+	if len(req.TrustedCommit.Signatures) > len(req.TrustedCommit.Validators) {
 		return nil, fmt.Errorf("More signatures than validators")
 	}
-	if len(req.UntrustedCommit.Signatures) > len(req.UntrustedCommit.Signatures) {
+	if len(req.UntrustedCommit.Signatures) > len(req.UntrustedCommit.Validators) {
 		return nil, fmt.Errorf("More signatures than validators")
 	}
 

--- a/galoisd/grpc/server.go
+++ b/galoisd/grpc/server.go
@@ -305,10 +305,10 @@ func (p *proverServer) Poll(ctx context.Context, pollReq *grpc.PollRequest) (*gr
 	if len(req.UntrustedCommit.Validators) > lightclient.MaxVal {
 		return nil, fmt.Errorf("The circuit can handle a maximum of %d validators", lightclient.MaxVal)
 	}
-	if len(req.TrustedCommit.Signatures) > len(req.TrustedCommit.Signatures) {
+	if len(req.TrustedCommit.Signatures) > len(req.TrustedCommit.Validators) {
 		return nil, fmt.Errorf("More signatures than validators")
 	}
-	if len(req.UntrustedCommit.Signatures) > len(req.UntrustedCommit.Signatures) {
+	if len(req.UntrustedCommit.Signatures) > len(req.UntrustedCommit.Validators) {
 		return nil, fmt.Errorf("More signatures than validators")
 	}
 

--- a/galoisd/grpc/server_test.go
+++ b/galoisd/grpc/server_test.go
@@ -1,0 +1,49 @@
+package grpc
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	v3 "galois/grpc/api/v3"
+
+	types "github.com/cometbft/cometbft/api/cometbft/types/v1"
+)
+
+type pollServer interface {
+	Poll(context.Context, *v3.PollRequest) (*v3.PollResponse, error)
+}
+
+// Regression test for #5428: Poll must reject any commit with more signatures than
+// validators. The guard fires before proving, so a zero-value server (maxJobs == 0) works.
+func TestPollSignatureValidatorGuard(t *testing.T) {
+	const wantErr = "More signatures than validators"
+
+	oneVal := []*types.SimpleValidator{{}}
+	okCommit := func() *v3.ValidatorSetCommit {
+		return &v3.ValidatorSetCommit{Validators: oneVal, Signatures: [][]byte{{}}}
+	}
+	badCommit := func() *v3.ValidatorSetCommit {
+		return &v3.ValidatorSetCommit{Validators: oneVal, Signatures: [][]byte{{}, {}}}
+	}
+
+	servers := map[string]pollServer{
+		"bn254":    &proverServer{},
+		"bls12381": &proverServerBls12381{},
+	}
+
+	for sName, srv := range servers {
+		reqs := map[string]*v3.ProveRequest{
+			"trusted":   {TrustedCommit: badCommit(), UntrustedCommit: okCommit()},
+			"untrusted": {TrustedCommit: okCommit(), UntrustedCommit: badCommit()},
+		}
+		for rName, proveReq := range reqs {
+			t.Run(sName+"/"+rName, func(t *testing.T) {
+				_, err := srv.Poll(context.Background(), &v3.PollRequest{Request: proveReq})
+				if err == nil || !strings.Contains(err.Error(), wantErr) {
+					t.Fatalf("expected error containing %q, got: %v", wantErr, err)
+				}
+			})
+		}
+	}
+}


### PR DESCRIPTION
fixes #5428

## Summary

both `Poll` implementations had two input-validation guards comparing each commit's `Signatures` slice length against itself, so the condition was always false and the "More signatures than validators" error never fired.
a malformed request with more signatures than validators would skip the check entirely and reach the prover. this fixes both comparisons to use `Validators` on the right-hand side. the same copy paste bug was in both server files; both are patched in this commit

## Changes

- `galoisd/grpc/server.go`: compare `Signatures` against `Validators` for both the trusted and untrusted commits
- `galoisd/grpc/bls12381_server.go`: same fix (the guard was copy pasted from `server.go` with the same typo)
- `galoisd/grpc/server_test.go`: regression test that `Poll` rejects a commit with more signatures than validators, covering both server types and both commit fields (4 sub-cases total)

## Testing

`go test ./grpc/...` in `galoisd\`. the new test fails before the fix (the dead guard is skipped so a zero-value server hits the job-slot check and returns `busy_building`), and passes after. also ran `go build ./grpc/...` and `go vet ./grpc/...`